### PR TITLE
Add global terminals: standalone terminal tabs outside sessions

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -39,6 +39,9 @@ public final class AppState {
     /// Fixed UUID for the review board tab.
     nonisolated public static let reviewBoardSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
 
+    /// Fixed UUID for the global terminals page.
+    nonisolated public static let globalTerminalSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
+
     public var managerSession: Session? {
         sessions.first { $0.id == Self.managerSessionID }
     }
@@ -143,6 +146,12 @@ public final class AppState {
     /// Called to close a non-managed terminal tab.
     public var onCloseTerminal: ((UUID, UUID) -> Void)?  // receives (sessionID, terminalID)
 
+    /// Called to add a new global terminal tab.
+    public var onAddGlobalTerminal: (() -> Void)?
+
+    /// Called to close a global terminal tab.
+    public var onCloseGlobalTerminal: ((UUID) -> Void)?  // receives terminalID
+
     // MARK: - Closures wired by AppDelegate
 
     /// Called to delete a session and clean up its worktrees.
@@ -175,7 +184,8 @@ public final class AppState {
     public var selectedSession: Session? {
         guard selectedSessionID != Self.ticketBoardSessionID,
               selectedSessionID != Self.allowListSessionID,
-              selectedSessionID != Self.reviewBoardSessionID else { return nil }
+              selectedSessionID != Self.reviewBoardSessionID,
+              selectedSessionID != Self.globalTerminalSessionID else { return nil }
         return sessions.first { $0.id == selectedSessionID }
     }
 

--- a/Packages/CrowUI/Sources/CrowUI/GlobalTerminalView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/GlobalTerminalView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import CrowCore
+import CrowTerminal
+
+/// View for global terminals that exist outside of any session.
+public struct GlobalTerminalView: View {
+    @Bindable var appState: AppState
+
+    public init(appState: AppState) {
+        self.appState = appState
+    }
+
+    private var globalTerminals: [SessionTerminal] {
+        appState.terminals(for: AppState.globalTerminalSessionID)
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(CorveilTheme.borderSubtle)
+            terminalArea
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("Terminals")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(CorveilTheme.gold)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(CorveilTheme.bgSurface)
+    }
+
+    // MARK: - Terminal Area
+
+    @ViewBuilder
+    private var terminalArea: some View {
+        if globalTerminals.isEmpty {
+            emptyState
+        } else {
+            VStack(spacing: 0) {
+                TerminalTabBar(
+                    terminals: globalTerminals,
+                    activeID: appState.activeTerminalID[AppState.globalTerminalSessionID] ?? globalTerminals[0].id,
+                    onSelect: { id in
+                        appState.activeTerminalID[AppState.globalTerminalSessionID] = id
+                    },
+                    onClose: { id in
+                        appState.onCloseGlobalTerminal?(id)
+                    },
+                    onAdd: {
+                        appState.onAddGlobalTerminal?()
+                    }
+                )
+                Divider().overlay(CorveilTheme.borderSubtle)
+                let activeID = appState.activeTerminalID[AppState.globalTerminalSessionID] ?? globalTerminals[0].id
+                if let terminal = globalTerminals.first(where: { $0.id == activeID }) {
+                    TerminalSurfaceView(
+                        terminalID: terminal.id,
+                        workingDirectory: terminal.cwd,
+                        command: terminal.command
+                    )
+                    .id(terminal.id)
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "terminal")
+                .font(.system(size: 40))
+                .foregroundStyle(CorveilTheme.textMuted)
+            Text("No terminals open")
+                .font(.headline)
+                .foregroundStyle(CorveilTheme.textSecondary)
+            Text("Create a terminal to get started.")
+                .font(.subheadline)
+                .foregroundStyle(CorveilTheme.textMuted)
+            Button {
+                appState.onAddGlobalTerminal?()
+            } label: {
+                Label("New Terminal", systemImage: "plus")
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            .buttonStyle(.bordered)
+            .tint(CorveilTheme.gold)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(CorveilTheme.bgDeep)
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
@@ -20,6 +20,8 @@ public struct MainContentView: View {
                 AllowListView(appState: appState)
             } else if appState.selectedSessionID == AppState.reviewBoardSessionID {
                 ReviewBoardView(appState: appState)
+            } else if appState.selectedSessionID == AppState.globalTerminalSessionID {
+                GlobalTerminalView(appState: appState)
             } else if let session = appState.selectedSession {
                 SessionDetailView(session: session, appState: appState)
             } else {

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -175,8 +175,8 @@ struct ReviewRow: View {
 
 // MARK: - Sidebar Row
 
-/// Compact sidebar row showing pending review count.
-public struct ReviewBoardSidebarRow: View {
+/// Combined Reviews and Terminals toggle buttons in the sidebar.
+public struct ReviewTerminalsSidebarRow: View {
     @Bindable var appState: AppState
 
     public init(appState: AppState) {
@@ -184,45 +184,76 @@ public struct ReviewBoardSidebarRow: View {
     }
 
     public var body: some View {
-        HStack {
-            Spacer()
-            HStack(spacing: 6) {
-                Image(systemName: "eye.circle")
-                    .font(.system(size: 12))
-                    .foregroundStyle(CorveilTheme.gold)
+        HStack(spacing: 6) {
+            reviewButton
+            terminalButton
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var reviewButton: some View {
+        let isActive = appState.selectedSessionID == AppState.reviewBoardSessionID
+        return Button {
+            appState.selectedSessionID = AppState.reviewBoardSessionID
+        } label: {
+            HStack(spacing: 4) {
                 Text("Reviews")
-                    .font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(CorveilTheme.gold)
+                    .font(.system(size: 12, weight: .bold))
                 if appState.isLoadingReviews {
                     ProgressView()
                         .controlSize(.mini)
                 }
                 if appState.reviewRequests.count > 0 {
                     Text("\(appState.reviewRequests.count)")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 10, weight: .semibold))
                         .monospacedDigit()
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(unseenCount > 0 ? CorveilTheme.gold.opacity(0.2) : Color.secondary.opacity(0.15))
-                        .foregroundStyle(unseenCount > 0 ? CorveilTheme.gold : CorveilTheme.textSecondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(appState.unseenReviewCount > 0 ? CorveilTheme.gold.opacity(0.2) : Color.secondary.opacity(0.15))
+                        .foregroundStyle(appState.unseenReviewCount > 0 ? CorveilTheme.gold : CorveilTheme.textSecondary)
                         .clipShape(Capsule())
                 }
             }
-            Spacer()
+            .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(
+                                isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
+                                lineWidth: 1
+                            )
+                    )
+            )
         }
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(CorveilTheme.bgSurface)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(CorveilTheme.borderSubtle, lineWidth: 1)
-                )
-        )
-        .padding(.vertical, 2)
+        .buttonStyle(.plain)
     }
 
-    private var unseenCount: Int {
-        appState.unseenReviewCount
+    private var terminalButton: some View {
+        let isActive = appState.selectedSessionID == AppState.globalTerminalSessionID
+        return Button {
+            appState.selectedSessionID = AppState.globalTerminalSessionID
+        } label: {
+            Text("Terminals")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(
+                                    isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
+                                    lineWidth: 1
+                                )
+                        )
+                )
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -24,9 +24,8 @@ public struct SessionListView: View {
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
 
-            // Review board row
-            ReviewBoardSidebarRow(appState: appState)
-                .tag(AppState.reviewBoardSessionID)
+            // Reviews + Terminals row
+            ReviewTerminalsSidebarRow(appState: appState)
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -172,6 +172,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.onCloseTerminal = { [weak service] sessionID, terminalID in
             service?.closeTerminal(sessionID: sessionID, terminalID: terminalID)
         }
+        appState.onAddGlobalTerminal = { [weak service] in
+            service?.addGlobalTerminal()
+        }
+        appState.onCloseGlobalTerminal = { [weak service] terminalID in
+            service?.closeGlobalTerminal(terminalID: terminalID)
+        }
 
         // Detect VS Code CLI and wire open action
         service.detectVSCode()
@@ -591,6 +597,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "list-terminals": { @Sendable params in
                 guard let idStr = params["session_id"]?.stringValue, let id = UUID(uuidString: idStr) else {
                     throw RPCError.invalidParams("session_id required")
+                }
+                // Global terminals are not exposed via the session CLI
+                if id == AppState.globalTerminalSessionID {
+                    return ["terminals": .array([])]
                 }
                 let terms = await MainActor.run { capturedAppState.terminals(for: id) }
                 let items: [JSONValue] = terms.map { t in

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -84,6 +84,19 @@ final class SessionService {
                 )
             }
         }
+
+        // Hydrate global terminals (not tied to any session)
+        let globalTerminals = data.terminals.filter { $0.sessionID == AppState.globalTerminalSessionID }
+        if !globalTerminals.isEmpty {
+            appState.terminals[AppState.globalTerminalSessionID] = globalTerminals
+            for terminal in globalTerminals {
+                TerminalManager.shared.preInitialize(
+                    id: terminal.id,
+                    workingDirectory: terminal.cwd,
+                    command: terminal.command
+                )
+            }
+        }
     }
 
     /// Bridge `TerminalManager.SurfaceState` callbacks to `AppState.terminalReadiness`.
@@ -611,6 +624,39 @@ final class SessionService {
         appState.terminals[sessionID]?.removeAll { $0.id == terminalID }
         appState.terminalReadiness.removeValue(forKey: terminalID)
         appState.autoLaunchTerminals.remove(terminalID)
+
+        if appState.activeTerminalID[sessionID] == terminalID {
+            appState.activeTerminalID[sessionID] = appState.terminals[sessionID]?.first?.id
+        }
+
+        store.mutate { data in data.terminals.removeAll { $0.id == terminalID } }
+    }
+
+    // MARK: - Global Terminal Management
+
+    /// Add a new global terminal tab (not tied to any session).
+    func addGlobalTerminal() {
+        let sessionID = AppState.globalTerminalSessionID
+        let cwd = ConfigStore.loadDevRoot()
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
+        let count = appState.terminals(for: sessionID).count
+        let terminal = SessionTerminal(
+            sessionID: sessionID,
+            name: "Terminal \(count + 1)",
+            cwd: cwd,
+            isManaged: false
+        )
+        appState.terminals[sessionID, default: []].append(terminal)
+        appState.activeTerminalID[sessionID] = terminal.id
+        store.mutate { data in data.terminals.append(terminal) }
+        TerminalManager.shared.preInitialize(id: terminal.id, workingDirectory: cwd)
+    }
+
+    /// Close a global terminal tab.
+    func closeGlobalTerminal(terminalID: UUID) {
+        let sessionID = AppState.globalTerminalSessionID
+        TerminalManager.shared.destroy(id: terminalID)
+        appState.terminals[sessionID]?.removeAll { $0.id == terminalID }
 
         if appState.activeTerminalID[sessionID] == terminalID {
             appState.activeTerminalID[sessionID] = appState.terminals[sessionID]?.first?.id


### PR DESCRIPTION
## Summary
- Adds a **Global Terminals** section — standalone terminal tabs that exist outside of any session, accessible via a new "Terminals" sidebar button
- Splits the Reviews sidebar row into a two-button layout ("Reviews" | "Terminals") matching the existing Manager/Allow List pattern
- Global terminals persist across app restarts, support full tab management (create/close/switch), and default CWD to devRoot
- Global terminals are excluded from `crow list-terminals --session <uuid>` CLI output

Closes #104

## Test plan
- [ ] Build compiles cleanly (`make build`)
- [ ] Sidebar shows "Reviews | Terminals" split button row
- [ ] Clicking "Terminals" shows empty state with "New Terminal" button
- [ ] Pressing "+" or "New Terminal" creates a terminal tab at devRoot
- [ ] Multiple tabs can be created and switched between
- [ ] Tabs can be closed via the X button
- [ ] Switching to a session and back preserves global terminal tabs
- [ ] Quit and relaunch restores global terminals
- [ ] `crow list-terminals --session <work-session-uuid>` does not include global terminals
- [ ] Reviews button still works with badge count

🤖 Generated with [Claude Code](https://claude.com/claude-code)