### PR TITLE
Add .claude/prompts/ to write allowlist

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -47,6 +47,7 @@
       "Bash(sleep:*)",
       "Read",
       "Write",
+      "Write(.claude/prompts/**)",
       "Edit",
       "Glob",
       "Grep"


### PR DESCRIPTION
## Summary
- Add `Write(.claude/prompts/**)` to `settings.json` so the Manager session can write prompt files without triggering a permission dialog during workspace setup

Closes #122

## Test plan
- [x] `make build` passes
- [x] Launch Crow, run `/crow-workspace` for an issue — prompt file is written without a permission dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)