### PR TITLE
Quality pass: worktree management

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Worktree.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Worktree.swift
@@ -34,3 +34,31 @@ public struct SessionWorktree: Identifiable, Codable, Sendable {
         self.createdAt = createdAt
     }
 }
+
+// MARK: - Worktree Classification
+
+extension SessionWorktree {
+    /// Default branches that should never be deleted during worktree cleanup.
+    public static let protectedBranchNames: Set<String> = [
+        "main", "master", "develop", "dev", "trunk", "release",
+    ]
+
+    /// Returns true if a branch name is a protected default branch.
+    /// Strips `refs/heads/` and `origin/` prefixes before comparison.
+    public static func isProtectedBranch(_ branch: String) -> Bool {
+        let name = branch
+            .replacingOccurrences(of: "refs/heads/", with: "")
+            .replacingOccurrences(of: "origin/", with: "")
+            .lowercased()
+        return protectedBranchNames.contains(name)
+    }
+
+    /// Returns true if this worktree points at the main repo checkout (not a real git worktree).
+    /// True when the worktree path matches the repo path, or the branch is a protected default branch.
+    public var isMainRepoCheckout: Bool {
+        let worktree = (worktreePath as NSString).standardizingPath
+        let repo = (repoPath as NSString).standardizingPath
+        if worktree == repo { return true }
+        return Self.isProtectedBranch(branch)
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/WorktreeTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/WorktreeTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// MARK: - isProtectedBranch
+
+@Test func protectedBranchDetectsAllNames() {
+    let names = ["main", "master", "develop", "dev", "trunk", "release"]
+    for name in names {
+        #expect(SessionWorktree.isProtectedBranch(name) == true, "Expected '\(name)' to be protected")
+    }
+}
+
+@Test func protectedBranchStripsRefsHeadsPrefix() {
+    #expect(SessionWorktree.isProtectedBranch("refs/heads/main") == true)
+    #expect(SessionWorktree.isProtectedBranch("refs/heads/develop") == true)
+}
+
+@Test func protectedBranchStripsOriginPrefix() {
+    #expect(SessionWorktree.isProtectedBranch("origin/main") == true)
+    #expect(SessionWorktree.isProtectedBranch("origin/master") == true)
+}
+
+@Test func protectedBranchIsCaseInsensitive() {
+    #expect(SessionWorktree.isProtectedBranch("Main") == true)
+    #expect(SessionWorktree.isProtectedBranch("MASTER") == true)
+}
+
+@Test func protectedBranchReturnsFalseForFeatureBranches() {
+    #expect(SessionWorktree.isProtectedBranch("feature/crow-70") == false)
+    #expect(SessionWorktree.isProtectedBranch("fix/login-bug") == false)
+    #expect(SessionWorktree.isProtectedBranch("main-feature") == false)
+    #expect(SessionWorktree.isProtectedBranch("develop-next") == false)
+}
+
+// MARK: - isMainRepoCheckout
+
+private func makeWorktree(
+    repoPath: String = "/repo",
+    worktreePath: String = "/worktree",
+    branch: String = "feature/test"
+) -> SessionWorktree {
+    SessionWorktree(
+        sessionID: UUID(),
+        repoName: "repo",
+        repoPath: repoPath,
+        worktreePath: worktreePath,
+        branch: branch,
+        workspace: "TestOrg"
+    )
+}
+
+@Test func isMainRepoCheckoutWhenPathsMatch() {
+    let wt = makeWorktree(
+        repoPath: "/Users/test/Dev/Org/repo",
+        worktreePath: "/Users/test/Dev/Org/repo",
+        branch: "feature/something"
+    )
+    #expect(wt.isMainRepoCheckout == true)
+}
+
+@Test func isMainRepoCheckoutForProtectedBranch() {
+    let wt = makeWorktree(
+        repoPath: "/repo",
+        worktreePath: "/different/path",
+        branch: "main"
+    )
+    #expect(wt.isMainRepoCheckout == true)
+}
+
+@Test func isMainRepoCheckoutReturnsFalseForFeatureBranch() {
+    let wt = makeWorktree(
+        repoPath: "/repo",
+        worktreePath: "/worktree",
+        branch: "feature/crow-70-quality-pass"
+    )
+    #expect(wt.isMainRepoCheckout == false)
+}

--- a/Packages/CrowGit/Package.swift
+++ b/Packages/CrowGit/Package.swift
@@ -12,5 +12,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "CrowGit", dependencies: ["CrowCore"]),
+        .testTarget(name: "CrowGitTests", dependencies: ["CrowGit"]),
     ]
 )

--- a/Packages/CrowGit/Sources/CrowGit/GitManager.swift
+++ b/Packages/CrowGit/Sources/CrowGit/GitManager.swift
@@ -52,41 +52,94 @@ public actor GitManager {
     }
 
     /// Create a worktree for a repo.
