### PR TITLE
Add contextual help headers to sidebar sections

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/AllowListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AllowListView.swift
@@ -37,7 +37,7 @@ public struct AllowListView: View {
         VStack(spacing: 0) {
             header
             SectionHelpBanner(
-                description: "Pre-approved tool permissions so Claude Code can take actions without prompting each time.",
+                description: "Promote worktree allow-list entries to the global list so you don't have to re-approve them in future worktrees.",
                 storageKey: "helpDismissed_allowList"
             )
             Divider()

--- a/Packages/CrowUI/Sources/CrowUI/AllowListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AllowListView.swift
@@ -36,6 +36,10 @@ public struct AllowListView: View {
     public var body: some View {
         VStack(spacing: 0) {
             header
+            SectionHelpBanner(
+                description: "Pre-approved tool permissions so Claude Code can take actions without prompting each time.",
+                storageKey: "helpDismissed_allowList"
+            )
             Divider()
             toolbar
             Divider()

--- a/Packages/CrowUI/Sources/CrowUI/GlobalTerminalView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/GlobalTerminalView.swift
@@ -17,6 +17,10 @@ public struct GlobalTerminalView: View {
     public var body: some View {
         VStack(spacing: 0) {
             header
+            SectionHelpBanner(
+                description: "Standalone terminals that live outside of any session. Useful for long-lived processes, monitoring, or ad-hoc shell access.",
+                storageKey: "helpDismissed_terminals"
+            )
             Divider().overlay(CorveilTheme.borderSubtle)
             terminalArea
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -14,6 +14,10 @@ public struct ReviewBoardView: View {
     public var body: some View {
         VStack(spacing: 0) {
             reviewBoardHeader
+            SectionHelpBanner(
+                description: "Sessions in review status \u{2014} find PRs and work that needs feedback.",
+                storageKey: "helpDismissed_reviews"
+            )
             Divider()
             reviewList
         }

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -15,7 +15,7 @@ public struct ReviewBoardView: View {
         VStack(spacing: 0) {
             reviewBoardHeader
             SectionHelpBanner(
-                description: "Sessions in review status \u{2014} find PRs and work that needs feedback.",
+                description: "PRs where your review has been requested. Quickly kick off a review session from here.",
                 storageKey: "helpDismissed_reviews"
             )
             Divider()

--- a/Packages/CrowUI/Sources/CrowUI/SectionHelpBanner.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SectionHelpBanner.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// A dismissible help banner that explains a section's purpose.
+/// Dismissal state persists via `@AppStorage` using a per-section key.
+public struct SectionHelpBanner: View {
+    let description: String
+    @AppStorage private var isDismissed: Bool
+
+    public init(description: String, storageKey: String) {
+        self.description = description
+        self._isDismissed = AppStorage(wrappedValue: false, storageKey)
+    }
+
+    public var body: some View {
+        if !isDismissed {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textMuted)
+                    .accessibilityHidden(true)
+
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isDismissed = true
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(CorveilTheme.textMuted)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss help text")
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(CorveilTheme.bgCard)
+        }
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -24,6 +24,12 @@ public struct SessionDetailView: View {
     public var body: some View {
         VStack(spacing: 0) {
             sessionHeader
+            if session.id == AppState.managerSessionID {
+                SectionHelpBanner(
+                    description: "Orchestration hub for Crow workspaces. Use /crow-workspace to set up new sessions with worktrees, ticket tracking, and auto-launched Claude Code.",
+                    storageKey: "helpDismissed_manager"
+                )
+            }
             Divider().overlay(CorveilTheme.borderSubtle)
             terminalArea
                 .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- Adds a reusable `SectionHelpBanner` component — dismissible info banner with `@AppStorage` persistence
- Inserts help banners into Manager, Terminals, Reviews, and Allow List detail views
- Each banner explains the section's purpose with muted styling that doesn't compete with content

## Test plan
- [x] Launch app and verify each of the 4 sections shows a help banner below the header
- [x] Dismiss a banner via the X button — verify smooth animation
- [x] Quit and relaunch — verify dismissed banners stay dismissed
- [x] Verify each section's banner dismisses independently

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)