### PR TITLE
Add git worktree to dangerouslyDisableSandbox guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This is the development root managed by Crow. The Manager tab runs Claude Code h
 
 ## crow CLI Reference
 
-The `crow` CLI communicates with the Crow app via Unix socket at `~/.local/share/crow/crow.sock`. The app must be running for commands to work. **All `crow`, `gh`, and `glab` commands require `dangerouslyDisableSandbox: true`** and return JSON.
+The `crow` CLI communicates with the Crow app via Unix socket at `~/.local/share/crow/crow.sock`. The app must be running for commands to work. **All `crow`, `gh`, `glab`, and `git worktree` commands require `dangerouslyDisableSandbox: true`** and return JSON.
 
 ### Session Commands
 ```

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -6,7 +6,7 @@ Orchestrates work sessions in **Crow** by setting up git worktrees and creating 
 
 ## Important: Sandbox Bypass
 
-All `crow`, `gh`, and `glab` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket or need network/TLS access.
+All `crow`, `gh`, `glab`, and `git worktree` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket, need network/TLS access, or write outside the sandbox-allowed directories.
 
 ## Activation
 
@@ -178,7 +178,7 @@ git -C {repo_path} worktree add {path} \
 
 ## crow Session Creation
 
-All `crow` commands require `dangerouslyDisableSandbox: true`.
+All `crow` and `git worktree` commands require `dangerouslyDisableSandbox: true`.
 
 ### Complete Step-by-Step Flow
 

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -81,8 +81,7 @@ struct Scaffolder {
         # Crow — Manager Context
 
         See crow --help for CLI reference.
-        All crow commands require dangerouslyDisableSandbox: true.
-        All gh/glab commands require dangerouslyDisableSandbox: true.
+        All crow, gh, glab, and git worktree commands require dangerouslyDisableSandbox: true.
         Write temp files to $TMPDIR, not /tmp.
 
         ## Known Issues / Corrections
@@ -105,7 +104,7 @@ struct Scaffolder {
         This skill activates when user invokes `/crow-workspace` command.
 
         ## Important
-        All `crow` CLI commands require `dangerouslyDisableSandbox: true`.
+        All `crow` CLI and `git worktree` commands require `dangerouslyDisableSandbox: true`.
         See the CLAUDE.md in this directory for the full crow CLI reference.
         """
     }

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -6,7 +6,7 @@ Orchestrates work sessions in **Crow** by setting up git worktrees and creating 
 
 ## Important: Sandbox Bypass
 
-All `crow`, `gh`, and `glab` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket or need network/TLS access.
+All `crow`, `gh`, `glab`, and `git worktree` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket, need network/TLS access, or write outside the sandbox-allowed directories.
 
 ## Activation
 
@@ -195,7 +195,7 @@ git -C {repo_path} worktree add {path} \
 
 ## crow Session Creation
 
-All `crow` commands require `dangerouslyDisableSandbox: true`.
+All `crow` and `git worktree` commands require `dangerouslyDisableSandbox: true`.
 
 ### Session Naming Convention
 


### PR DESCRIPTION
## Summary
- Adds `git worktree` to the list of commands requiring `dangerouslyDisableSandbox: true` across all skill docs, CLAUDE.md, and Scaffolder.swift fallbacks
- `git worktree add` writes files outside sandbox-allowed directories (e.g., `.gitmodules`), causing "Operation not permitted" errors that leave behind partially-created branches

Closes #107

## Test plan
- [x] Verify `git worktree` appears in sandbox bypass guidance in SKILL.md, template, CLAUDE.md, and Scaffolder.swift
- [x] Run `make build` to confirm Swift compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)