### PR TITLE
Fix ticket number comma formatting

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -91,7 +91,7 @@ struct ReviewRow: View {
                     Text(request.repo)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text("#\(request.prNumber)")
+                    Text("#\(String(request.prNumber))")
                         .font(.callout)
                         .fontWeight(.medium)
                     if request.isDraft {

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -84,7 +84,7 @@ public struct SessionDetailView: View {
                 // Issue link
                 if let url = session.ticketURL {
                     LinkChip(
-                        label: session.ticketNumber.map { "Issue #\($0)" } ?? "Issue",
+                        label: session.ticketNumber.map { "Issue #\(String($0))" } ?? "Issue",
                         url: url,
                         icon: "link"
                     )

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -295,7 +295,7 @@ struct SessionRow: View {
             if hasBadges {
                 HStack(spacing: 6) {
                     if let num = session.ticketNumber {
-                        CapsuleBadge("Issue #\(num)", color: CorveilTheme.gold)
+                        CapsuleBadge("Issue #\(String(num))", color: CorveilTheme.gold)
                     }
                     if let pr = prLink {
                         PRBadge(label: pr.label, status: prStatus)

--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -291,7 +291,7 @@ struct TicketCard: View {
                     .font(.caption)
                     .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textSecondary)
 
-                Text("#\(issue.number)")
+                Text("#\(String(issue.number))")
                     .font(.system(size: 12, weight: .medium))
                     .monospacedDigit()
                     .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textPrimary)
@@ -367,7 +367,7 @@ struct TicketCard: View {
         HStack(spacing: 3) {
             Image(systemName: "arrow.triangle.pull")
                 .font(.caption2)
-            Text("PR #\(number)")
+            Text("PR #\(String(number))")
                 .font(.caption2)
                 .fontWeight(.medium)
         }


### PR DESCRIPTION
## Summary
- Fixes ticket and PR numbers displaying with locale-aware comma separators (e.g., `#1,486` instead of `#1486`)
- Wraps `Int` string interpolations with `String()` across 4 UI files to bypass Swift's locale formatting

Closes #124

## Test plan
- [x] Verify ticket numbers >= 1,000 display without commas in session list
- [x] Verify ticket numbers display correctly in session detail view
- [x] Verify issue numbers display correctly on the ticket board
- [x] Verify PR numbers display correctly on the ticket board and review board

🤖 Generated with [Claude Code](https://claude.com/claude-code)