### PR TITLE
Expand test coverage for core packages

### DIFF
--- a/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+import ArgumentParser
+@testable import CrowCLILib
+
+// MARK: - Command Argument Parsing Tests
+
+private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+@Test func hookEventCmdParsesValidArgs() throws {
+    let cmd = try HookEventCmd.parse(["--session", validUUID, "--event", "Stop"])
+    #expect(cmd.session == validUUID)
+    #expect(cmd.event == "Stop")
+}
+
+@Test func hookEventCmdRejectsInvalidUUID() {
+    // Validation functions are tested directly (matching existing ValidationTests pattern)
+    #expect(throws: (any Error).self) {
+        try validateUUID("not-a-uuid", label: "session UUID")
+    }
+}
+
+@Test func setStatusParsesArgs() throws {
+    let cmd = try SetStatus.parse(["--session", validUUID, "active"])
+    #expect(cmd.session == validUUID)
+    #expect(cmd.status == "active")
+}
+
+@Test func setStatusRejectsInvalidStatus() {
+    #expect(throws: (any Error).self) {
+        try validateSessionStatus("invalid-status")
+    }
+}
+
+@Test func addLinkParsesAllArgs() throws {
+    let cmd = try AddLink.parse(["--session", validUUID, "--label", "PR", "--url", "https://example.com", "--type", "pr"])
+    #expect(cmd.session == validUUID)
+    #expect(cmd.label == "PR")
+    #expect(cmd.url == "https://example.com")
+    #expect(cmd.type == "pr")
+}
+
+@Test func addLinkDefaultTypeIsCustom() throws {
+    let cmd = try AddLink.parse(["--session", validUUID, "--label", "Docs", "--url", "https://docs.com"])
+    #expect(cmd.type == "custom")
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AllowEntryTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AllowEntryTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// MARK: - AllowEntry Tests
+
+@Test func allowEntryIsInGlobalWhenGlobalPresent() {
+    let entry = AllowEntry(pattern: "Bash(npm test:*)", sources: [.global, .worktree(sessionName: "feat", path: "/p")])
+    #expect(entry.isInGlobal == true)
+}
+
+@Test func allowEntryIsNotInGlobalWhenWorktreeOnly() {
+    let entry = AllowEntry(pattern: "Read", sources: [.worktree(sessionName: "feat", path: "/p")])
+    #expect(entry.isInGlobal == false)
+}
+
+@Test func allowEntryWorktreeSessionNamesSorted() {
+    let entry = AllowEntry(pattern: "Edit", sources: [
+        .global,
+        .worktree(sessionName: "zeta-session", path: "/z"),
+        .worktree(sessionName: "alpha-session", path: "/a"),
+    ])
+    #expect(entry.worktreeSessionNames == ["alpha-session", "zeta-session"])
+}
+
+@Test func allowEntryWorktreeSessionNamesEmptyForGlobalOnly() {
+    let entry = AllowEntry(pattern: "Bash", sources: [.global])
+    #expect(entry.worktreeSessionNames.isEmpty)
+}
+
+@Test func allowEntryIdMatchesPattern() {
+    let entry = AllowEntry(pattern: "Bash(make build:*)", sources: [.global])
+    #expect(entry.id == "Bash(make build:*)")
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AssignedIssueTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AssignedIssueTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// MARK: - AssignedIssue Tests
+
+@Test func assignedIssueCodableRoundTrip() throws {
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+    let issue = AssignedIssue(
+        id: "github:radiusmethod/crow#64",
+        number: 64,
+        title: "Expand test coverage",
+        state: "open",
+        url: "https://github.com/radiusmethod/crow/issues/64",
+        repo: "radiusmethod/crow",
+        labels: ["enhancement", "testing"],
+        provider: .github,
+        prNumber: 100,
+        prURL: "https://github.com/radiusmethod/crow/pull/100",
+        updatedAt: date,
+        projectStatus: .inProgress
+    )
+    let data = try JSONEncoder().encode(issue)
+    let decoded = try JSONDecoder().decode(AssignedIssue.self, from: data)
+    #expect(decoded.id == "github:radiusmethod/crow#64")
+    #expect(decoded.number == 64)
+    #expect(decoded.title == "Expand test coverage")
+    #expect(decoded.state == "open")
+    #expect(decoded.labels == ["enhancement", "testing"])
+    #expect(decoded.provider == .github)
+    #expect(decoded.prNumber == 100)
+    #expect(decoded.prURL == "https://github.com/radiusmethod/crow/pull/100")
+    #expect(decoded.updatedAt == date)
+    #expect(decoded.projectStatus == .inProgress)
+}
+
+@Test func assignedIssueCodableNilOptionals() throws {
+    let issue = AssignedIssue(
+        id: "gitlab:host:org/repo#5",
+        number: 5,
+        title: "Bug",
+        state: "open",
+        url: "https://gitlab.com/org/repo/-/issues/5",
+        repo: "org/repo",
+        provider: .gitlab
+    )
+    let data = try JSONEncoder().encode(issue)
+    let decoded = try JSONDecoder().decode(AssignedIssue.self, from: data)
+    #expect(decoded.prNumber == nil)
+    #expect(decoded.prURL == nil)
+    #expect(decoded.updatedAt == nil)
+}
+
+@Test func assignedIssueDefaultProjectStatus() {
+    let issue = AssignedIssue(
+        id: "github:o/r#1", number: 1, title: "T", state: "open",
+        url: "u", repo: "o/r", provider: .github
+    )
+    #expect(issue.projectStatus == .unknown)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/HookEventTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/HookEventTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// MARK: - HookEvent Tests
+
+@Test func hookEventInitDefaults() {
+    let sessionID = UUID()
+    let before = Date()
+    let event = HookEvent(sessionID: sessionID, eventName: "Stop", summary: "Session stopped")
+    let after = Date()
+    #expect(event.sessionID == sessionID)
+    #expect(event.eventName == "Stop")
+    #expect(event.summary == "Session stopped")
+    #expect(event.timestamp >= before && event.timestamp <= after)
+}
+
+@Test func hookEventCustomIDAndTimestamp() {
+    let id = UUID()
+    let date = Date(timeIntervalSince1970: 1_000_000)
+    let event = HookEvent(id: id, sessionID: UUID(), eventName: "PreToolUse", summary: "Using Bash", timestamp: date)
+    #expect(event.id == id)
+    #expect(event.timestamp == date)
+}
+
+@Test func hookEventStoresAllFields() {
+    let sessionID = UUID()
+    let event = HookEvent(sessionID: sessionID, eventName: "Notification", summary: "Task complete")
+    #expect(event.sessionID == sessionID)
+    #expect(event.eventName == "Notification")
+    #expect(event.summary == "Task complete")
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/HookNotificationTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/HookNotificationTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// MARK: - HookNotification Tests
+
+@Test func hookNotificationStoresAllFields() {
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+    let notif = HookNotification(message: "Task finished", notificationType: "info", timestamp: date)
+    #expect(notif.message == "Task finished")
+    #expect(notif.notificationType == "info")
+    #expect(notif.timestamp == date)
+}
+
+@Test func hookNotificationDefaultTimestamp() {
+    let before = Date()
+    let notif = HookNotification(message: "Alert", notificationType: "warning")
+    let after = Date()
+    #expect(notif.timestamp >= before && notif.timestamp <= after)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionLinkTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionLinkTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// MARK: - SessionLink Tests
+
+@Test func sessionLinkCodableRoundTrip() throws {
+    let sessionID = UUID()
+    let link = SessionLink(sessionID: sessionID, label: "Issue", url: "https://github.com/org/repo/issues/1", linkType: .ticket)
+    let data = try JSONEncoder().encode(link)
+    let decoded = try JSONDecoder().decode(SessionLink.self, from: data)
+    #expect(decoded.id == link.id)
+    #expect(decoded.sessionID == sessionID)
+    #expect(decoded.label == "Issue")
+    #expect(decoded.url == "https://github.com/org/repo/issues/1")
+    #expect(decoded.linkType == .ticket)
+}
+
+@Test func sessionLinkAllLinkTypes() throws {
+    let sessionID = UUID()
+    for linkType in [LinkType.ticket, .pr, .repo, .custom] {
+        let link = SessionLink(sessionID: sessionID, label: "L", url: "u", linkType: linkType)
+        let data = try JSONEncoder().encode(link)
+        let decoded = try JSONDecoder().decode(SessionLink.self, from: data)
+        #expect(decoded.linkType == linkType)
+    }
+}
+
+@Test func sessionLinkDefaultIDIsValidUUID() {
+    let link = SessionLink(sessionID: UUID(), label: "PR", url: "https://example.com", linkType: .pr)
+    // The id is auto-generated — just verify it's a valid UUID by checking it's not empty
+    #expect(link.id.uuidString.isEmpty == false)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/ToolActivityTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/ToolActivityTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// MARK: - ToolActivity Tests
+
+@Test func toolActivityDefaultsActiveTrue() {
+    let activity = ToolActivity(toolName: "Bash")
+    #expect(activity.isActive == true)
+}
+
+@Test func toolActivityInactiveState() {
+    let activity = ToolActivity(toolName: "Read", isActive: false)
+    #expect(activity.isActive == false)
+}
+
+@Test func toolActivityToolNameStored() {
+    let activity = ToolActivity(toolName: "Edit")
+    #expect(activity.toolName == "Edit")
+}
+
+@Test func toolActivityTimestampDefault() {
+    let before = Date()
+    let activity = ToolActivity(toolName: "Write")
+    let after = Date()
+    #expect(activity.timestamp >= before && activity.timestamp <= after)
+}

--- a/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
+++ b/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import CrowGit
+import CrowCore
 
 // MARK: - GitError Descriptions
 
@@ -22,4 +23,150 @@ import Testing
     let error = GitError.noDefaultBranch(remote: "origin")
     let desc = error.errorDescription ?? ""
     #expect(desc.contains("origin"))
+}
+
+// MARK: - RepoInfo
+
+@Test func repoInfoStoresAllProperties() {
+    let info = RepoInfo(name: "crow", path: "/dev/crow", workspace: "RadiusMethod", provider: "github", cli: "gh", host: "github.com")
+    #expect(info.name == "crow")
+    #expect(info.path == "/dev/crow")
+    #expect(info.workspace == "RadiusMethod")
+    #expect(info.provider == "github")
+    #expect(info.cli == "gh")
+    #expect(info.host == "github.com")
+}
+
+@Test func repoInfoHostCanBeNil() {
+    let info = RepoInfo(name: "repo", path: "/p", workspace: "ws", provider: "github", cli: "gh", host: nil)
+    #expect(info.host == nil)
+}
+
+// MARK: - discoverRepos
+
+/// Helper to create a temporary dev root directory for discoverRepos tests.
+private func makeTempDevRoot() -> URL {
+    let base = FileManager.default.temporaryDirectory.appendingPathComponent("crow-test-\(UUID().uuidString)")
+    try! FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+    return base
+}
+
+/// Helper to create a fake git repo (directory with .git subdirectory).
+private func createFakeRepo(at base: URL, workspace: String, repo: String) {
+    let gitDir = base.appendingPathComponent(workspace).appendingPathComponent(repo).appendingPathComponent(".git")
+    try! FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+}
+
+/// Helper to build a WorkspaceConfig pointing at a temp devRoot.
+private func makeConfig(
+    devRoot: String,
+    workspaces: [String: WorkspaceEntry] = [:],
+    defaults: WorkspaceDefaults = WorkspaceDefaults()
+) -> WorkspaceConfig {
+    WorkspaceConfig(devRoot: devRoot, workspaces: workspaces, defaults: defaults)
+}
+
+@Test func discoverReposFindsGitRepos() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    createFakeRepo(at: root, workspace: "OrgA", repo: "my-app")
+    let config = makeConfig(devRoot: root.path)
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.count == 1)
+    #expect(repos[0].name == "my-app")
+    #expect(repos[0].workspace == "OrgA")
+}
+
+@Test func discoverReposSkipsExcludedDirs() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // "node_modules" is in the default excludeDirs list
+    createFakeRepo(at: root, workspace: "node_modules", repo: "some-pkg")
+    let config = makeConfig(devRoot: root.path)
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.isEmpty)
+}
+
+@Test func discoverReposSkipsWorktrees() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // Worktrees have .git as a file, not a directory
+    let repoDir = root.appendingPathComponent("OrgA").appendingPathComponent("worktree-repo")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    let gitFile = repoDir.appendingPathComponent(".git")
+    try "gitdir: /some/other/path/.git/worktrees/worktree-repo".write(to: gitFile, atomically: true, encoding: .utf8)
+
+    let config = makeConfig(devRoot: root.path)
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.isEmpty)
+}
+
+@Test func discoverReposReturnsEmptyForMissingDevRoot() async throws {
+    let config = makeConfig(devRoot: "/nonexistent/path/\(UUID().uuidString)")
+    let repos = try await GitManager(config: config).discoverRepos()
+    #expect(repos.isEmpty)
+}
+
+@Test func discoverReposUsesWorkspaceOverrides() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    createFakeRepo(at: root, workspace: "CorpGitLab", repo: "project")
+    let entry = WorkspaceEntry(provider: "gitlab", cli: "glab", host: "gitlab.corp.com")
+    let config = makeConfig(devRoot: root.path, workspaces: ["CorpGitLab": entry])
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.count == 1)
+    #expect(repos[0].provider == "gitlab")
+    #expect(repos[0].cli == "glab")
+    #expect(repos[0].host == "gitlab.corp.com")
+}
+
+@Test func discoverReposUsesDefaults() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    createFakeRepo(at: root, workspace: "MyOrg", repo: "repo1")
+    let config = makeConfig(devRoot: root.path)
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.count == 1)
+    #expect(repos[0].provider == "github")
+    #expect(repos[0].cli == "gh")
+    #expect(repos[0].host == nil)
+}
+
+@Test func discoverReposFindsMultipleRepos() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    createFakeRepo(at: root, workspace: "Org", repo: "repo-a")
+    createFakeRepo(at: root, workspace: "Org", repo: "repo-b")
+    let config = makeConfig(devRoot: root.path)
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.count == 2)
+    let names = Set(repos.map(\.name))
+    #expect(names.contains("repo-a"))
+    #expect(names.contains("repo-b"))
+}
+
+@Test func discoverReposSkipsNonDirectoryEntries() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // Create a regular file at the workspace level (not a directory)
+    let filePath = root.appendingPathComponent("not-a-dir.txt")
+    try "hello".write(to: filePath, atomically: true, encoding: .utf8)
+
+    let config = makeConfig(devRoot: root.path)
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.isEmpty)
 }

