### PR TITLE
CI: move macOS jobs to release pipeline to save runner minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -10,50 +8,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-# test, shellcheck, and build run in parallel; all are required for merge
 jobs:
-  test:
-    name: Test
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "16"
-
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-
-      - name: Get Ghostty submodule SHA
-        id: ghostty-sha
-        run: echo "sha=$(git -C vendor/ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Ghostty framework
-        id: ghostty-cache
-        uses: actions/cache@v4
-        with:
-          path: Frameworks
-          key: ghostty-${{ runner.os }}-${{ runner.arch }}-${{ steps.ghostty-sha.outputs.sha }}
-
-      - name: Build Ghostty
-        if: steps.ghostty-cache.outputs.cache-hit != 'true'
-        run: |
-          unset ZIG_LOCAL_CACHE_DIR ZIG_GLOBAL_CACHE_DIR
-          make ghostty
-
-      - name: Run tests
-        run: |
-          for pkg in Packages/*/; do
-            if [ -d "$pkg/Tests" ]; then
-              echo "==> Testing $(basename "$pkg")..."
-              swift test --package-path "$pkg"
-            fi
-          done
-
   shellcheck:
     name: Shell Lint
     runs-on: ubuntu-latest
@@ -62,50 +17,3 @@ jobs:
 
       - name: Check scripts
         run: shellcheck scripts/*.sh
-
-  build:
-    name: Build
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "16"
-
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
-
-      - name: Get Ghostty submodule SHA
-        id: ghostty-sha
-        run: echo "sha=$(git -C vendor/ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Ghostty framework
-        id: ghostty-cache
-        uses: actions/cache@v4
-        with:
-          path: Frameworks
-          key: ghostty-${{ runner.os }}-${{ runner.arch }}-${{ steps.ghostty-sha.outputs.sha }}
-
-      - name: Build Ghostty
-        if: steps.ghostty-cache.outputs.cache-hit != 'true'
-        run: |
-          unset ZIG_LOCAL_CACHE_DIR ZIG_GLOBAL_CACHE_DIR
-          make ghostty
-
-      - name: Cache SPM dependencies
-        uses: actions/cache@v4
-        with:
-          path: .build
-          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.swift', 'Packages/*/Package.swift') }}
-          restore-keys: |
-            spm-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Generate build info
-        run: bash scripts/generate-build-info.sh
-
-      - name: Build
-        run: swift build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,60 @@ env:
   ZIG_VERSION: '0.15.2'
 
 jobs:
+  test:
+    name: Test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16"
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Get Ghostty submodule SHA
+        id: ghostty-sha
+        run: echo "sha=$(git -C vendor/ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Ghostty framework
+        id: ghostty-cache
+        uses: actions/cache@v4
+        with:
+          path: Frameworks
+          key: ghostty-${{ runner.os }}-${{ runner.arch }}-${{ steps.ghostty-sha.outputs.sha }}
+
+      - name: Build Ghostty
+        if: steps.ghostty-cache.outputs.cache-hit != 'true'
+        run: |
+          unset ZIG_LOCAL_CACHE_DIR ZIG_GLOBAL_CACHE_DIR
+          make ghostty
+
+      - name: Run tests
+        run: |
+          for pkg in Packages/*/; do
+            if [ -d "$pkg/Tests" ]; then
+              echo "==> Testing $(basename "$pkg")..."
+              swift test --package-path "$pkg"
+            fi
+          done
+
+  shellcheck:
+    name: Shell Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check scripts
+        run: shellcheck scripts/*.sh
+
   release:
     name: Build, Sign & Release
+    needs: [test, shellcheck]
     runs-on: macos-15
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary
- Remove `test` and `build` macOS jobs from CI workflow — now only runs `shellcheck` on ubuntu for PRs
- Add `test` and `shellcheck` as gating jobs in the release workflow so they run on tag push before releasing
- Remove redundant push-to-main trigger from CI

macOS runners cost 10x Linux runners. This eliminates macOS usage from every PR, reserving it for releases only.

Closes #117

## Test plan
- [x] Open this PR and verify only `shellcheck` runs in CI
- [x] Push a test tag to verify the release workflow runs `test` + `shellcheck` before the release job

🤖 Generated with [Claude Code](https://claude.com/claude-code)