+    ///
+    /// If the branch already exists on the remote, the worktree tracks it.
+    /// Otherwise, a new branch is created from the repo's default branch with `--no-track`
+    /// to prevent accidental pushes to the default branch.
+    ///
+    /// If creation fails because a local branch with the same name already exists,
+    /// the conflicting branch is deleted and the operation is retried once.
     public func createWorktree(repoPath: String, worktreePath: String, branch: String) async throws {
         // Check if branch exists on remote
-        let lsRemote = try await shell("git", "-C", repoPath, "ls-remote", "--heads", "origin", branch)
+        let lsRemote = try await run(["git", "-C", repoPath, "ls-remote", "--heads", "origin", branch])
         let branchExistsOnRemote = !lsRemote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-        _ = try await shell("git", "-C", repoPath, "fetch", "origin")
+        _ = try await run(["git", "-C", repoPath, "fetch", "origin"])
 
         if branchExistsOnRemote {
-            _ = try await shell("git", "-C", repoPath, "worktree", "add", worktreePath,
-                                "-b", branch, "--track", "origin/\(branch)")
+            try await createWorktreeWithRetry(repoPath: repoPath, worktreePath: worktreePath, args: [
+                "git", "-C", repoPath, "worktree", "add", worktreePath,
+                "-b", branch, "--track", "origin/\(branch)",
+            ], branch: branch)
         } else {
-            _ = try await shell("git", "-C", repoPath, "worktree", "add", worktreePath,
-                                "-b", branch, "origin/main")
+            let defaultBranch = try await resolveDefaultBranch(repoPath: repoPath)
+            try await createWorktreeWithRetry(repoPath: repoPath, worktreePath: worktreePath, args: [
+                "git", "-C", repoPath, "worktree", "add", worktreePath,
+                "-b", branch, "--no-track", "origin/\(defaultBranch)",
+            ], branch: branch)
         }
     }
 
     /// Remove a worktree.
     public func removeWorktree(repoPath: String, worktreePath: String) async throws {
-        _ = try await shell("git", "-C", repoPath, "worktree", "remove", worktreePath)
+        _ = try await run(["git", "-C", repoPath, "worktree", "remove", worktreePath])
     }
 
-    private func shell(_ args: String...) async throws -> String {
+    // MARK: - Private Helpers
+
+    /// Resolve the default branch for the remote (e.g. main, master).
+    private func resolveDefaultBranch(repoPath: String) async throws -> String {
+        let ref = try await run(["git", "-C", repoPath, "symbolic-ref", "refs/remotes/origin/HEAD"])
+        let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines)
+        // refs/remotes/origin/main → main
+        if let lastSlash = trimmed.lastIndex(of: "/") {
+            return String(trimmed[trimmed.index(after: lastSlash)...])
+        }
+        throw GitError.noDefaultBranch(remote: "origin")
+    }
+
+    /// Attempt to create a worktree; retry once if the branch already exists locally.
+    private func createWorktreeWithRetry(
+        repoPath: String, worktreePath: String, args: [String], branch: String
+    ) async throws {
+        do {
+            _ = try await run(args)
+        } catch let error as GitError {
+            guard case .commandFailed(_, _, let stderr) = error,
+                  stderr.contains("already exists") else {
+                throw error
+            }
+            // Delete the conflicting local branch and retry once
+            _ = try await run(["git", "-C", repoPath, "branch", "-D", branch])
+            _ = try await run(args)
+        }
+    }
+
+    /// Run a git command, returning stdout on success.
+    private func run(_ args: [String]) async throws -> String {
         let process = Process()
-        let pipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = args
-        process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
         try process.run()
         process.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+
         guard process.terminationStatus == 0 else {
-            throw GitError.commandFailed(String(data: data, encoding: .utf8) ?? "")
+            throw GitError.commandFailed(
+                command: args.joined(separator: " "),
+                exitCode: process.terminationStatus,
+                stderr: stderr
+            )
         }
-        return String(data: data, encoding: .utf8) ?? ""
+        return stdout
     }
 }
 
@@ -99,6 +152,19 @@ public struct RepoInfo: Sendable {
     public let host: String?
 }
 
-public enum GitError: Error {
-    case commandFailed(String)
+public enum GitError: Error, LocalizedError {
+    case commandFailed(command: String, exitCode: Int32, stderr: String)
+    case branchAlreadyExists(String)
+    case noDefaultBranch(remote: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .commandFailed(let command, let exitCode, let stderr):
+            return "Git command failed (\(exitCode)): \(command)\n\(stderr)"
+        case .branchAlreadyExists(let branch):
+            return "Branch '\(branch)' already exists"
+        case .noDefaultBranch(let remote):
+            return "Could not determine default branch for remote '\(remote)'"
+        }
+    }
 }

