### PR TITLE
Remove vestigial workspace property from SessionWorktree

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Worktree.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Worktree.swift
@@ -8,7 +8,6 @@ public struct SessionWorktree: Identifiable, Codable, Sendable {
     public var repoPath: String
     public var worktreePath: String
     public var branch: String
-    public var workspace: String
     public var isPrimary: Bool
     public var createdAt: Date
 
@@ -19,7 +18,6 @@ public struct SessionWorktree: Identifiable, Codable, Sendable {
         repoPath: String,
         worktreePath: String,
         branch: String,
-        workspace: String,
         isPrimary: Bool = false,
         createdAt: Date = Date()
     ) {
@@ -29,7 +27,6 @@ public struct SessionWorktree: Identifiable, Codable, Sendable {
         self.repoPath = repoPath
         self.worktreePath = worktreePath
         self.branch = branch
-        self.workspace = workspace
         self.isPrimary = isPrimary
         self.createdAt = createdAt
     }

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
@@ -103,7 +103,7 @@ import Testing
     let session = Session(id: sessionID, name: "round-trip")
     let worktree = SessionWorktree(
         sessionID: sessionID, repoName: "crow", repoPath: "/path/to/crow",
-        worktreePath: "/path/to/worktree", branch: "feature/test", workspace: "RadiusMethod"
+        worktreePath: "/path/to/worktree", branch: "feature/test"
     )
     let link = SessionLink(
         sessionID: sessionID, label: "Issue", url: "https://github.com/org/repo/issues/1",
@@ -135,7 +135,6 @@ import Testing
 
     let rw = reloaded.data.worktrees.first!
     #expect(rw.branch == "feature/test")
-    #expect(rw.workspace == "RadiusMethod")
 
     let rl = reloaded.data.links.first!
     #expect(rl.linkType == .ticket)

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/SessionRepositoryTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/SessionRepositoryTests.swift
@@ -51,7 +51,7 @@ import Testing
     store.mutate { data in
         data.worktrees.append(SessionWorktree(
             sessionID: sessionID, repoName: "crow", repoPath: "/repo",
-            worktreePath: "/wt", branch: "feature/x", workspace: "ws"
+            worktreePath: "/wt", branch: "feature/x"
         ))
         data.links.append(SessionLink(
             sessionID: sessionID, label: "PR", url: "https://example.com", linkType: .pr
@@ -104,11 +104,11 @@ import Testing
     store.mutate { data in
         data.worktrees.append(SessionWorktree(
             sessionID: session1, repoName: "a", repoPath: "/a",
-            worktreePath: "/wt-a", branch: "feature/a", workspace: "ws"
+            worktreePath: "/wt-a", branch: "feature/a"
         ))
         data.worktrees.append(SessionWorktree(
             sessionID: session2, repoName: "b", repoPath: "/b",
-            worktreePath: "/wt-b", branch: "feature/b", workspace: "ws"
+            worktreePath: "/wt-b", branch: "feature/b"
         ))
         data.links.append(SessionLink(
             sessionID: session1, label: "Issue", url: "https://example.com/1", linkType: .ticket

--- a/Packages/CrowUI/Tests/CrowUITests/CrowUITests.swift
+++ b/Packages/CrowUI/Tests/CrowUITests/CrowUITests.swift
@@ -83,8 +83,7 @@ private func makeWorktree(
         repoName: repoName,
         repoPath: repoPath,
         worktreePath: worktreePath,
-        branch: branch,
-        workspace: "TestOrg"
+        branch: branch
     )
 }
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -522,8 +522,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // repo_path is the main repo (for git commands). Defaults to path if not provided.
                 let repoPath = params["repo_path"]?.stringValue ?? path
                 let wt = SessionWorktree(sessionID: sessionID, repoName: repo, repoPath: repoPath, worktreePath: path,
-                                         branch: branch, workspace: params["workspace"]?.stringValue ?? "",
-                                         isPrimary: params["primary"]?.boolValue ?? false)
+                                         branch: branch, isPrimary: params["primary"]?.boolValue ?? false)
                 return await MainActor.run {
                     capturedAppState.worktrees[sessionID, default: []].append(wt)
                     capturedStore.mutate { $0.worktrees.append(wt) }

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -355,7 +355,7 @@ final class SessionService {
 
                     // This is an orphan — recover it
                     NSLog("[SessionService] Recovered orphan worktree: \(wt.path) branch=\(wt.branch)")
-                    await recoverOrphan(worktreePath: wt.path, branch: wt.branch, repoName: repoDir, repoPath: repoPath, workspace: wsDir)
+                    await recoverOrphan(worktreePath: wt.path, branch: wt.branch, repoName: repoDir, repoPath: repoPath)
                 }
             }
         }
@@ -396,7 +396,7 @@ final class SessionService {
         return entries
     }
 
-    private func recoverOrphan(worktreePath: String, branch: String, repoName: String, repoPath: String, workspace: String) async {
+    private func recoverOrphan(worktreePath: String, branch: String, repoName: String, repoPath: String) async {
         let dirName = (worktreePath as NSString).lastPathComponent
 
         // Try to parse ticket number from directory name (e.g., "citadel-209-slug" → 209)
@@ -459,7 +459,6 @@ final class SessionService {
             repoPath: repoPath,
             worktreePath: worktreePath,
             branch: branch,
-            workspace: workspace,
             isPrimary: true
         )
 


### PR DESCRIPTION
## Summary
- Removes the unused `workspace: String` property from `SessionWorktree` model, IPC handler, and orphan recovery path
- The CLI already had no `--workspace` flag; this completes the cleanup by removing the field from the server side
- Backward-compatible: existing `store.json` files with the old field decode fine (Swift `Codable` ignores unknown keys)

Closes #108

## Test plan
- [x] `make build` passes
- [x] All tests pass (CrowCore, CrowPersistence, CrowUI)
- [x] Verified `store.json` round-trip works via existing `JSONStoreTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)