--- a/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
@@ -80,4 +80,122 @@ struct ProviderManagerTests {
         let result = ProviderManager.parseTicketURLComponents("https://github.com/org/repo/issues/abc")
         #expect(result == nil)
     }
+
+    // MARK: - detectProvider edge cases
+
+    @Test func detectProviderCaseSensitiveHost() async {
+        // url.contains("github.com") is case-sensitive — uppercase doesn't match
+        let result = await manager.detectProvider(from: "https://GitHub.COM/org/repo/issues/1")
+        // Falls back to GitHub anyway (default fallback), but via fallback path
+        #expect(result.provider == .github)
+        #expect(result.cli == "gh")
+    }
+
+    @Test func detectProviderWithPortInURL() async {
+        let mgr = ProviderManager(additionalGitLabHosts: ["gitlab.internal.io"])
+        let result = await mgr.detectProvider(from: "https://gitlab.internal.io:8443/org/repo/-/issues/5")
+        #expect(result.provider == .gitlab)
+        #expect(result.host == "gitlab.internal.io")
+    }
+
+    @Test func detectProviderEmptyURL() async {
+        let result = await manager.detectProvider(from: "")
+        #expect(result.provider == .github)
+    }
+
+    @Test func detectProviderMultipleCustomHosts() async {
+        let mgr = ProviderManager(additionalGitLabHosts: ["gitlab.a.com", "gitlab.b.com"])
+        let resultA = await mgr.detectProvider(from: "https://gitlab.a.com/org/repo")
+        #expect(resultA.host == "gitlab.a.com")
+        let resultB = await mgr.detectProvider(from: "https://gitlab.b.com/org/repo")
+        #expect(resultB.host == "gitlab.b.com")
+    }
+
+    // MARK: - parseTicketURLComponents edge cases
+
+    @Test func parseGitHubURLWithTrailingSlash() {
+        // split(separator: "/") omits empty subsequences, so trailing "/" is harmless
+        let result = ProviderManager.parseTicketURLComponents("https://github.com/org/repo/issues/42/")
+        #expect(result?.number == 42)
+        #expect(result?.org == "org")
+    }
+
+    @Test func parseGitHubURLWithQueryParams() {
+        // Int("42?tab=comments") returns nil
+        let result = ProviderManager.parseTicketURLComponents("https://github.com/org/repo/issues/42?tab=comments")
+        #expect(result == nil)
+    }
+
+    @Test func parseGitHubURLWithFragment() {
+        // Int("42#issuecomment-123") returns nil
+        let result = ProviderManager.parseTicketURLComponents("https://github.com/org/repo/issues/42#issuecomment-123")
+        #expect(result == nil)
+    }
+
+    @Test func parseGitLabSelfHostedIssue() {
+        let result = ProviderManager.parseTicketURLComponents("https://gitlab.company.io/team/project/-/issues/10")
+        #expect(result?.org == "team")
+        #expect(result?.repo == "project")
+        #expect(result?.number == 10)
+        #expect(result?.isMR == false)
+    }
+
+    @Test func parseHTTPNotHTTPS() {
+        // Parser doesn't check protocol scheme
+        let result = ProviderManager.parseTicketURLComponents("http://github.com/org/repo/issues/1")
+        #expect(result?.number == 1)
+    }
+
+    @Test func parseLargeIssueNumber() {
+        let result = ProviderManager.parseTicketURLComponents("https://github.com/org/repo/issues/999999")
+        #expect(result?.number == 999999)
+    }
+
+    @Test func parseGitLabSubgroupDocumentsLimitation() {
+        // Subgroup URLs: parts[2]="org", parts[3]="sub" — repo is actually "sub", not "repo"
+        let result = ProviderManager.parseTicketURLComponents("https://gitlab.com/org/sub/repo/-/issues/5")
+        // Misparses: treats "sub" as the repo name (known limitation of flat split parsing)
+        #expect(result?.org == "org")
+        #expect(result?.repo == "sub")
+    }
+
+    // MARK: - ProviderError
+
+    @Test func providerErrorInvalidURLStoresURL() {
+        let error = ProviderError.invalidURL("bad-url")
+        if case .invalidURL(let url) = error {
+            #expect(url == "bad-url")
+        } else {
+            #expect(Bool(false), "Expected invalidURL case")
+        }
+    }
+
+    @Test func providerErrorCommandFailedStoresOutput() {
+        let error = ProviderError.commandFailed("stderr output here")
+        if case .commandFailed(let output) = error {
+            #expect(output == "stderr output here")
+        } else {
+            #expect(Bool(false), "Expected commandFailed case")
+        }
+    }
+
+    // MARK: - TicketInfo
+
+    @Test func ticketInfoStoresAllProperties() {
+        let info = TicketInfo(number: 42, title: "Fix bug", repo: "crow", org: "radiusmethod", url: "https://github.com/radiusmethod/crow/issues/42", provider: .github, isMR: false)
+        #expect(info.number == 42)
+        #expect(info.title == "Fix bug")
+        #expect(info.repo == "crow")
+        #expect(info.org == "radiusmethod")
+        #expect(info.url == "https://github.com/radiusmethod/crow/issues/42")
+        #expect(info.provider == .github)
+        #expect(info.isMR == false)
+    }
+
+    @Test func ticketInfoDistinguishesIssueFromMR() {
+        let issue = TicketInfo(number: 1, title: "Issue", repo: "r", org: "o", url: "u", provider: .github, isMR: false)
+        let mr = TicketInfo(number: 2, title: "MR", repo: "r", org: "o", url: "u", provider: .gitlab, isMR: true)
+        #expect(issue.isMR == false)
+        #expect(mr.isMR == true)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds ~50 new tests across 4 packages (CrowGit, CrowProvider, CrowCore, CrowCLI), bringing total test count from ~185 to 235
- **CrowGit**: RepoInfo + discoverRepos() integration tests using temp directories (3 → 13 tests)
- **CrowProvider**: detectProvider/parseTicketURL edge cases, ProviderError, TicketInfo (8 → 25 tests)
- **CrowCore**: 6 new test files for AllowEntry, AssignedIssue, HookEvent, HookNotification, ToolActivity, SessionLink (81 → 101 tests)
- **CrowCLI**: Command argument parsing tests using ArgumentParser's .parse() (28 → 34 tests)

Closes #64

## Test plan
- [x] All 235 tests pass across all 7 testable packages
- [x] No flaky tests — all deterministic, no network calls or external dependencies
- [x] CI should pass (`swift test --package-path` for each package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)