### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16"
+
+      - name: Run tests
+        run: swift test --package-path Packages/CrowCore
+
+  build:
+    name: Build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16"
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Get Ghostty submodule SHA
+        id: ghostty-sha
+        run: echo "sha=$(git -C vendor/ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Ghostty framework
+        id: ghostty-cache
+        uses: actions/cache@v4
+        with:
+          path: Frameworks
+          key: ghostty-${{ runner.os }}-${{ runner.arch }}-${{ steps.ghostty-sha.outputs.sha }}
+
+      - name: Build Ghostty
+        if: steps.ghostty-cache.outputs.cache-hit != 'true'
+        run: make ghostty
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Packages/*/Package.swift') }}
+          restore-keys: |
+            spm-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Generate build info
+        run: bash scripts/generate-build-info.sh
+
+      - name: Build
+        run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
 
       - name: Build Ghostty
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
-        run: make ghostty
+        run: |
+          unset ZIG_LOCAL_CACHE_DIR ZIG_GLOBAL_CACHE_DIR
+          make ghostty
 
       - name: Cache SPM dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with two parallel CI jobs
- **Test** job: runs CrowCore unit tests (~1 min), no Ghostty/Zig needed
- **Build** job: full pipeline with Ghostty framework cached by submodule SHA, SPM deps cached by manifest hashes
- Concurrency group cancels superseded runs on the same branch

Closes #58

## Test plan
- [ ] CI triggers on this PR and both jobs pass
- [ ] Ghostty framework cache populates on first run
- [ ] Subsequent pushes to this PR hit the Ghostty cache (visible in Actions logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)