### PR TITLE
Extract deterministic workspace steps into setup.sh

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalManager.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalManager.swift
@@ -116,9 +116,10 @@ public final class TerminalManager {
         if monitoredTerminals.contains(id) {
             monitoredTerminals.remove(id)
             // Shell needs time to initialize after surface creation.
-            // Wait 2 seconds then mark as ready — the surface is in a window,
-            // createSurface() has spawned the shell, we just need the shell to start.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            // On app restart, multiple terminals initialize concurrently which
+            // causes shell startup to take longer than a single terminal.
+            // 5 seconds handles the common case; the TODO above tracks proper detection.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { [weak self] in
                 guard let self else { return }
                 self.onStateChanged?(id, .shellReady)
             }

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -1,0 +1,141 @@
+# Crow Review PR
+
+Perform a comprehensive code and security review on a GitHub pull request, then post the findings as a PR review.
+
+## Important: Sandbox Bypass
+
+All `gh` and `git` commands require `dangerouslyDisableSandbox: true` because they need network/TLS access.
+
+## Arguments
+
+- `$ARGUMENTS` - The PR URL or number to review (required)
+
+## Activation
+
+This skill activates when:
+- User invokes `/crow-review-pr` command
+- User asks to "review a PR" or "review this pull request"
+- This is a review session (the session was created via the Crow Reviews board)
+
+## Instructions
+
+You are performing a code and security review on PR $ARGUMENTS. Follow these steps:
+
+### Step 1: Checkout the PR
+
+```bash
+gh pr checkout $ARGUMENTS
+```
+
+### Step 2: Gather PR Information
+
+Get the PR details including title, description, and changed files:
+
+```bash
+gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,additions,deletions,changedFiles,files
+```
+
+### Step 3: Review the Code
+
+Read all changed files in the PR. For each file, analyze:
+
+**Security Review:**
+- Authentication/authorization issues
+- Input validation vulnerabilities
+- Injection risks (SQL, command, XSS)
+- Secrets/credentials exposure
+- Cryptographic weaknesses
+- Insecure configurations
+- OWASP Top 10 concerns
+
+**Code Quality:**
+- Logic errors
+- Error handling
+- Resource leaks
+- Race conditions
+- API design issues
+- Missing tests for new code
+
+### Step 4: Run Static Analysis
+
+For Go projects:
+```bash
+cd core && go vet ./... 2>&1
+cd core && go test ./... -v 2>&1 | head -50
+```
+
+For JavaScript/TypeScript projects:
+```bash
+npm run lint 2>&1 | head -50
+```
+
+For Swift projects:
+```bash
+swift build 2>&1 | tail -20
+```
+
+For Python projects:
+```bash
+ruff check . 2>&1 | head -50
+```
+
+### Step 5: Post Review
+
+Based on your findings, determine the appropriate review action:
+
+- **Approve**: No critical or blocking issues found → use `--approve`
+- **Request Changes**: Critical or blocking issues found → use `--request-changes`
+- **Comment**: Informational only, no strong opinion either way → use `--comment`
+
+Post the review using the appropriate flag:
+
+```bash
+# If approving:
+gh pr review $ARGUMENTS --approve --body "YOUR_REVIEW_HERE"
+
+# If requesting changes:
+gh pr review $ARGUMENTS --request-changes --body "YOUR_REVIEW_HERE"
+
+# If commenting only:
+gh pr review $ARGUMENTS --comment --body "YOUR_REVIEW_HERE"
+```
+
+Use this format for the review:
+
+```markdown
+## Code & Security Review
+
+### Critical Issues (if any)
+[List blocking issues that must be fixed]
+
+### Security Review
+**Strengths:**
+- [Positive security aspects]
+
+**Concerns:**
+- [Security issues found]
+
+### Code Quality
+- [Code quality issues]
+
+### Summary Table
+| Priority | Issue |
+|----------|-------|
+| Red | Must fix items |
+| Yellow | Should fix items |
+| Green | Consider items |
+
+**Recommendation:** [Approve / Request Changes / Comment — with reasoning]
+```
+
+### Important Notes
+
+- Be thorough but concise
+- Prioritize security issues
+- Include file:line references for specific issues
+- Don't include sensitive information in the review
+- If tests fail, note which ones and why
+- Use `--approve` when the PR looks good (no red/blocking items)
+- Use `--request-changes` when there are critical issues that must be fixed before merge
+- Use `--comment` only when you have no strong recommendation either way
+- All `gh` and `git` commands require `dangerouslyDisableSandbox: true`

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -168,30 +168,16 @@ WRONG: {devRoot}/{workspace}/worktrees/{repo}-{feature}
 ```
 Branch: `feature/{feature-slug}`
 
-### Git Commands (Provider-Agnostic)
+### Git Commands
 
-```bash
-git -C {repo_path} fetch origin
-git -C {repo_path} ls-remote --heads origin feature/{name}
+Git worktree creation is handled by `setup.sh`. The script automatically selects the correct flags:
+- **PR branch**: `--track origin/{pr_branch}`
+- **Existing remote branch**: `--track origin/{branch}`
+- **New branch**: `--no-track origin/main`
 
-# Existing remote branch (no PR):
-git -C {repo_path} worktree add {path} \
-  -b feature/{name} \
-  --track origin/feature/{name}
+Always uses `-b` to create a local branch (avoids detached HEAD). If the branch already exists locally, the script deletes it and retries.
 
-# New branch (no PR, no remote branch):
-git -C {repo_path} worktree add {path} \
-  -b feature/{name} \
-  --no-track \
-  origin/main
-
-# PR branch (existing PR detected):
-git -C {repo_path} worktree add {path} \
-  -b {pr_branch} \
-  --track origin/{pr_branch}
-```
-
-**Important:** Always use `-b` to create a local branch. Without it, the worktree ends up in detached HEAD state. Use `--no-track` for new branches to prevent accidental push to main.
+**Important:** Always use `--no-track` for new branches to prevent accidental push to main.
 
 ## crow Session Creation
 
@@ -209,97 +195,102 @@ This keeps session names, worktree paths, and branch names consistent.
 
 ### Complete Step-by-Step Flow
 
-> **IMPORTANT: Execute steps 1-9 SEQUENTIALLY — one at a time, never in parallel.**
-> Parallel calls cascade on failure (a failed `add-worktree` cancels sibling `add-link` calls).
+After the LLM resolves names (slug, branch, worktree path, session name), detects any existing PR, and composes the prompt content, the setup is executed by calling `setup.sh`.
+
+> **IMPORTANT:** All `crow`, `gh`, `glab`, and `git` commands require `dangerouslyDisableSandbox: true`. The `setup.sh` call itself must use `dangerouslyDisableSandbox: true` since it runs these commands internally.
+
+#### Step 1: Write the prompt file
+
+The LLM writes the prompt content (see template below) to a file:
 
 ```bash
-# 1. Create session (parse session_id from JSON output)
-#    The name MUST match the worktree directory name
-crow new-session --name "{repo}-{ticket_number}-{slug}"
-# Output: {"session_id":"<uuid>","name":"crow-51-drag-drop-photo"}
-# >>> Wait for completion — parse session_id before proceeding <<<
-
-# 2. Set ticket metadata (only if URL was provided)
-crow set-ticket --session {session_id} \
-  --url "{ticket_url}" \
-  --title "{ticket_title}" \
-  --number {ticket_number}
-# >>> Wait for completion <<<
-
-# 3. Register each worktree (after creating with git)
-#    IMPORTANT: --repo-path is the MAIN repo path (e.g., .../citadel)
-#    --path is the WORKTREE path (e.g., .../citadel-197-slug)
-crow add-worktree --session {session_id} \
-  --repo "{repo_name}" \
-  --repo-path "{main_repo_path}" \
-  --path "{worktree_path}" \
-  --branch "feature/{name}" \
-  --primary   # for the first/main repo
-# >>> Wait for completion <<<
-
-# 4. Add ticket link (only if URL was provided)
-crow add-link --session {session_id} \
-  --label "Issue" \
-  --url "{ticket_url}" \
-  --type ticket
-# >>> Wait for completion <<<
-
-# 4a. Add PR link (only if an existing PR was detected)
-crow add-link --session {session_id} \
-  --label "PR #{pr_number}" \
-  --url "{pr_url}" \
-  --type pr
-# >>> Wait for completion <<<
-
-# 4b. Auto-assign and set project status (GitHub issues only, best-effort)
-#     All gh commands require dangerouslyDisableSandbox: true.
-#     Don't fail the workspace setup if these error.
-#
-#     Step A: Assign yourself to the issue
-gh issue edit {ticket_url} --add-assignee @me
-#
-#     Step B: Set the issue's project status to "In progress"
-#     This requires multiple GraphQL calls chained together:
-#     1. Get the projectItem ID and project ID for the issue
-#     2. Get the Status field ID from the project
-#     3. Get the option ID for "In progress" from the Status field options
-#     4. Mutate the field value
-#
-#     Use gh api graphql with --jq to extract values. Chain them:
-#       - query repository.issue.projectItems.nodes[0] for {itemId, project.id}
-#       - query node(id: projectId).field(name: "Status") for fieldId and options
-#       - find the option where name == "In progress" (case-sensitive, match exactly)
-#       - call updateProjectV2ItemFieldValue mutation
-#     If the issue is not on any project, skip silently.
-
-# 5. Write prompt to temp file
-#    IMPORTANT: Write to {devRoot}/.claude/prompts/ — NOT $TMPDIR (which differs per session)
-#    The prompt MUST start with /plan to enter plan mode
 mkdir -p {devRoot}/.claude/prompts
 cat > {devRoot}/.claude/prompts/crow-prompt-{session_name}.md << 'PROMPT'
 {prompt content — see template below}
 PROMPT
+```
 
-# 6. Create a shell terminal in the primary worktree (NO command — just a shell)
-crow new-terminal --session {session_id} \
-  --cwd "{primary_worktree_path}" \
-  --name "Claude Code" \
-  --managed
-# Output: {"terminal_id":"<uuid>","session_id":"..."}
-# IMPORTANT: Capture the terminal_id from the output!
+#### Step 2: Run setup.sh
 
-# 7. Switch to the new session so the terminal gets created in the UI
-crow select-session --session {session_id}
+```bash
+.claude/skills/crow-workspace/setup.sh \
+  --dev-root "{devRoot}" \
+  --workspace "{workspace}" \
+  --repo "{repo}" \
+  --repo-path "{repo_path}" \
+  --slug "{slug}" \
+  --branch "{branch}" \
+  --worktree-path "{worktree_path}" \
+  --session-name "{session_name}" \
+  --provider "{provider}" \
+  --cli "{cli}" \
+  --ticket-url "{ticket_url}" \
+  --ticket-title "{ticket_title}" \
+  --ticket-number {ticket_number} \
+  --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
+  --claude-binary "$(which claude)" \
+  --primary
+```
 
-# 8. Wait for the shell to initialize (the terminal needs to be visible and ready)
-sleep 3
+If an existing PR was detected, also pass:
+```
+  --pr-number {pr_number} \
+  --pr-url "{pr_url}" \
+  --pr-branch "{pr_branch}"
+```
 
-# 9. Send the claude launch command to the terminal
-#    CRITICAL: End the text with literal \n — the app converts \n to Enter.
-#    Use single quotes so the shell doesn't expand $(cat ...).
-#    Use --permission-mode plan to start Claude in plan mode.
-#    Use full path to claude binary.
-crow send --session {session_id} --terminal {terminal_id} 'cd {primary_worktree_path} && {claude_binary_path} --permission-mode plan "$(cat {devRoot}/.claude/prompts/crow-prompt-{session_name}.md)"\n'
+For GitLab, also pass:
+```
+  --host "{gitlab_host}"
+```
+
+#### Step 3: Parse the result
+
+The script outputs JSON to stdout. On success:
+```json
+{
+  "status": "ok",
+  "session_id": "uuid",
+  "terminal_id": "uuid",
+  "worktree_path": "/path/to/worktree",
+  "branch": "feature/name"
+}
+```
+
+On failure:
+```json
+{
+  "status": "error",
+  "step": "git_worktree_add",
+  "message": "error details",
+  "partial": { "session_id": "uuid-if-created" }
+}
+```
+
+If the script fails, read the error message and apply error handling (see below).
+
+#### Multi-Repo Flow
+
+For cross-workspace setups with multiple repos, call `setup.sh` once per repo:
+
+1. **First repo** (primary): Use `--primary` flag. Capture `session_id` from output.
+2. **Additional repos**: Pass `--session-id {uuid}` from the first call's output and use `--skip-launch` (Claude only launches once, in the primary worktree).
+
+```bash
+# Secondary repo (no launch, attach to existing session):
+.claude/skills/crow-workspace/setup.sh \
+  --session-id "{session_id_from_first_call}" \
+  --dev-root "{devRoot}" \
+  --workspace "{other_workspace}" \
+  --repo "{other_repo}" \
+  --repo-path "{other_repo_path}" \
+  --slug "{slug}" \
+  --branch "main" \
+  --worktree-path "{other_repo_path}" \
+  --session-name "{session_name}" \
+  --provider "{provider}" \
+  --cli "{cli}" \
+  --skip-launch
 ```
 
 ## First Prompt Template
@@ -375,19 +366,23 @@ GITLAB_HOST=gitlab.example.com glab mr view {number} --repo {org/repo} --comment
 
 ## Error Handling and Self-Correction
 
-If a `crow` command fails:
-1. Read the error message from the JSON response
-2. If the error indicates a usage problem (wrong arg format, missing param), append a one-line correction to `{devRoot}/CLAUDE.md` under "## Known Issues / Corrections"
-3. Retry with corrected command
-4. If transient error (socket unavailable), retry up to 3 times with 1s delay
+If `setup.sh` returns a JSON error (`"status": "error"`):
+1. Read the `step` and `message` fields to understand what failed
+2. If the error indicates a usage problem (wrong arg format, missing param), fix the invocation and retry
+3. If `partial.session_id` is present, the session was created before the failure — you can pass `--session-id` to retry without recreating the session
+4. If the error is in `git_worktree_add`, the branch may already exist — try with a different slug
+5. Append a one-line correction to `{devRoot}/CLAUDE.md` under "## Known Issues / Corrections"
 
 | Error | Response |
 |-------|----------|
-| Socket not found | Crow app may not be running. Inform user. |
-| Session not found | Use full UUID from new-session output, not short names |
-| Unknown workspace | Use defaults, warn user |
-| CLI not installed | Report which CLI is needed (gh, glab) |
-| No repos matched | List all repos across all workspaces |
+| `parse_args` — Missing required arguments | Check that all required flags are provided |
+| `git_fetch` — git fetch failed | Check repo path exists and has remote configured |
+| `git_worktree_add` — worktree creation failed | Branch may exist; script auto-retries after cleanup |
+| `new_session` — crow new-session failed | Crow app may not be running. Inform user. |
+| `add_worktree` — crow add-worktree failed | Use full UUID from session, check paths |
+| `new_terminal` — crow new-terminal failed | Session may not exist; check session_id |
+| `send_launch` — crow send failed | Terminal may not be ready; retry |
+| `write_prompt` — prompt file not found | Verify prompt was written before calling setup.sh |
 
 ## crow CLI Reference
 
@@ -402,7 +397,7 @@ crow delete-session --session <uuid>
 crow set-ticket --session <uuid> --url "..." [--title "..."] [--number N]
 crow add-worktree --session <uuid> --repo "name" --repo-path "/main/repo/path" --path "/worktree/path" --branch "..." [--primary]
 crow list-worktrees --session <uuid>
-crow new-terminal --session <uuid> --cwd "/..." [--name "..."] [--managed]
+crow new-terminal --session <uuid> --cwd "/..." [--name "..."] [--command "..."]
 crow list-terminals --session <uuid>
 crow send --session <uuid> --terminal <uuid> "text"
 crow add-link --session <uuid> --label "..." --url "..." --type ticket|pr|repo|custom

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -47,6 +47,14 @@ TERMINAL_ID=""
 
 log() { echo "[setup.sh] $*" >&2; }
 
+# Extract a JSON string value by key. Handles both compact and pretty-printed JSON.
+# Usage: json_val "key" <<< "$json_string"
+json_val() {
+  local key="$1"
+  # Normalize whitespace: collapse the JSON to one line, strip spaces around : and quotes
+  tr -d '\n' | sed 's/[[:space:]]*:[[:space:]]*/:/g' | grep -o "\"$key\":\"[^\"]*\"" | cut -d'"' -f4 | head -1
+}
+
 die() {
   local step="$1" msg="$2"
   local partial=""
@@ -229,7 +237,7 @@ create_session() {
     if ! result=$(crow new-session --name "$SESSION_NAME" 2>&1); then
       die "new_session" "crow new-session failed: $result"
     fi
-    SESSION_ID=$(echo "$result" | grep -o '"session_id":"[^"]*"' | cut -d'"' -f4)
+    SESSION_ID=$(json_val "session_id" <<< "$result")
     if [[ -z "$SESSION_ID" ]]; then
       die "new_session" "Could not parse session_id from: $result"
     fi
@@ -444,7 +452,7 @@ launch_claude() {
     die "new_terminal" "crow new-terminal failed: $term_result"
   fi
 
-  TERMINAL_ID=$(echo "$term_result" | grep -o '"terminal_id":"[^"]*"' | cut -d'"' -f4)
+  TERMINAL_ID=$(json_val "terminal_id" <<< "$term_result")
   if [[ -z "$TERMINAL_ID" ]]; then
     die "new_terminal" "Could not parse terminal_id from: $term_result"
   fi

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -462,6 +462,12 @@ launch_claude() {
   crow select-session --session "$SESSION_ID" >/dev/null 2>&1 \
     || log "Warning: select-session failed"
 
+  # Wait for the shell to initialize in the new terminal.
+  # The terminal surface is pre-initialized by crow new-terminal, but the
+  # shell process needs time to start and display its prompt.
+  log "Waiting for shell to initialize..."
+  sleep 3
+
   # Build the prompt file path
   local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
 

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -1,0 +1,468 @@
+#!/bin/bash
+# setup.sh — Deterministic workspace setup for Crow
+#
+# Called by the crow-workspace skill after the LLM resolves names,
+# detects PRs, and composes the prompt content. This script handles
+# all mechanical operations: git worktree creation, crow session
+# setup, GitHub housekeeping, prompt file writing, and Claude Code launch.
+#
+# All output goes to stderr except the final JSON result on stdout.
+
+set -euo pipefail
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+
+DEV_ROOT=""
+WORKSPACE=""
+REPO=""
+REPO_PATH=""
+SLUG=""
+BRANCH=""
+WORKTREE_PATH=""
+SESSION_NAME=""
+PROVIDER=""
+CLI_TOOL=""
+HOST=""
+TICKET_URL=""
+TICKET_TITLE=""
+TICKET_NUMBER=""
+PR_NUMBER=""
+PR_URL=""
+PR_BRANCH=""
+PROMPT_CONTENT=""
+CLAUDE_BINARY=""
+SESSION_ID=""
+PRIMARY=false
+SKIP_LAUNCH=false
+SKIP_ASSIGN=false
+SKIP_PROJECT_STATUS=false
+
+# Runtime state
+TERMINAL_ID=""
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+log() { echo "[setup.sh] $*" >&2; }
+
+die() {
+  local step="$1" msg="$2"
+  local partial=""
+  if [[ -n "$SESSION_ID" ]]; then
+    partial=", \"partial\": {\"session_id\": \"$SESSION_ID\"}"
+  fi
+  printf '{"status":"error","step":"%s","message":"%s"%s}\n' \
+    "$step" \
+    "$(echo "$msg" | sed 's/"/\\"/g' | tr '\n' ' ')" \
+    "$partial"
+  exit 1
+}
+
+# ─── Argument Parsing ────────────────────────────────────────────────────────
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: setup.sh [OPTIONS]
+
+Required:
+  --dev-root <path>          Development root directory
+  --workspace <name>         Workspace name (e.g. RadiusMethod)
+  --repo <name>              Repository name
+  --repo-path <path>         Main repo clone path
+  --slug <slug>              LLM-generated slug (e.g. 104-global-terminals)
+  --branch <branch>          Target branch name
+  --worktree-path <path>     Target worktree path
+  --session-name <name>      Crow session name
+  --provider <github|gitlab> Git provider
+  --cli <gh|glab>            CLI tool
+
+Optional:
+  --host <hostname>          GitLab host (required for gitlab)
+  --ticket-url <url>         Issue/ticket URL
+  --ticket-title <title>     Ticket title
+  --ticket-number <number>   Ticket number
+  --pr-number <number>       Existing PR number
+  --pr-url <url>             Existing PR URL
+  --pr-branch <branch>       Existing PR branch name
+  --prompt-content <path>    Path to LLM-written prompt file
+  --claude-binary <path>     Full path to claude binary
+  --session-id <uuid>        Existing session ID (for secondary repos)
+  --primary                  Mark worktree as primary
+  --skip-launch              Skip Claude Code launch
+  --skip-assign              Skip auto-assign
+  --skip-project-status      Skip project status mutation
+  --help                     Show this help
+EOF
+  exit 0
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dev-root)          DEV_ROOT="$2"; shift 2 ;;
+      --workspace)         WORKSPACE="$2"; shift 2 ;;
+      --repo)              REPO="$2"; shift 2 ;;
+      --repo-path)         REPO_PATH="$2"; shift 2 ;;
+      --slug)              SLUG="$2"; shift 2 ;;
+      --branch)            BRANCH="$2"; shift 2 ;;
+      --worktree-path)     WORKTREE_PATH="$2"; shift 2 ;;
+      --session-name)      SESSION_NAME="$2"; shift 2 ;;
+      --provider)          PROVIDER="$2"; shift 2 ;;
+      --cli)               CLI_TOOL="$2"; shift 2 ;;
+      --host)              HOST="$2"; shift 2 ;;
+      --ticket-url)        TICKET_URL="$2"; shift 2 ;;
+      --ticket-title)      TICKET_TITLE="$2"; shift 2 ;;
+      --ticket-number)     TICKET_NUMBER="$2"; shift 2 ;;
+      --pr-number)         PR_NUMBER="$2"; shift 2 ;;
+      --pr-url)            PR_URL="$2"; shift 2 ;;
+      --pr-branch)         PR_BRANCH="$2"; shift 2 ;;
+      --prompt-content)    PROMPT_CONTENT="$2"; shift 2 ;;
+      --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
+      --session-id)        SESSION_ID="$2"; shift 2 ;;
+      --primary)           PRIMARY=true; shift ;;
+      --skip-launch)       SKIP_LAUNCH=true; shift ;;
+      --skip-assign)       SKIP_ASSIGN=true; shift ;;
+      --skip-project-status) SKIP_PROJECT_STATUS=true; shift ;;
+      --help)              usage ;;
+      *)                   die "parse_args" "Unknown argument: $1" ;;
+    esac
+  done
+
+  # Validate required args
+  local missing=()
+  [[ -z "$DEV_ROOT" ]]      && missing+=("--dev-root")
+  [[ -z "$WORKSPACE" ]]     && missing+=("--workspace")
+  [[ -z "$REPO" ]]          && missing+=("--repo")
+  [[ -z "$REPO_PATH" ]]     && missing+=("--repo-path")
+  [[ -z "$SLUG" ]]          && missing+=("--slug")
+  [[ -z "$BRANCH" ]]        && missing+=("--branch")
+  [[ -z "$WORKTREE_PATH" ]] && missing+=("--worktree-path")
+  [[ -z "$SESSION_NAME" ]]  && missing+=("--session-name")
+  [[ -z "$PROVIDER" ]]      && missing+=("--provider")
+  [[ -z "$CLI_TOOL" ]]      && missing+=("--cli")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "parse_args" "Missing required arguments: ${missing[*]}"
+  fi
+}
+
+# ─── Git Worktree ────────────────────────────────────────────────────────────
+
+setup_worktree() {
+  log "Fetching origin..."
+  git -C "$REPO_PATH" fetch origin 2>&1 >&2 || die "git_fetch" "git fetch origin failed"
+
+  # Determine which branch and tracking mode to use
+  local use_branch="$BRANCH"
+  local track_flag="--no-track"
+  local base_ref="origin/main"
+
+  if [[ -n "$PR_BRANCH" ]]; then
+    # PR branch: track the remote PR branch
+    use_branch="$PR_BRANCH"
+    track_flag="--track"
+    base_ref="origin/$PR_BRANCH"
+    log "Using PR branch: $PR_BRANCH"
+  else
+    # Check if branch already exists on remote
+    local remote_check
+    remote_check=$(git -C "$REPO_PATH" ls-remote --heads origin "$BRANCH" 2>/dev/null || true)
+    if [[ -n "$remote_check" ]]; then
+      track_flag="--track"
+      base_ref="origin/$BRANCH"
+      log "Branch $BRANCH exists on remote, will track"
+    else
+      log "Creating new branch $BRANCH from origin/main"
+    fi
+  fi
+
+  log "Creating worktree at $WORKTREE_PATH..."
+  if ! git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+       -b "$use_branch" \
+       $track_flag \
+       "$base_ref" 2>&1 >&2; then
+    # Branch might already exist locally — try deleting and retrying
+    log "Worktree add failed, attempting branch cleanup..."
+    git -C "$REPO_PATH" branch -D "$use_branch" 2>/dev/null || true
+    git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+      -b "$use_branch" \
+      $track_flag \
+      "$base_ref" 2>&1 >&2 \
+      || die "git_worktree_add" "Failed to create worktree at $WORKTREE_PATH"
+  fi
+
+  log "Worktree created successfully"
+}
+
+# ─── Crow Session ────────────────────────────────────────────────────────────
+
+create_session() {
+  # Step 1: Create session (or use existing)
+  if [[ -z "$SESSION_ID" ]]; then
+    log "Creating session: $SESSION_NAME"
+    local result
+    result=$(crow new-session --name "$SESSION_NAME") \
+      || die "new_session" "crow new-session failed: $result"
+    SESSION_ID=$(echo "$result" | grep -o '"session_id":"[^"]*"' | cut -d'"' -f4)
+    if [[ -z "$SESSION_ID" ]]; then
+      die "new_session" "Could not parse session_id from: $result"
+    fi
+    log "Session created: $SESSION_ID"
+  else
+    log "Using existing session: $SESSION_ID"
+  fi
+
+  # Step 2: Set ticket metadata (if URL provided and this is a new session)
+  if [[ -n "$TICKET_URL" && -n "$TICKET_NUMBER" ]]; then
+    log "Setting ticket metadata..."
+    local ticket_cmd="crow set-ticket --session $SESSION_ID --url \"$TICKET_URL\""
+    [[ -n "$TICKET_TITLE" ]] && ticket_cmd+=" --title \"$TICKET_TITLE\""
+    ticket_cmd+=" --number $TICKET_NUMBER"
+    eval "$ticket_cmd" >/dev/null 2>&1 \
+      || log "Warning: set-ticket failed (may already be set)"
+  fi
+
+  # Step 3: Register worktree
+  log "Registering worktree..."
+  local wt_cmd="crow add-worktree --session $SESSION_ID"
+  wt_cmd+=" --repo \"$REPO\""
+  wt_cmd+=" --repo-path \"$REPO_PATH\""
+  wt_cmd+=" --path \"$WORKTREE_PATH\""
+  wt_cmd+=" --branch \"$BRANCH\""
+  [[ "$PRIMARY" == "true" ]] && wt_cmd+=" --primary"
+  eval "$wt_cmd" >/dev/null 2>&1 \
+    || die "add_worktree" "crow add-worktree failed"
+
+  # Step 4: Add ticket link (if URL provided)
+  if [[ -n "$TICKET_URL" ]]; then
+    log "Adding ticket link..."
+    crow add-link --session "$SESSION_ID" \
+      --label "Issue" \
+      --url "$TICKET_URL" \
+      --type ticket >/dev/null 2>&1 \
+      || log "Warning: add-link (ticket) failed"
+  fi
+
+  # Step 4a: Add PR link (if PR detected)
+  if [[ -n "$PR_URL" && -n "$PR_NUMBER" ]]; then
+    log "Adding PR link..."
+    crow add-link --session "$SESSION_ID" \
+      --label "PR #$PR_NUMBER" \
+      --url "$PR_URL" \
+      --type pr >/dev/null 2>&1 \
+      || log "Warning: add-link (PR) failed"
+  fi
+}
+
+# ─── GitHub Housekeeping (best-effort) ───────────────────────────────────────
+
+github_ops() {
+  if [[ "$PROVIDER" != "github" ]]; then
+    return
+  fi
+
+  # Auto-assign
+  if [[ "$SKIP_ASSIGN" != "true" && -n "$TICKET_URL" ]]; then
+    log "Auto-assigning issue..."
+    gh issue edit "$TICKET_URL" --add-assignee @me 2>/dev/null || log "Warning: auto-assign failed"
+  fi
+
+  # Project status mutation
+  if [[ "$SKIP_PROJECT_STATUS" != "true" && -n "$TICKET_URL" && -n "$TICKET_NUMBER" ]]; then
+    log "Setting project status to In progress..."
+    set_project_status || log "Warning: project status update failed"
+  fi
+}
+
+set_project_status() {
+  # Extract owner/repo from ticket URL
+  local owner_repo
+  owner_repo=$(echo "$TICKET_URL" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/.*|\1|p')
+  if [[ -z "$owner_repo" ]]; then
+    return 1
+  fi
+
+  # Step 1: Get project item ID and project ID
+  local item_query
+  item_query=$(cat <<GRAPHQL
+query {
+  repository(owner: "${owner_repo%%/*}", name: "${owner_repo##*/}") {
+    issue(number: $TICKET_NUMBER) {
+      projectItems(first: 1) {
+        nodes {
+          id
+          project { id }
+        }
+      }
+    }
+  }
+}
+GRAPHQL
+  )
+
+  local item_result
+  item_result=$(gh api graphql -f query="$item_query" 2>/dev/null) || return 1
+  local item_id project_id
+  item_id=$(echo "$item_result" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+  project_id=$(echo "$item_result" | grep -o '"id":"[^"]*"' | tail -1 | cut -d'"' -f4)
+
+  if [[ -z "$item_id" || -z "$project_id" || "$item_id" == "$project_id" ]]; then
+    log "Issue not on any project, skipping status update"
+    return 0
+  fi
+
+  # Step 2: Get Status field ID and "In progress" option ID
+  local field_query
+  field_query=$(cat <<GRAPHQL
+query {
+  node(id: "$project_id") {
+    ... on ProjectV2 {
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }
+}
+GRAPHQL
+  )
+
+  local field_result
+  field_result=$(gh api graphql -f query="$field_query" 2>/dev/null) || return 1
+
+  local field_id option_id
+  field_id=$(echo "$field_result" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+  # Extract "In progress" option — look for the option name then grab its id
+  # Use a simple approach: find the line with "In progress" (or "In Progress") and extract the preceding id
+  option_id=$(echo "$field_result" | tr ',' '\n' | grep -B1 '"In [Pp]rogress"' | grep -o '"id":"[^"]*"' | cut -d'"' -f4 | head -1)
+
+  if [[ -z "$field_id" || -z "$option_id" ]]; then
+    log "Could not find Status field or In progress option"
+    return 1
+  fi
+
+  # Step 3: Set the value
+  local mutation
+  mutation=$(cat <<GRAPHQL
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "$project_id"
+    itemId: "$item_id"
+    fieldId: "$field_id"
+    value: { singleSelectOptionId: "$option_id" }
+  }) {
+    projectV2Item { id }
+  }
+}
+GRAPHQL
+  )
+
+  gh api graphql -f query="$mutation" >/dev/null 2>&1 || return 1
+  log "Project status set to In progress"
+}
+
+# ─── Prompt File ─────────────────────────────────────────────────────────────
+
+write_prompt() {
+  if [[ -z "$PROMPT_CONTENT" ]]; then
+    log "No prompt content path provided, skipping prompt write"
+    return
+  fi
+
+  if [[ ! -f "$PROMPT_CONTENT" ]]; then
+    die "write_prompt" "Prompt content file not found: $PROMPT_CONTENT"
+  fi
+
+  local prompts_dir="$DEV_ROOT/.claude/prompts"
+  mkdir -p "$prompts_dir"
+
+  local prompt_dest="$prompts_dir/crow-prompt-$SESSION_NAME.md"
+
+  # If prompt content path differs from destination, copy it
+  if [[ "$PROMPT_CONTENT" != "$prompt_dest" ]]; then
+    cp "$PROMPT_CONTENT" "$prompt_dest"
+    log "Prompt copied to $prompt_dest"
+  else
+    log "Prompt already at $prompt_dest"
+  fi
+}
+
+# ─── Launch Claude Code ─────────────────────────────────────────────────────
+
+launch_claude() {
+  if [[ "$SKIP_LAUNCH" == "true" ]]; then
+    log "Skipping Claude Code launch (--skip-launch)"
+    return
+  fi
+
+  # Resolve claude binary
+  local claude_bin="$CLAUDE_BINARY"
+  if [[ -z "$claude_bin" ]]; then
+    claude_bin=$(which claude 2>/dev/null || true)
+    if [[ -z "$claude_bin" ]]; then
+      die "launch_claude" "claude binary not found — provide --claude-binary"
+    fi
+  fi
+
+  # Create terminal
+  log "Creating terminal..."
+  local term_result
+  term_result=$(crow new-terminal --session "$SESSION_ID" \
+    --cwd "$WORKTREE_PATH" \
+    --name "Claude Code" \
+    --managed) \
+    || die "new_terminal" "crow new-terminal failed: $term_result"
+
+  TERMINAL_ID=$(echo "$term_result" | grep -o '"terminal_id":"[^"]*"' | cut -d'"' -f4)
+  if [[ -z "$TERMINAL_ID" ]]; then
+    die "new_terminal" "Could not parse terminal_id from: $term_result"
+  fi
+  log "Terminal created: $TERMINAL_ID"
+
+  # Select session
+  crow select-session --session "$SESSION_ID" >/dev/null 2>&1 \
+    || log "Warning: select-session failed"
+
+  # Build the prompt file path
+  local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
+
+  # Send launch command
+  log "Launching Claude Code..."
+  local send_text="cd $WORKTREE_PATH && $claude_bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
+  crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1 \
+    || die "send_launch" "crow send failed"
+
+  log "Claude Code launched"
+}
+
+# ─── Result ──────────────────────────────────────────────────────────────────
+
+emit_result() {
+  local terminal_field=""
+  if [[ -n "$TERMINAL_ID" ]]; then
+    terminal_field=", \"terminal_id\": \"$TERMINAL_ID\""
+  fi
+
+  printf '{"status":"ok","session_id":"%s"%s,"worktree_path":"%s","branch":"%s"}\n' \
+    "$SESSION_ID" \
+    "$terminal_field" \
+    "$WORKTREE_PATH" \
+    "$BRANCH"
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  parse_args "$@"
+
+  setup_worktree
+  create_session
+  github_ops
+  write_prompt
+  launch_claude
+  emit_result
+}
+
+main "$@"

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -8,7 +8,10 @@
 #
 # All output goes to stderr except the final JSON result on stdout.
 
-set -euo pipefail
+set -uo pipefail
+# NOTE: We intentionally do NOT use `set -e`. Each fallible command is
+# handled explicitly with `if ! ...` or `|| die/log` so that we always
+# emit structured JSON on failure instead of silently exiting.
 
 # ─── Defaults ────────────────────────────────────────────────────────────────
 
@@ -145,11 +148,24 @@ parse_args() {
   fi
 }
 
+# ─── Preflight ───────────────────────────────────────────────────────────────
+
+preflight() {
+  if ! command -v crow >/dev/null 2>&1; then
+    die "preflight" "crow binary not found in PATH"
+  fi
+  if ! command -v git >/dev/null 2>&1; then
+    die "preflight" "git binary not found in PATH"
+  fi
+}
+
 # ─── Git Worktree ────────────────────────────────────────────────────────────
 
 setup_worktree() {
   log "Fetching origin..."
-  git -C "$REPO_PATH" fetch origin 2>&1 >&2 || die "git_fetch" "git fetch origin failed"
+  if ! git -C "$REPO_PATH" fetch origin >&2 2>&1; then
+    die "git_fetch" "git fetch origin failed"
+  fi
 
   # Determine which branch and tracking mode to use
   local use_branch="$BRANCH"
@@ -165,7 +181,7 @@ setup_worktree() {
   else
     # Check if branch already exists on remote
     local remote_check
-    remote_check=$(git -C "$REPO_PATH" ls-remote --heads origin "$BRANCH" 2>/dev/null || true)
+    remote_check=$(git -C "$REPO_PATH" ls-remote --heads origin "$BRANCH" 2>/dev/null) || true
     if [[ -n "$remote_check" ]]; then
       track_flag="--track"
       base_ref="origin/$BRANCH"
@@ -176,18 +192,28 @@ setup_worktree() {
   fi
 
   log "Creating worktree at $WORKTREE_PATH..."
-  if ! git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+  local wt_err
+  if ! wt_err=$(git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
        -b "$use_branch" \
        $track_flag \
-       "$base_ref" 2>&1 >&2; then
-    # Branch might already exist locally — try deleting and retrying
-    log "Worktree add failed, attempting branch cleanup..."
+       "$base_ref" 2>&1); then
+    # Branch or worktree might already exist — clean up and retry
+    log "Worktree add failed, attempting cleanup..."
+    log "  Error was: $wt_err"
+    # Remove any existing worktree at this path first
+    git -C "$REPO_PATH" worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
+    # Prune stale worktree references
+    git -C "$REPO_PATH" worktree prune 2>/dev/null || true
+    # Now delete the branch (safe after worktree removal)
     git -C "$REPO_PATH" branch -D "$use_branch" 2>/dev/null || true
-    git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
-      -b "$use_branch" \
-      $track_flag \
-      "$base_ref" 2>&1 >&2 \
-      || die "git_worktree_add" "Failed to create worktree at $WORKTREE_PATH"
+
+    log "Retrying worktree creation..."
+    if ! wt_err=$(git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+         -b "$use_branch" \
+         $track_flag \
+         "$base_ref" 2>&1); then
+      die "git_worktree_add" "Failed to create worktree at $WORKTREE_PATH: $wt_err"
+    fi
   fi
 
   log "Worktree created successfully"
@@ -200,8 +226,9 @@ create_session() {
   if [[ -z "$SESSION_ID" ]]; then
     log "Creating session: $SESSION_NAME"
     local result
-    result=$(crow new-session --name "$SESSION_NAME") \
-      || die "new_session" "crow new-session failed: $result"
+    if ! result=$(crow new-session --name "$SESSION_NAME" 2>&1); then
+      die "new_session" "crow new-session failed: $result"
+    fi
     SESSION_ID=$(echo "$result" | grep -o '"session_id":"[^"]*"' | cut -d'"' -f4)
     if [[ -z "$SESSION_ID" ]]; then
       die "new_session" "Could not parse session_id from: $result"
@@ -211,26 +238,28 @@ create_session() {
     log "Using existing session: $SESSION_ID"
   fi
 
-  # Step 2: Set ticket metadata (if URL provided and this is a new session)
+  # Step 2: Set ticket metadata (if URL provided)
   if [[ -n "$TICKET_URL" && -n "$TICKET_NUMBER" ]]; then
     log "Setting ticket metadata..."
-    local ticket_cmd="crow set-ticket --session $SESSION_ID --url \"$TICKET_URL\""
-    [[ -n "$TICKET_TITLE" ]] && ticket_cmd+=" --title \"$TICKET_TITLE\""
-    ticket_cmd+=" --number $TICKET_NUMBER"
-    eval "$ticket_cmd" >/dev/null 2>&1 \
+    local ticket_args=(crow set-ticket --session "$SESSION_ID" --url "$TICKET_URL")
+    [[ -n "$TICKET_TITLE" ]] && ticket_args+=(--title "$TICKET_TITLE")
+    ticket_args+=(--number "$TICKET_NUMBER")
+    "${ticket_args[@]}" >/dev/null 2>&1 \
       || log "Warning: set-ticket failed (may already be set)"
   fi
 
   # Step 3: Register worktree
   log "Registering worktree..."
-  local wt_cmd="crow add-worktree --session $SESSION_ID"
-  wt_cmd+=" --repo \"$REPO\""
-  wt_cmd+=" --repo-path \"$REPO_PATH\""
-  wt_cmd+=" --path \"$WORKTREE_PATH\""
-  wt_cmd+=" --branch \"$BRANCH\""
-  [[ "$PRIMARY" == "true" ]] && wt_cmd+=" --primary"
-  eval "$wt_cmd" >/dev/null 2>&1 \
-    || die "add_worktree" "crow add-worktree failed"
+  local wt_args=(crow add-worktree --session "$SESSION_ID"
+    --repo "$REPO"
+    --repo-path "$REPO_PATH"
+    --path "$WORKTREE_PATH"
+    --branch "$BRANCH")
+  [[ "$PRIMARY" == "true" ]] && wt_args+=(--primary)
+  local wt_result
+  if ! wt_result=$("${wt_args[@]}" 2>&1); then
+    die "add_worktree" "crow add-worktree failed: $wt_result"
+  fi
 
   # Step 4: Add ticket link (if URL provided)
   if [[ -n "$TICKET_URL" ]]; then
@@ -335,7 +364,6 @@ GRAPHQL
   field_id=$(echo "$field_result" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
   # Extract "In progress" option — look for the option name then grab its id
-  # Use a simple approach: find the line with "In progress" (or "In Progress") and extract the preceding id
   option_id=$(echo "$field_result" | tr ',' '\n' | grep -B1 '"In [Pp]rogress"' | grep -o '"id":"[^"]*"' | cut -d'"' -f4 | head -1)
 
   if [[ -z "$field_id" || -z "$option_id" ]]; then
@@ -400,7 +428,7 @@ launch_claude() {
   # Resolve claude binary
   local claude_bin="$CLAUDE_BINARY"
   if [[ -z "$claude_bin" ]]; then
-    claude_bin=$(which claude 2>/dev/null || true)
+    claude_bin=$(command -v claude 2>/dev/null) || true
     if [[ -z "$claude_bin" ]]; then
       die "launch_claude" "claude binary not found — provide --claude-binary"
     fi
@@ -409,11 +437,12 @@ launch_claude() {
   # Create terminal
   log "Creating terminal..."
   local term_result
-  term_result=$(crow new-terminal --session "$SESSION_ID" \
+  if ! term_result=$(crow new-terminal --session "$SESSION_ID" \
     --cwd "$WORKTREE_PATH" \
     --name "Claude Code" \
-    --managed) \
-    || die "new_terminal" "crow new-terminal failed: $term_result"
+    --managed 2>&1); then
+    die "new_terminal" "crow new-terminal failed: $term_result"
+  fi
 
   TERMINAL_ID=$(echo "$term_result" | grep -o '"terminal_id":"[^"]*"' | cut -d'"' -f4)
   if [[ -z "$TERMINAL_ID" ]]; then
@@ -431,8 +460,9 @@ launch_claude() {
   # Send launch command
   log "Launching Claude Code..."
   local send_text="cd $WORKTREE_PATH && $claude_bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
-  crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1 \
-    || die "send_launch" "crow send failed"
+  if ! crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1; then
+    die "send_launch" "crow send failed"
+  fi
 
   log "Claude Code launched"
 }
@@ -456,6 +486,7 @@ emit_result() {
 
 main() {
   parse_args "$@"
+  preflight
 
   setup_worktree
   create_session

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -109,7 +109,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Create session service and hydrate state
         let service = SessionService(store: store, appState: appState)
         service.hydrateState()
-        service.wireTerminalReadiness()
         self.sessionService = service
         NSLog("[Crow] Session state hydrated (%d sessions)", appState.sessions.count)
 

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -60,6 +60,12 @@ struct Scaffolder {
         let skillTemplate = Self.bundledSkill()
         try skillTemplate.write(toFile: skillPath, atomically: true, encoding: .utf8)
 
+        // Always overwrite setup.sh with the latest version and make executable
+        let setupScriptPath = (skillsDir as NSString).appendingPathComponent("setup.sh")
+        let setupScript = Self.bundledSetupScript()
+        try setupScript.write(toFile: setupScriptPath, atomically: true, encoding: .utf8)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: setupScriptPath)
+
         // Always overwrite the review-pr skill with the latest version
         let reviewSkillPath = (reviewSkillsDir as NSString).appendingPathComponent("SKILL.md")
         let reviewSkillTemplate = Self.bundledReviewSkill()
@@ -121,6 +127,22 @@ struct Scaffolder {
         """
     }
 
+    /// The crow-workspace setup.sh script bundled with the app.
+    static func bundledSetupScript() -> String {
+        if let content = loadFromRepo("skills/crow-workspace/setup.sh") {
+            return content
+        }
+        if let url = Bundle.main.url(forResource: "crow-workspace-setup.sh", withExtension: "template"),
+           let content = try? String(contentsOf: url) {
+            return content
+        }
+        return """
+        #!/bin/bash
+        echo '{"status":"error","message":"setup.sh not bundled"}'
+        exit 1
+        """
+    }
+
     /// The crow-review-pr SKILL.md template bundled with the app.
     static func bundledReviewSkill() -> String {
         if let content = loadFromRepo("skills/crow-review-pr/SKILL.md") {
@@ -152,6 +174,8 @@ struct Scaffolder {
           "permissions": {
             "allow": [
               "Bash(crow *)",
+              "Bash(bash .claude/skills/crow-workspace/setup.sh *)",
+              "Bash(.claude/skills/crow-workspace/setup.sh *)",
               "Bash(gh issue view:*)",
               "Bash(gh issue create:*)",
               "Bash(gh issue edit:*)",

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -190,6 +190,7 @@ struct Scaffolder {
               "Bash(GITLAB_HOST=* glab mr view:*)",
               "Bash(GITLAB_HOST=* glab mr list:*)",
               "Bash(git -C:*)",
+              "Write(.claude/prompts/**)",
               "Bash(git fetch:*)",
               "Bash(git worktree:*)",
               "Bash(git ls-remote:*)",

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -72,23 +72,37 @@ final class SessionService {
                     appState.autoLaunchTerminals.insert(terminal.id)
                 }
             }
-
-            // Pre-initialize all terminal surfaces in the offscreen window so
-            // Ghostty can create surfaces and spawn shells without the user
-            // navigating to each tab.
-            for terminal in terminals {
-                TerminalManager.shared.preInitialize(
-                    id: terminal.id,
-                    workingDirectory: terminal.cwd,
-                    command: terminal.command
-                )
-            }
         }
 
         // Hydrate global terminals (not tied to any session)
         let globalTerminals = data.terminals.filter { $0.sessionID == AppState.globalTerminalSessionID }
         if !globalTerminals.isEmpty {
             appState.terminals[AppState.globalTerminalSessionID] = globalTerminals
+        }
+
+        // Wire readiness callback BEFORE pre-initializing surfaces.
+        // preInitialize() triggers viewDidMoveToWindow → createSurface() → surfaceDidCreate()
+        // which fires onStateChanged synchronously. The callback must be wired first
+        // so the .created and .shellReady events are not lost.
+        wireTerminalReadiness()
+
+        // Pre-initialize all terminal surfaces in the offscreen window so
+        // Ghostty can create surfaces and spawn shells without the user
+        // navigating to each tab.
+        for session in appState.sessions {
+            if let terminals = appState.terminals[session.id] {
+                for terminal in terminals {
+                    TerminalManager.shared.preInitialize(
+                        id: terminal.id,
+                        workingDirectory: terminal.cwd,
+                        command: terminal.command
+                    )
+                }
+            }
+        }
+
+        // Pre-initialize global terminals
+        if let globalTerminals = appState.terminals[AppState.globalTerminalSessionID] {
             for terminal in globalTerminals {
                 TerminalManager.shared.preInitialize(
                     id: terminal.id,

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -122,13 +122,20 @@ final class SessionService {
         TerminalManager.shared.onStateChanged = { [weak self] terminalID, state in
             guard let self else { return }
             // Only update state for terminals we're tracking (work sessions, not Manager)
-            guard self.appState.terminalReadiness[terminalID] != nil else { return }
-            NSLog("[SessionService] onStateChanged: terminal=\(terminalID), state=\(state)")
+            guard let currentState = self.appState.terminalReadiness[terminalID] else { return }
+            NSLog("[SessionService] onStateChanged: terminal=\(terminalID), state=\(state), current=\(currentState)")
             switch state {
             case .created:
-                self.appState.terminalReadiness[terminalID] = .surfaceCreated
+                // Only advance forward — don't overwrite a later state
+                if currentState < .surfaceCreated {
+                    self.appState.terminalReadiness[terminalID] = .surfaceCreated
+                }
             case .shellReady:
-                self.appState.terminalReadiness[terminalID] = .shellReady
+                // Only advance forward — the `send` handler may have already
+                // set .claudeLaunched before this timer fires.
+                if currentState < .shellReady {
+                    self.appState.terminalReadiness[terminalID] = .shellReady
+                }
                 // Auto-launch Claude now that the shell is ready.
                 // Previously this was triggered by the SwiftUI view's onChange,
                 // but with offscreen pre-init the view may not be rendered yet.

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -55,6 +55,12 @@ if [ -d "$FRAMEWORKS_DIR/ghostty-resources" ]; then
     echo "    Bundled Ghostty resources"
 fi
 
+# Copy template resources for Scaffolder (CLAUDE.md, SKILL.md, setup.sh, settings)
+for f in "$ROOT_DIR"/Resources/*.template; do
+    [ -f "$f" ] && cp "$f" "$APP_DIR/Contents/Resources/"
+done
+echo "    Bundled template resources"
+
 # TODO: Add CFBundleIconFile and bundle AppIcon.icns once icon asset pipeline is created
 
 # Create Info.plist

--- a/settings.json
+++ b/settings.json
@@ -2,6 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(crow *)",
+      "Bash(bash .claude/skills/crow-workspace/setup.sh *)",
+      "Bash(.claude/skills/crow-workspace/setup.sh *)",
       "Bash(crow new-session:*)",
       "Bash(crow rename-session:*)",
       "Bash(crow select-session:*)",

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -168,30 +168,16 @@ WRONG: {devRoot}/{workspace}/worktrees/{repo}-{feature}
 ```
 Branch: `feature/{feature-slug}`
 
-### Git Commands (Provider-Agnostic)
+### Git Commands
 
-```bash
-git -C {repo_path} fetch origin
-git -C {repo_path} ls-remote --heads origin feature/{name}
+Git worktree creation is handled by `setup.sh`. The script automatically selects the correct flags:
+- **PR branch**: `--track origin/{pr_branch}`
+- **Existing remote branch**: `--track origin/{branch}`
+- **New branch**: `--no-track origin/main`
 
-# Existing remote branch (no PR):
-git -C {repo_path} worktree add {path} \
-  -b feature/{name} \
-  --track origin/feature/{name}
+Always uses `-b` to create a local branch (avoids detached HEAD). If the branch already exists locally, the script deletes it and retries.
 
-# New branch (no PR, no remote branch):
-git -C {repo_path} worktree add {path} \
-  -b feature/{name} \
-  --no-track \
-  origin/main
-
-# PR branch (existing PR detected):
-git -C {repo_path} worktree add {path} \
-  -b {pr_branch} \
-  --track origin/{pr_branch}
-```
-
-**Important:** Always use `-b` to create a local branch. Without it, the worktree ends up in detached HEAD state. Use `--no-track` for new branches to prevent accidental push to main.
+**Important:** Always use `--no-track` for new branches to prevent accidental push to main.
 
 ## crow Session Creation
 
@@ -209,95 +195,102 @@ This keeps session names, worktree paths, and branch names consistent.
 
 ### Complete Step-by-Step Flow
 
-> **IMPORTANT: Execute steps 1-9 SEQUENTIALLY — one at a time, never in parallel.**
-> Parallel calls cascade on failure (a failed `add-worktree` cancels sibling `add-link` calls).
+After the LLM resolves names (slug, branch, worktree path, session name), detects any existing PR, and composes the prompt content, the setup is executed by calling `setup.sh`.
+
+> **IMPORTANT:** All `crow`, `gh`, `glab`, and `git` commands require `dangerouslyDisableSandbox: true`. The `setup.sh` call itself must use `dangerouslyDisableSandbox: true` since it runs these commands internally.
+
+#### Step 1: Write the prompt file
+
+The LLM writes the prompt content (see template below) to a file:
 
 ```bash
-# 1. Create session (parse session_id from JSON output)
-#    The name MUST match the worktree directory name
-crow new-session --name "{repo}-{ticket_number}-{slug}"
-# Output: {"session_id":"<uuid>","name":"crow-51-drag-drop-photo"}
-# >>> Wait for completion — parse session_id before proceeding <<<
-
-# 2. Set ticket metadata (only if URL was provided)
-crow set-ticket --session {session_id} \
-  --url "{ticket_url}" \
-  --title "{ticket_title}" \
-  --number {ticket_number}
-# >>> Wait for completion <<<
-
-# 3. Register each worktree (after creating with git)
-#    IMPORTANT: --repo-path is the MAIN repo path (e.g., .../citadel)
-#    --path is the WORKTREE path (e.g., .../citadel-197-slug)
-crow add-worktree --session {session_id} \
-  --repo "{repo_name}" \
-  --repo-path "{main_repo_path}" \
-  --path "{worktree_path}" \
-  --branch "feature/{name}" \
-  --primary   # for the first/main repo
-# >>> Wait for completion <<<
-
-# 4. Add ticket link (only if URL was provided)
-crow add-link --session {session_id} \
-  --label "Issue" \
-  --url "{ticket_url}" \
-  --type ticket
-# >>> Wait for completion <<<
-
-# 4a. Add PR link (only if an existing PR was detected)
-crow add-link --session {session_id} \
-  --label "PR #{pr_number}" \
-  --url "{pr_url}" \
-  --type pr
-# >>> Wait for completion <<<
-
-# 4b. Auto-assign and set project status (GitHub issues only, best-effort)
-#     All gh commands require dangerouslyDisableSandbox: true.
-#     Don't fail the workspace setup if these error.
-#
-#     Step A: Assign yourself to the issue
-gh issue edit {ticket_url} --add-assignee @me
-#
-#     Step B: Set the issue's project status to "In progress"
-#     This requires multiple GraphQL calls chained together:
-#     1. Get the projectItem ID and project ID for the issue
-#     2. Get the Status field ID from the project
-#     3. Get the option ID for "In progress" from the Status field options
-#     4. Mutate the field value
-#
-#     Use gh api graphql with --jq to extract values. Chain them:
-#       - query repository.issue.projectItems.nodes[0] for {itemId, project.id}
-#       - query node(id: projectId).field(name: "Status") for fieldId and options
-#       - find the option where name == "In progress" (case-sensitive, match exactly)
-#       - call updateProjectV2ItemFieldValue mutation
-#     If the issue is not on any project, skip silently.
-
-# 5. Write prompt to temp file
-#    IMPORTANT: Write to {devRoot}/.claude/prompts/ — NOT $TMPDIR (which differs per session)
-#    The prompt MUST start with /plan to enter plan mode
 mkdir -p {devRoot}/.claude/prompts
 cat > {devRoot}/.claude/prompts/crow-prompt-{session_name}.md << 'PROMPT'
 {prompt content — see template below}
 PROMPT
+```
 
-# 6. Create a shell terminal in the primary worktree (NO command — just a shell)
-crow new-terminal --session {session_id} \
-  --cwd "{primary_worktree_path}" \
-  --name "Claude Code" \
-  --managed
-# Output: {"terminal_id":"<uuid>","session_id":"..."}
-# IMPORTANT: Capture the terminal_id from the output!
+#### Step 2: Run setup.sh
 
-# 7. Switch to the new session
-crow select-session --session {session_id}
+```bash
+.claude/skills/crow-workspace/setup.sh \
+  --dev-root "{devRoot}" \
+  --workspace "{workspace}" \
+  --repo "{repo}" \
+  --repo-path "{repo_path}" \
+  --slug "{slug}" \
+  --branch "{branch}" \
+  --worktree-path "{worktree_path}" \
+  --session-name "{session_name}" \
+  --provider "{provider}" \
+  --cli "{cli}" \
+  --ticket-url "{ticket_url}" \
+  --ticket-title "{ticket_title}" \
+  --ticket-number {ticket_number} \
+  --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
+  --claude-binary "$(which claude)" \
+  --primary
+```
 
-# 8. Send the claude launch command to the terminal
-#    The shell is already running (pre-initialized in background) — no sleep needed.
-#    CRITICAL: End the text with literal \n — the app converts \n to Enter.
-#    Use single quotes so the shell doesn't expand $(cat ...).
-#    Use --permission-mode plan to start Claude in plan mode.
-#    Use full path to claude binary.
-crow send --session {session_id} --terminal {terminal_id} 'cd {primary_worktree_path} && {claude_binary_path} --permission-mode plan "$(cat {devRoot}/.claude/prompts/crow-prompt-{session_name}.md)"\n'
+If an existing PR was detected, also pass:
+```
+  --pr-number {pr_number} \
+  --pr-url "{pr_url}" \
+  --pr-branch "{pr_branch}"
+```
+
+For GitLab, also pass:
+```
+  --host "{gitlab_host}"
+```
+
+#### Step 3: Parse the result
+
+The script outputs JSON to stdout. On success:
+```json
+{
+  "status": "ok",
+  "session_id": "uuid",
+  "terminal_id": "uuid",
+  "worktree_path": "/path/to/worktree",
+  "branch": "feature/name"
+}
+```
+
+On failure:
+```json
+{
+  "status": "error",
+  "step": "git_worktree_add",
+  "message": "error details",
+  "partial": { "session_id": "uuid-if-created" }
+}
+```
+
+If the script fails, read the error message and apply error handling (see below).
+
+#### Multi-Repo Flow
+
+For cross-workspace setups with multiple repos, call `setup.sh` once per repo:
+
+1. **First repo** (primary): Use `--primary` flag. Capture `session_id` from output.
+2. **Additional repos**: Pass `--session-id {uuid}` from the first call's output and use `--skip-launch` (Claude only launches once, in the primary worktree).
+
+```bash
+# Secondary repo (no launch, attach to existing session):
+.claude/skills/crow-workspace/setup.sh \
+  --session-id "{session_id_from_first_call}" \
+  --dev-root "{devRoot}" \
+  --workspace "{other_workspace}" \
+  --repo "{other_repo}" \
+  --repo-path "{other_repo_path}" \
+  --slug "{slug}" \
+  --branch "main" \
+  --worktree-path "{other_repo_path}" \
+  --session-name "{session_name}" \
+  --provider "{provider}" \
+  --cli "{cli}" \
+  --skip-launch
 ```
 
 ## First Prompt Template
@@ -373,19 +366,23 @@ GITLAB_HOST=gitlab.example.com glab mr view {number} --repo {org/repo} --comment
 
 ## Error Handling and Self-Correction
 
-If a `crow` command fails:
-1. Read the error message from the JSON response
-2. If the error indicates a usage problem (wrong arg format, missing param), append a one-line correction to `{devRoot}/CLAUDE.md` under "## Known Issues / Corrections"
-3. Retry with corrected command
-4. If transient error (socket unavailable), retry up to 3 times with 1s delay
+If `setup.sh` returns a JSON error (`"status": "error"`):
+1. Read the `step` and `message` fields to understand what failed
+2. If the error indicates a usage problem (wrong arg format, missing param), fix the invocation and retry
+3. If `partial.session_id` is present, the session was created before the failure — you can pass `--session-id` to retry without recreating the session
+4. If the error is in `git_worktree_add`, the branch may already exist — try with a different slug
+5. Append a one-line correction to `{devRoot}/CLAUDE.md` under "## Known Issues / Corrections"
 
 | Error | Response |
 |-------|----------|
-| Socket not found | Crow app may not be running. Inform user. |
-| Session not found | Use full UUID from new-session output, not short names |
-| Unknown workspace | Use defaults, warn user |
-| CLI not installed | Report which CLI is needed (gh, glab) |
-| No repos matched | List all repos across all workspaces |
+| `parse_args` — Missing required arguments | Check that all required flags are provided |
+| `git_fetch` — git fetch failed | Check repo path exists and has remote configured |
+| `git_worktree_add` — worktree creation failed | Branch may exist; script auto-retries after cleanup |
+| `new_session` — crow new-session failed | Crow app may not be running. Inform user. |
+| `add_worktree` — crow add-worktree failed | Use full UUID from session, check paths |
+| `new_terminal` — crow new-terminal failed | Session may not exist; check session_id |
+| `send_launch` — crow send failed | Terminal may not be ready; retry |
+| `write_prompt` — prompt file not found | Verify prompt was written before calling setup.sh |
 
 ## crow CLI Reference
 

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -47,6 +47,14 @@ TERMINAL_ID=""
 
 log() { echo "[setup.sh] $*" >&2; }
 
+# Extract a JSON string value by key. Handles both compact and pretty-printed JSON.
+# Usage: json_val "key" <<< "$json_string"
+json_val() {
+  local key="$1"
+  # Normalize whitespace: collapse the JSON to one line, strip spaces around : and quotes
+  tr -d '\n' | sed 's/[[:space:]]*:[[:space:]]*/:/g' | grep -o "\"$key\":\"[^\"]*\"" | cut -d'"' -f4 | head -1
+}
+
 die() {
   local step="$1" msg="$2"
   local partial=""
@@ -229,7 +237,7 @@ create_session() {
     if ! result=$(crow new-session --name "$SESSION_NAME" 2>&1); then
       die "new_session" "crow new-session failed: $result"
     fi
-    SESSION_ID=$(echo "$result" | grep -o '"session_id":"[^"]*"' | cut -d'"' -f4)
+    SESSION_ID=$(json_val "session_id" <<< "$result")
     if [[ -z "$SESSION_ID" ]]; then
       die "new_session" "Could not parse session_id from: $result"
     fi
@@ -444,7 +452,7 @@ launch_claude() {
     die "new_terminal" "crow new-terminal failed: $term_result"
   fi
 
-  TERMINAL_ID=$(echo "$term_result" | grep -o '"terminal_id":"[^"]*"' | cut -d'"' -f4)
+  TERMINAL_ID=$(json_val "terminal_id" <<< "$term_result")
   if [[ -z "$TERMINAL_ID" ]]; then
     die "new_terminal" "Could not parse terminal_id from: $term_result"
   fi

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -462,6 +462,12 @@ launch_claude() {
   crow select-session --session "$SESSION_ID" >/dev/null 2>&1 \
     || log "Warning: select-session failed"
 
+  # Wait for the shell to initialize in the new terminal.
+  # The terminal surface is pre-initialized by crow new-terminal, but the
+  # shell process needs time to start and display its prompt.
+  log "Waiting for shell to initialize..."
+  sleep 3
+
   # Build the prompt file path
   local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
 

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -1,0 +1,468 @@
+#!/bin/bash
+# setup.sh — Deterministic workspace setup for Crow
+#
+# Called by the crow-workspace skill after the LLM resolves names,
+# detects PRs, and composes the prompt content. This script handles
+# all mechanical operations: git worktree creation, crow session
+# setup, GitHub housekeeping, prompt file writing, and Claude Code launch.
+#
+# All output goes to stderr except the final JSON result on stdout.
+
+set -euo pipefail
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+
+DEV_ROOT=""
+WORKSPACE=""
+REPO=""
+REPO_PATH=""
+SLUG=""
+BRANCH=""
+WORKTREE_PATH=""
+SESSION_NAME=""
+PROVIDER=""
+CLI_TOOL=""
+HOST=""
+TICKET_URL=""
+TICKET_TITLE=""
+TICKET_NUMBER=""
+PR_NUMBER=""
+PR_URL=""
+PR_BRANCH=""
+PROMPT_CONTENT=""
+CLAUDE_BINARY=""
+SESSION_ID=""
+PRIMARY=false
+SKIP_LAUNCH=false
+SKIP_ASSIGN=false
+SKIP_PROJECT_STATUS=false
+
+# Runtime state
+TERMINAL_ID=""
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+log() { echo "[setup.sh] $*" >&2; }
+
+die() {
+  local step="$1" msg="$2"
+  local partial=""
+  if [[ -n "$SESSION_ID" ]]; then
+    partial=", \"partial\": {\"session_id\": \"$SESSION_ID\"}"
+  fi
+  printf '{"status":"error","step":"%s","message":"%s"%s}\n' \
+    "$step" \
+    "$(echo "$msg" | sed 's/"/\\"/g' | tr '\n' ' ')" \
+    "$partial"
+  exit 1
+}
+
+# ─── Argument Parsing ────────────────────────────────────────────────────────
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: setup.sh [OPTIONS]
+
+Required:
+  --dev-root <path>          Development root directory
+  --workspace <name>         Workspace name (e.g. RadiusMethod)
+  --repo <name>              Repository name
+  --repo-path <path>         Main repo clone path
+  --slug <slug>              LLM-generated slug (e.g. 104-global-terminals)
+  --branch <branch>          Target branch name
+  --worktree-path <path>     Target worktree path
+  --session-name <name>      Crow session name
+  --provider <github|gitlab> Git provider
+  --cli <gh|glab>            CLI tool
+
+Optional:
+  --host <hostname>          GitLab host (required for gitlab)
+  --ticket-url <url>         Issue/ticket URL
+  --ticket-title <title>     Ticket title
+  --ticket-number <number>   Ticket number
+  --pr-number <number>       Existing PR number
+  --pr-url <url>             Existing PR URL
+  --pr-branch <branch>       Existing PR branch name
+  --prompt-content <path>    Path to LLM-written prompt file
+  --claude-binary <path>     Full path to claude binary
+  --session-id <uuid>        Existing session ID (for secondary repos)
+  --primary                  Mark worktree as primary
+  --skip-launch              Skip Claude Code launch
+  --skip-assign              Skip auto-assign
+  --skip-project-status      Skip project status mutation
+  --help                     Show this help
+EOF
+  exit 0
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dev-root)          DEV_ROOT="$2"; shift 2 ;;
+      --workspace)         WORKSPACE="$2"; shift 2 ;;
+      --repo)              REPO="$2"; shift 2 ;;
+      --repo-path)         REPO_PATH="$2"; shift 2 ;;
+      --slug)              SLUG="$2"; shift 2 ;;
+      --branch)            BRANCH="$2"; shift 2 ;;
+      --worktree-path)     WORKTREE_PATH="$2"; shift 2 ;;
+      --session-name)      SESSION_NAME="$2"; shift 2 ;;
+      --provider)          PROVIDER="$2"; shift 2 ;;
+      --cli)               CLI_TOOL="$2"; shift 2 ;;
+      --host)              HOST="$2"; shift 2 ;;
+      --ticket-url)        TICKET_URL="$2"; shift 2 ;;
+      --ticket-title)      TICKET_TITLE="$2"; shift 2 ;;
+      --ticket-number)     TICKET_NUMBER="$2"; shift 2 ;;
+      --pr-number)         PR_NUMBER="$2"; shift 2 ;;
+      --pr-url)            PR_URL="$2"; shift 2 ;;
+      --pr-branch)         PR_BRANCH="$2"; shift 2 ;;
+      --prompt-content)    PROMPT_CONTENT="$2"; shift 2 ;;
+      --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
+      --session-id)        SESSION_ID="$2"; shift 2 ;;
+      --primary)           PRIMARY=true; shift ;;
+      --skip-launch)       SKIP_LAUNCH=true; shift ;;
+      --skip-assign)       SKIP_ASSIGN=true; shift ;;
+      --skip-project-status) SKIP_PROJECT_STATUS=true; shift ;;
+      --help)              usage ;;
+      *)                   die "parse_args" "Unknown argument: $1" ;;
+    esac
+  done
+
+  # Validate required args
+  local missing=()
+  [[ -z "$DEV_ROOT" ]]      && missing+=("--dev-root")
+  [[ -z "$WORKSPACE" ]]     && missing+=("--workspace")
+  [[ -z "$REPO" ]]          && missing+=("--repo")
+  [[ -z "$REPO_PATH" ]]     && missing+=("--repo-path")
+  [[ -z "$SLUG" ]]          && missing+=("--slug")
+  [[ -z "$BRANCH" ]]        && missing+=("--branch")
+  [[ -z "$WORKTREE_PATH" ]] && missing+=("--worktree-path")
+  [[ -z "$SESSION_NAME" ]]  && missing+=("--session-name")
+  [[ -z "$PROVIDER" ]]      && missing+=("--provider")
+  [[ -z "$CLI_TOOL" ]]      && missing+=("--cli")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "parse_args" "Missing required arguments: ${missing[*]}"
+  fi
+}
+
+# ─── Git Worktree ────────────────────────────────────────────────────────────
+
+setup_worktree() {
+  log "Fetching origin..."
+  git -C "$REPO_PATH" fetch origin 2>&1 >&2 || die "git_fetch" "git fetch origin failed"
+
+  # Determine which branch and tracking mode to use
+  local use_branch="$BRANCH"
+  local track_flag="--no-track"
+  local base_ref="origin/main"
+
+  if [[ -n "$PR_BRANCH" ]]; then
+    # PR branch: track the remote PR branch
+    use_branch="$PR_BRANCH"
+    track_flag="--track"
+    base_ref="origin/$PR_BRANCH"
+    log "Using PR branch: $PR_BRANCH"
+  else
+    # Check if branch already exists on remote
+    local remote_check
+    remote_check=$(git -C "$REPO_PATH" ls-remote --heads origin "$BRANCH" 2>/dev/null || true)
+    if [[ -n "$remote_check" ]]; then
+      track_flag="--track"
+      base_ref="origin/$BRANCH"
+      log "Branch $BRANCH exists on remote, will track"
+    else
+      log "Creating new branch $BRANCH from origin/main"
+    fi
+  fi
+
+  log "Creating worktree at $WORKTREE_PATH..."
+  if ! git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+       -b "$use_branch" \
+       $track_flag \
+       "$base_ref" 2>&1 >&2; then
+    # Branch might already exist locally — try deleting and retrying
+    log "Worktree add failed, attempting branch cleanup..."
+    git -C "$REPO_PATH" branch -D "$use_branch" 2>/dev/null || true
+    git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+      -b "$use_branch" \
+      $track_flag \
+      "$base_ref" 2>&1 >&2 \
+      || die "git_worktree_add" "Failed to create worktree at $WORKTREE_PATH"
+  fi
+
+  log "Worktree created successfully"
+}
+
+# ─── Crow Session ────────────────────────────────────────────────────────────
+
+create_session() {
+  # Step 1: Create session (or use existing)
+  if [[ -z "$SESSION_ID" ]]; then
+    log "Creating session: $SESSION_NAME"
+    local result
+    result=$(crow new-session --name "$SESSION_NAME") \
+      || die "new_session" "crow new-session failed: $result"
+    SESSION_ID=$(echo "$result" | grep -o '"session_id":"[^"]*"' | cut -d'"' -f4)
+    if [[ -z "$SESSION_ID" ]]; then
+      die "new_session" "Could not parse session_id from: $result"
+    fi
+    log "Session created: $SESSION_ID"
+  else
+    log "Using existing session: $SESSION_ID"
+  fi
+
+  # Step 2: Set ticket metadata (if URL provided and this is a new session)
+  if [[ -n "$TICKET_URL" && -n "$TICKET_NUMBER" ]]; then
+    log "Setting ticket metadata..."
+    local ticket_cmd="crow set-ticket --session $SESSION_ID --url \"$TICKET_URL\""
+    [[ -n "$TICKET_TITLE" ]] && ticket_cmd+=" --title \"$TICKET_TITLE\""
+    ticket_cmd+=" --number $TICKET_NUMBER"
+    eval "$ticket_cmd" >/dev/null 2>&1 \
+      || log "Warning: set-ticket failed (may already be set)"
+  fi
+
+  # Step 3: Register worktree
+  log "Registering worktree..."
+  local wt_cmd="crow add-worktree --session $SESSION_ID"
+  wt_cmd+=" --repo \"$REPO\""
+  wt_cmd+=" --repo-path \"$REPO_PATH\""
+  wt_cmd+=" --path \"$WORKTREE_PATH\""
+  wt_cmd+=" --branch \"$BRANCH\""
+  [[ "$PRIMARY" == "true" ]] && wt_cmd+=" --primary"
+  eval "$wt_cmd" >/dev/null 2>&1 \
+    || die "add_worktree" "crow add-worktree failed"
+
+  # Step 4: Add ticket link (if URL provided)
+  if [[ -n "$TICKET_URL" ]]; then
+    log "Adding ticket link..."
+    crow add-link --session "$SESSION_ID" \
+      --label "Issue" \
+      --url "$TICKET_URL" \
+      --type ticket >/dev/null 2>&1 \
+      || log "Warning: add-link (ticket) failed"
+  fi
+
+  # Step 4a: Add PR link (if PR detected)
+  if [[ -n "$PR_URL" && -n "$PR_NUMBER" ]]; then
+    log "Adding PR link..."
+    crow add-link --session "$SESSION_ID" \
+      --label "PR #$PR_NUMBER" \
+      --url "$PR_URL" \
+      --type pr >/dev/null 2>&1 \
+      || log "Warning: add-link (PR) failed"
+  fi
+}
+
+# ─── GitHub Housekeeping (best-effort) ───────────────────────────────────────
+
+github_ops() {
+  if [[ "$PROVIDER" != "github" ]]; then
+    return
+  fi
+
+  # Auto-assign
+  if [[ "$SKIP_ASSIGN" != "true" && -n "$TICKET_URL" ]]; then
+    log "Auto-assigning issue..."
+    gh issue edit "$TICKET_URL" --add-assignee @me 2>/dev/null || log "Warning: auto-assign failed"
+  fi
+
+  # Project status mutation
+  if [[ "$SKIP_PROJECT_STATUS" != "true" && -n "$TICKET_URL" && -n "$TICKET_NUMBER" ]]; then
+    log "Setting project status to In progress..."
+    set_project_status || log "Warning: project status update failed"
+  fi
+}
+
+set_project_status() {
+  # Extract owner/repo from ticket URL
+  local owner_repo
+  owner_repo=$(echo "$TICKET_URL" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/.*|\1|p')
+  if [[ -z "$owner_repo" ]]; then
+    return 1
+  fi
+
+  # Step 1: Get project item ID and project ID
+  local item_query
+  item_query=$(cat <<GRAPHQL
+query {
+  repository(owner: "${owner_repo%%/*}", name: "${owner_repo##*/}") {
+    issue(number: $TICKET_NUMBER) {
+      projectItems(first: 1) {
+        nodes {
+          id
+          project { id }
+        }
+      }
+    }
+  }
+}
+GRAPHQL
+  )
+
+  local item_result
+  item_result=$(gh api graphql -f query="$item_query" 2>/dev/null) || return 1
+  local item_id project_id
+  item_id=$(echo "$item_result" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+  project_id=$(echo "$item_result" | grep -o '"id":"[^"]*"' | tail -1 | cut -d'"' -f4)
+
+  if [[ -z "$item_id" || -z "$project_id" || "$item_id" == "$project_id" ]]; then
+    log "Issue not on any project, skipping status update"
+    return 0
+  fi
+
+  # Step 2: Get Status field ID and "In progress" option ID
+  local field_query
+  field_query=$(cat <<GRAPHQL
+query {
+  node(id: "$project_id") {
+    ... on ProjectV2 {
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }
+}
+GRAPHQL
+  )
+
+  local field_result
+  field_result=$(gh api graphql -f query="$field_query" 2>/dev/null) || return 1
+
+  local field_id option_id
+  field_id=$(echo "$field_result" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+  # Extract "In progress" option — look for the option name then grab its id
+  # Use a simple approach: find the line with "In progress" (or "In Progress") and extract the preceding id
+  option_id=$(echo "$field_result" | tr ',' '\n' | grep -B1 '"In [Pp]rogress"' | grep -o '"id":"[^"]*"' | cut -d'"' -f4 | head -1)
+
+  if [[ -z "$field_id" || -z "$option_id" ]]; then
+    log "Could not find Status field or In progress option"
+    return 1
+  fi
+
+  # Step 3: Set the value
+  local mutation
+  mutation=$(cat <<GRAPHQL
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "$project_id"
+    itemId: "$item_id"
+    fieldId: "$field_id"
+    value: { singleSelectOptionId: "$option_id" }
+  }) {
+    projectV2Item { id }
+  }
+}
+GRAPHQL
+  )
+
+  gh api graphql -f query="$mutation" >/dev/null 2>&1 || return 1
+  log "Project status set to In progress"
+}
+
+# ─── Prompt File ─────────────────────────────────────────────────────────────
+
+write_prompt() {
+  if [[ -z "$PROMPT_CONTENT" ]]; then
+    log "No prompt content path provided, skipping prompt write"
+    return
+  fi
+
+  if [[ ! -f "$PROMPT_CONTENT" ]]; then
+    die "write_prompt" "Prompt content file not found: $PROMPT_CONTENT"
+  fi
+
+  local prompts_dir="$DEV_ROOT/.claude/prompts"
+  mkdir -p "$prompts_dir"
+
+  local prompt_dest="$prompts_dir/crow-prompt-$SESSION_NAME.md"
+
+  # If prompt content path differs from destination, copy it
+  if [[ "$PROMPT_CONTENT" != "$prompt_dest" ]]; then
+    cp "$PROMPT_CONTENT" "$prompt_dest"
+    log "Prompt copied to $prompt_dest"
+  else
+    log "Prompt already at $prompt_dest"
+  fi
+}
+
+# ─── Launch Claude Code ─────────────────────────────────────────────────────
+
+launch_claude() {
+  if [[ "$SKIP_LAUNCH" == "true" ]]; then
+    log "Skipping Claude Code launch (--skip-launch)"
+    return
+  fi
+
+  # Resolve claude binary
+  local claude_bin="$CLAUDE_BINARY"
+  if [[ -z "$claude_bin" ]]; then
+    claude_bin=$(which claude 2>/dev/null || true)
+    if [[ -z "$claude_bin" ]]; then
+      die "launch_claude" "claude binary not found — provide --claude-binary"
+    fi
+  fi
+
+  # Create terminal
+  log "Creating terminal..."
+  local term_result
+  term_result=$(crow new-terminal --session "$SESSION_ID" \
+    --cwd "$WORKTREE_PATH" \
+    --name "Claude Code" \
+    --managed) \
+    || die "new_terminal" "crow new-terminal failed: $term_result"
+
+  TERMINAL_ID=$(echo "$term_result" | grep -o '"terminal_id":"[^"]*"' | cut -d'"' -f4)
+  if [[ -z "$TERMINAL_ID" ]]; then
+    die "new_terminal" "Could not parse terminal_id from: $term_result"
+  fi
+  log "Terminal created: $TERMINAL_ID"
+
+  # Select session
+  crow select-session --session "$SESSION_ID" >/dev/null 2>&1 \
+    || log "Warning: select-session failed"
+
+  # Build the prompt file path
+  local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
+
+  # Send launch command
+  log "Launching Claude Code..."
+  local send_text="cd $WORKTREE_PATH && $claude_bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
+  crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1 \
+    || die "send_launch" "crow send failed"
+
+  log "Claude Code launched"
+}
+
+# ─── Result ──────────────────────────────────────────────────────────────────
+
+emit_result() {
+  local terminal_field=""
+  if [[ -n "$TERMINAL_ID" ]]; then
+    terminal_field=", \"terminal_id\": \"$TERMINAL_ID\""
+  fi
+
+  printf '{"status":"ok","session_id":"%s"%s,"worktree_path":"%s","branch":"%s"}\n' \
+    "$SESSION_ID" \
+    "$terminal_field" \
+    "$WORKTREE_PATH" \
+    "$BRANCH"
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  parse_args "$@"
+
+  setup_worktree
+  create_session
+  github_ops
+  write_prompt
+  launch_claude
+  emit_result
+}
+
+main "$@"

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -8,7 +8,10 @@
 #
 # All output goes to stderr except the final JSON result on stdout.
 
-set -euo pipefail
+set -uo pipefail
+# NOTE: We intentionally do NOT use `set -e`. Each fallible command is
+# handled explicitly with `if ! ...` or `|| die/log` so that we always
+# emit structured JSON on failure instead of silently exiting.
 
 # ─── Defaults ────────────────────────────────────────────────────────────────
 
@@ -145,11 +148,24 @@ parse_args() {
   fi
 }
 
+# ─── Preflight ───────────────────────────────────────────────────────────────
+
+preflight() {
+  if ! command -v crow >/dev/null 2>&1; then
+    die "preflight" "crow binary not found in PATH"
+  fi
+  if ! command -v git >/dev/null 2>&1; then
+    die "preflight" "git binary not found in PATH"
+  fi
+}
+
 # ─── Git Worktree ────────────────────────────────────────────────────────────
 
 setup_worktree() {
   log "Fetching origin..."
-  git -C "$REPO_PATH" fetch origin 2>&1 >&2 || die "git_fetch" "git fetch origin failed"
+  if ! git -C "$REPO_PATH" fetch origin >&2 2>&1; then
+    die "git_fetch" "git fetch origin failed"
+  fi
 
   # Determine which branch and tracking mode to use
   local use_branch="$BRANCH"
@@ -165,7 +181,7 @@ setup_worktree() {
   else
     # Check if branch already exists on remote
     local remote_check
-    remote_check=$(git -C "$REPO_PATH" ls-remote --heads origin "$BRANCH" 2>/dev/null || true)
+    remote_check=$(git -C "$REPO_PATH" ls-remote --heads origin "$BRANCH" 2>/dev/null) || true
     if [[ -n "$remote_check" ]]; then
       track_flag="--track"
       base_ref="origin/$BRANCH"
@@ -176,18 +192,28 @@ setup_worktree() {
   fi
 
   log "Creating worktree at $WORKTREE_PATH..."
-  if ! git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+  local wt_err
+  if ! wt_err=$(git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
        -b "$use_branch" \
        $track_flag \
-       "$base_ref" 2>&1 >&2; then
-    # Branch might already exist locally — try deleting and retrying
-    log "Worktree add failed, attempting branch cleanup..."
+       "$base_ref" 2>&1); then
+    # Branch or worktree might already exist — clean up and retry
+    log "Worktree add failed, attempting cleanup..."
+    log "  Error was: $wt_err"
+    # Remove any existing worktree at this path first
+    git -C "$REPO_PATH" worktree remove "$WORKTREE_PATH" --force 2>/dev/null || true
+    # Prune stale worktree references
+    git -C "$REPO_PATH" worktree prune 2>/dev/null || true
+    # Now delete the branch (safe after worktree removal)
     git -C "$REPO_PATH" branch -D "$use_branch" 2>/dev/null || true
-    git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
-      -b "$use_branch" \
-      $track_flag \
-      "$base_ref" 2>&1 >&2 \
-      || die "git_worktree_add" "Failed to create worktree at $WORKTREE_PATH"
+
+    log "Retrying worktree creation..."
+    if ! wt_err=$(git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" \
+         -b "$use_branch" \
+         $track_flag \
+         "$base_ref" 2>&1); then
+      die "git_worktree_add" "Failed to create worktree at $WORKTREE_PATH: $wt_err"
+    fi
   fi
 
   log "Worktree created successfully"
@@ -200,8 +226,9 @@ create_session() {
   if [[ -z "$SESSION_ID" ]]; then
     log "Creating session: $SESSION_NAME"
     local result
-    result=$(crow new-session --name "$SESSION_NAME") \
-      || die "new_session" "crow new-session failed: $result"
+    if ! result=$(crow new-session --name "$SESSION_NAME" 2>&1); then
+      die "new_session" "crow new-session failed: $result"
+    fi
     SESSION_ID=$(echo "$result" | grep -o '"session_id":"[^"]*"' | cut -d'"' -f4)
     if [[ -z "$SESSION_ID" ]]; then
       die "new_session" "Could not parse session_id from: $result"
@@ -211,26 +238,28 @@ create_session() {
     log "Using existing session: $SESSION_ID"
   fi
 
-  # Step 2: Set ticket metadata (if URL provided and this is a new session)
+  # Step 2: Set ticket metadata (if URL provided)
   if [[ -n "$TICKET_URL" && -n "$TICKET_NUMBER" ]]; then
     log "Setting ticket metadata..."
-    local ticket_cmd="crow set-ticket --session $SESSION_ID --url \"$TICKET_URL\""
-    [[ -n "$TICKET_TITLE" ]] && ticket_cmd+=" --title \"$TICKET_TITLE\""
-    ticket_cmd+=" --number $TICKET_NUMBER"
-    eval "$ticket_cmd" >/dev/null 2>&1 \
+    local ticket_args=(crow set-ticket --session "$SESSION_ID" --url "$TICKET_URL")
+    [[ -n "$TICKET_TITLE" ]] && ticket_args+=(--title "$TICKET_TITLE")
+    ticket_args+=(--number "$TICKET_NUMBER")
+    "${ticket_args[@]}" >/dev/null 2>&1 \
       || log "Warning: set-ticket failed (may already be set)"
   fi
 
   # Step 3: Register worktree
   log "Registering worktree..."
-  local wt_cmd="crow add-worktree --session $SESSION_ID"
-  wt_cmd+=" --repo \"$REPO\""
-  wt_cmd+=" --repo-path \"$REPO_PATH\""
-  wt_cmd+=" --path \"$WORKTREE_PATH\""
-  wt_cmd+=" --branch \"$BRANCH\""
-  [[ "$PRIMARY" == "true" ]] && wt_cmd+=" --primary"
-  eval "$wt_cmd" >/dev/null 2>&1 \
-    || die "add_worktree" "crow add-worktree failed"
+  local wt_args=(crow add-worktree --session "$SESSION_ID"
+    --repo "$REPO"
+    --repo-path "$REPO_PATH"
+    --path "$WORKTREE_PATH"
+    --branch "$BRANCH")
+  [[ "$PRIMARY" == "true" ]] && wt_args+=(--primary)
+  local wt_result
+  if ! wt_result=$("${wt_args[@]}" 2>&1); then
+    die "add_worktree" "crow add-worktree failed: $wt_result"
+  fi
 
   # Step 4: Add ticket link (if URL provided)
   if [[ -n "$TICKET_URL" ]]; then
@@ -335,7 +364,6 @@ GRAPHQL
   field_id=$(echo "$field_result" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
   # Extract "In progress" option — look for the option name then grab its id
-  # Use a simple approach: find the line with "In progress" (or "In Progress") and extract the preceding id
   option_id=$(echo "$field_result" | tr ',' '\n' | grep -B1 '"In [Pp]rogress"' | grep -o '"id":"[^"]*"' | cut -d'"' -f4 | head -1)
 
   if [[ -z "$field_id" || -z "$option_id" ]]; then
@@ -400,7 +428,7 @@ launch_claude() {
   # Resolve claude binary
   local claude_bin="$CLAUDE_BINARY"
   if [[ -z "$claude_bin" ]]; then
-    claude_bin=$(which claude 2>/dev/null || true)
+    claude_bin=$(command -v claude 2>/dev/null) || true
     if [[ -z "$claude_bin" ]]; then
       die "launch_claude" "claude binary not found — provide --claude-binary"
     fi
@@ -409,11 +437,12 @@ launch_claude() {
   # Create terminal
   log "Creating terminal..."
   local term_result
-  term_result=$(crow new-terminal --session "$SESSION_ID" \
+  if ! term_result=$(crow new-terminal --session "$SESSION_ID" \
     --cwd "$WORKTREE_PATH" \
     --name "Claude Code" \
-    --managed) \
-    || die "new_terminal" "crow new-terminal failed: $term_result"
+    --managed 2>&1); then
+    die "new_terminal" "crow new-terminal failed: $term_result"
+  fi
 
   TERMINAL_ID=$(echo "$term_result" | grep -o '"terminal_id":"[^"]*"' | cut -d'"' -f4)
   if [[ -z "$TERMINAL_ID" ]]; then
@@ -431,8 +460,9 @@ launch_claude() {
   # Send launch command
   log "Launching Claude Code..."
   local send_text="cd $WORKTREE_PATH && $claude_bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
-  crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1 \
-    || die "send_launch" "crow send failed"
+  if ! crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1; then
+    die "send_launch" "crow send failed"
+  fi
 
   log "Claude Code launched"
 }
@@ -456,6 +486,7 @@ emit_result() {
 
 main() {
   parse_args "$@"
+  preflight
 
   setup_worktree
   create_session


### PR DESCRIPTION
## Summary

Closes #127

- Add `skills/crow-workspace/setup.sh` — a shell script that handles all deterministic workspace operations (git worktree creation, crow session setup, GitHub project status mutations, auto-assign, prompt file writing, Claude Code launch)
- Refactor `SKILL.md` to replace the 90-line step-by-step flow with a single `setup.sh` invocation, keeping LLM-driven steps (repo matching, slug generation, PR detection, prompt composition)
- Update `Scaffolder.swift` to deploy `setup.sh` alongside `SKILL.md` with executable permissions

## Test plan

- [x] `make build` passes
- [x] `setup.sh --help` prints usage
- [x] `setup.sh` with missing args outputs structured JSON error
- [x] Invoke `/crow-workspace` with a real ticket URL — verify worktree, session, and Claude Code launch work end-to-end
- [x] Verify `setup.sh` is deployed to `{devRoot}/.claude/skills/crow-workspace/` on app launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)