### PR TITLE
Fix session not completing when linked issue is closed

### DIFF
--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -93,7 +93,7 @@ final class IssueTracker {
         syncInReviewSessions(issues: allIssues)
 
         // Auto-complete sessions whose linked issue/PR is no longer open
-        await autoCompleteFinishedSessions(openIssues: allIssues)
+        await autoCompleteFinishedSessions(openIssues: allIssues.filter { $0.state == "open" })
     }
 
     // MARK: - GitHub
@@ -403,7 +403,11 @@ final class IssueTracker {
     private func autoCompleteFinishedSessions(openIssues: [AssignedIssue]) async {
         let openIssueURLs = Set(openIssues.map(\.url))
 
-        for session in appState.activeSessions {
+        let candidateSessions = appState.sessions.filter {
+            $0.id != AppState.managerSessionID &&
+            ($0.status == .active || $0.status == .paused || $0.status == .inReview)
+        }
+        for session in candidateSessions {
             guard let ticketURL = session.ticketURL else { continue }
 
             // If the issue is still in the open list, it's not finished


### PR DESCRIPTION
## Summary
- Filter out recently-closed "done" issues before passing to `autoCompleteFinishedSessions`, so closed issues are correctly detected as no longer open
- Expand candidate sessions to include paused and inReview statuses (not just active), so issue closure completes the session regardless of its current state

Closes #77

## Test plan
- [x] Create a session linked to a GitHub issue (no PR)
- [x] Close the issue on GitHub
- [x] Wait for the 60-second poll cycle or trigger a refresh
- [x] Verify the session transitions to `completed`
- [x] Repeat with a session in paused and inReview states

🤖 Generated with [Claude Code](https://claude.com/claude-code)