--- a/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
+++ b/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import CrowGit
+
+// MARK: - GitError Descriptions
+
+@Test func commandFailedIncludesDetails() {
+    let error = GitError.commandFailed(command: "git status", exitCode: 128, stderr: "fatal: not a git repository")
+    let desc = error.errorDescription ?? ""
+    #expect(desc.contains("git status"))
+    #expect(desc.contains("128"))
+    #expect(desc.contains("fatal: not a git repository"))
+}
+
+@Test func branchAlreadyExistsIncludesBranchName() {
+    let error = GitError.branchAlreadyExists("feature/test")
+    let desc = error.errorDescription ?? ""
+    #expect(desc.contains("feature/test"))
+}
+
+@Test func noDefaultBranchIncludesRemoteName() {
+    let error = GitError.noDefaultBranch(remote: "origin")
+    let desc = error.errorDescription ?? ""
+    #expect(desc.contains("origin"))
+}

--- a/Packages/CrowUI/Sources/CrowUI/DeleteSessionAlert.swift
+++ b/Packages/CrowUI/Sources/CrowUI/DeleteSessionAlert.swift
@@ -35,15 +35,15 @@ struct DeleteSessionAlert: ViewModifier {
     private var buttonLabel: String {
         guard let session = sessionToDelete else { return "Delete" }
         let wts = appState.worktrees(for: session.id)
-        let hasRealWorktrees = wts.contains { !WorktreeClassification.isMainCheckout($0) }
+        let hasRealWorktrees = wts.contains { !$0.isMainRepoCheckout }
         return DeleteSessionMessageBuilder.buttonLabel(hasRealWorktrees: hasRealWorktrees)
     }
 
     private var messageText: String {
         guard let session = sessionToDelete else { return "" }
         let wts = appState.worktrees(for: session.id)
-        let realWorktrees = wts.filter { !WorktreeClassification.isMainCheckout($0) }
-        let mainCheckouts = wts.filter { WorktreeClassification.isMainCheckout($0) }
+        let realWorktrees = wts.filter { !$0.isMainRepoCheckout }
+        let mainCheckouts = wts.filter { $0.isMainRepoCheckout }
         return DeleteSessionMessageBuilder.buildMessage(
             sessionName: session.name,
             realWorktrees: realWorktrees,
@@ -91,21 +91,3 @@ enum DeleteSessionMessageBuilder {
     }
 }
 
-// MARK: - Worktree Classification
-
-/// Shared logic for classifying worktrees as main checkouts vs real worktrees.
-enum WorktreeClassification {
-    /// Returns true if the worktree points at the main repo checkout (not a real git worktree).
-    static func isMainCheckout(_ wt: SessionWorktree) -> Bool {
-        let worktree = (wt.worktreePath as NSString).standardizingPath
-        let repo = (wt.repoPath as NSString).standardizingPath
-        if worktree == repo { return true }
-
-        let branch = wt.branch
-            .replacingOccurrences(of: "refs/heads/", with: "")
-            .replacingOccurrences(of: "origin/", with: "")
-            .lowercased()
-        let protectedNames: Set<String> = ["main", "master", "develop", "dev", "trunk", "release"]
-        return protectedNames.contains(branch)
-    }
-}

--- a/Packages/CrowUI/Tests/CrowUITests/CrowUITests.swift
+++ b/Packages/CrowUI/Tests/CrowUITests/CrowUITests.swift
@@ -88,7 +88,7 @@ private func makeWorktree(
     )
 }
 
-// MARK: - WorktreeClassification
+// MARK: - Worktree Classification (uses SessionWorktree.isMainRepoCheckout from CrowCore)
 
 @Test func isMainCheckoutDetectsMatchingPaths() {
     let wt = makeWorktree(
@@ -96,25 +96,25 @@ private func makeWorktree(
         worktreePath: "/Users/test/Dev/Org/repo",
         branch: "feature/something"
     )
-    #expect(WorktreeClassification.isMainCheckout(wt) == true)
+    #expect(wt.isMainRepoCheckout == true)
 }
 
 @Test func isMainCheckoutDetectsProtectedBranches() {
     let protectedBranches = ["main", "master", "develop", "dev", "trunk", "release"]
     for branch in protectedBranches {
         let wt = makeWorktree(branch: branch)
-        #expect(WorktreeClassification.isMainCheckout(wt) == true, "Expected \(branch) to be a main checkout")
+        #expect(wt.isMainRepoCheckout == true, "Expected \(branch) to be a main checkout")
     }
 }
 
 @Test func isMainCheckoutDetectsProtectedBranchesWithPrefix() {
     let wt = makeWorktree(branch: "refs/heads/main")
-    #expect(WorktreeClassification.isMainCheckout(wt) == true)
+    #expect(wt.isMainRepoCheckout == true)
 }
 
 @Test func isMainCheckoutReturnsFalseForFeatureBranch() {
     let wt = makeWorktree(branch: "feature/crow-73-quality-pass")
-    #expect(WorktreeClassification.isMainCheckout(wt) == false)
+    #expect(wt.isMainRepoCheckout == false)
 }
 
 // MARK: - Delete Session Message Logic

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -173,7 +173,7 @@ final class SessionService {
         // Remove worktrees from disk: git worktree remove + branch delete
         // Skip cleanup for worktrees that point at the main repo checkout (not a real worktree)
         for wt in wts {
-            let isMainCheckout = Self.isMainRepoCheckout(wt)
+            let isMainCheckout = wt.isMainRepoCheckout
 
             if isMainCheckout {
                 NSLog("Skipping worktree cleanup for main checkout: \(wt.worktreePath) (branch: \(wt.branch))")
@@ -189,7 +189,7 @@ final class SessionService {
                 NSLog("Removed worktree: \(wt.worktreePath) \(removeResult)")
 
                 // Delete the local branch (only if not a protected branch)
-                if !Self.isProtectedBranch(wt.branch) {
+                if !SessionWorktree.isProtectedBranch(wt.branch) {
                     _ = try? await shell("git", "-C", wt.repoPath, "branch", "-D", wt.branch)
                 }
 
@@ -238,40 +238,25 @@ final class SessionService {
     }
 
     // MARK: - Worktree Safety Checks
-
-    /// Returns true if the worktree entry points at the main repo checkout (not a real git worktree).
-    private static func isMainRepoCheckout(_ wt: SessionWorktree) -> Bool {
-        // Normalize paths for comparison (resolve symlinks, trailing slashes)
-        let worktree = (wt.worktreePath as NSString).standardizingPath
-        let repo = (wt.repoPath as NSString).standardizingPath
-
-        if worktree == repo { return true }
-        if isProtectedBranch(wt.branch) { return true }
-
-        return false
-    }
-
-    /// Returns true if a branch name is a protected default branch that should never be deleted.
-    private static func isProtectedBranch(_ branch: String) -> Bool {
-        let name = branch
-            .replacingOccurrences(of: "refs/heads/", with: "")
-            .replacingOccurrences(of: "origin/", with: "")
-            .lowercased()
-        let protectedNames: Set<String> = ["main", "master", "develop", "dev", "trunk", "release"]
-        return protectedNames.contains(name)
-    }
+    // Protected branch and main-checkout detection are centralized on SessionWorktree in CrowCore.
 
     private func shell(_ args: String...) async throws -> String {
         let process = Process()
-        let pipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = args
-        process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
         try process.run()
         process.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8) ?? ""
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            throw NSError(domain: "SessionService", code: Int(process.terminationStatus),
+                          userInfo: [NSLocalizedDescriptionKey: stderr])
+        }
+        return stdout
     }
 
     /// Resolve org/repo slug from a repo's git remote URL.
@@ -351,7 +336,7 @@ final class SessionService {
                     if knownPaths.contains(standardPath) { continue }
 
                     // Skip protected branches
-                    if Self.isProtectedBranch(wt.branch) { continue }
+                    if SessionWorktree.isProtectedBranch(wt.branch) { continue }
 
                     // This is an orphan — recover it
                     NSLog("[SessionService] Recovered orphan worktree: \(wt.path) branch=\(wt.branch)")
@@ -407,7 +392,7 @@ final class SessionService {
 
         let parts = dirName.components(separatedBy: "-")
         // Look for a numeric part after the repo name prefix
-        if let repoPrefix = parts.first {
+        if !parts.isEmpty {
             for (i, part) in parts.enumerated() where i > 0 {
                 if let num = Int(part) {
                     ticketNumber = num


### PR DESCRIPTION
## Summary
- Centralize protected-branch and main-checkout detection on `SessionWorktree` in CrowCore, replacing 3 duplicate implementations across SessionService, DeleteSessionAlert, and WorktreeClassification
- Fix `GitManager.createWorktree` to resolve default branch dynamically (via `symbolic-ref`) instead of hardcoding `origin/main`, add `--no-track` for new branches, and retry on branch conflicts
- Improve `shell()` error handling in both GitManager and SessionService with separate stdout/stderr pipes and exit status checks
- Add structured `GitError` cases (`.commandFailed`, `.branchAlreadyExists`, `.noDefaultBranch`) with `LocalizedError` conformance
- Add CrowGit test target with error description tests and CrowCore worktree classification tests

Closes #70

## Test plan
- [x] `make build` compiles cleanly
- [x] `make test` — all 132 tests pass across 6 packages
- [x] Manual: delete a session with worktrees → worktrees removed, protected branches preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)