### PR TITLE
Fix MacWhisper accessibility support

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -461,6 +461,26 @@ public final class GhosttySurfaceView: NSView {
     }
 }
 
+// MARK: - Accessibility
+
+extension GhosttySurfaceView {
+    public override func isAccessibilityElement() -> Bool {
+        return true
+    }
+
+    public override func accessibilityRole() -> NSAccessibility.Role? {
+        return .textArea
+    }
+
+    public override func accessibilityHelp() -> String? {
+        return "Terminal content area"
+    }
+
+    public override func accessibilitySelectedTextRange() -> NSRange {
+        return selectedRange()
+    }
+}
+
 // MARK: - NSTextInputClient (separate extension to avoid concurrency issues)
 
 extension GhosttySurfaceView: @preconcurrency NSTextInputClient {


### PR DESCRIPTION
## Summary
- Add accessibility overrides (`isAccessibilityElement`, `accessibilityRole`, etc.) to `GhosttySurfaceView` so macOS recognizes it as a text input target
- MacWhisper and other assistive technologies use the Accessibility API to find where to type — without these overrides, the terminal is invisible to them
- Note: this fix also requires running Crow as a `.app` bundle (via `make release`) rather than a bare binary, so macOS registers the app in the accessibility system

Closes #25

## Test plan
- [ ] `make release` and launch `Crow.app`
- [ ] Use MacWhisper push-to-talk in terminal view — should transcribe and insert text
- [ ] Verify normal keyboard input still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)