### PR TITLE
Add parallel batch workspace setup skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,17 @@ Prevents accidental push to main:
 git worktree add /path -b feature/name --no-track origin/main
 ```
 
+## Concurrency Safety
+
+The crow CLI is safe for concurrent use. Multiple `crow` commands can run simultaneously without race conditions:
+
+- **Socket Server**: Each CLI connection is dispatched to GCD's global concurrent queue. Multiple connections are accepted and processed in parallel.
+- **State Mutations**: All RPC handlers use `await MainActor.run { ... }`, serializing all AppState mutations on the main thread. This prevents data races even when multiple CLI commands arrive simultaneously.
+- **Persistence**: JSONStore uses NSLock to serialize disk writes. Concurrent `mutate()` calls are safe.
+- **Git Operations**: Each `setup.sh` creates its own worktree at a unique path, its own session (unique UUID), and its own terminal. There are no shared resources between parallel workspace setups.
+
+Use `/crow-batch-workspace` to set up multiple workspaces in parallel.
+
 ## Known Issues / Corrections
 
 <!-- Auto-maintained by Claude Code during workspace setup -->

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -134,6 +134,9 @@ public final class AppState {
     /// Called when user clicks "Work on" for an assigned issue.
     public var onWorkOnIssue: ((String) -> Void)?  // receives issue URL
 
+    /// Called when user clicks "Start Working" for multiple selected issues (batch mode).
+    public var onBatchWorkOnIssues: (([String]) -> Void)?  // receives array of issue URLs
+
     /// Called when user clicks "Start Review" for a PR review request.
     public var onStartReview: ((String) -> Void)?  // receives PR URL
 

--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -6,6 +6,8 @@ import CrowCore
 /// Full-pane ticket board shown when the Ticket Board tab is selected.
 public struct TicketBoardView: View {
     @Bindable var appState: AppState
+    @State private var isSelectionMode = false
+    @State private var selectedIssueIDs: Set<String> = []
 
     public init(appState: AppState) {
         self.appState = appState
@@ -17,7 +19,15 @@ public struct TicketBoardView: View {
             Divider().overlay(CorveilTheme.borderSubtle)
             PipelineView(appState: appState)
             Divider().overlay(CorveilTheme.borderSubtle)
-            TicketListView(appState: appState)
+            TicketListView(
+                appState: appState,
+                isSelectionMode: isSelectionMode,
+                selectedIssueIDs: $selectedIssueIDs
+            )
+
+            if isSelectionMode && !selectedIssueIDs.isEmpty {
+                batchActionBar
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(CorveilTheme.bgDeep)
@@ -42,6 +52,8 @@ public struct TicketBoardView: View {
                     .font(.caption)
                     .foregroundStyle(CorveilTheme.textSecondary)
 
+                selectToggleButton
+
                 SortMenu(sortOrder: $appState.ticketSortOrder)
             }
 
@@ -51,6 +63,84 @@ public struct TicketBoardView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(CorveilTheme.bgSurface)
+    }
+
+    private var selectToggleButton: some View {
+        Button {
+            isSelectionMode.toggle()
+            if !isSelectionMode {
+                selectedIssueIDs.removeAll()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: isSelectionMode ? "xmark" : "checkmark.circle")
+                    .font(.system(size: 10))
+                Text(isSelectionMode ? "Cancel" : "Select")
+                    .font(.caption)
+            }
+            .foregroundStyle(isSelectionMode ? .red : CorveilTheme.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isSelectionMode ? Color.red.opacity(0.1) : CorveilTheme.bgCard)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(isSelectionMode ? Color.red.opacity(0.3) : CorveilTheme.borderSubtle, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var batchActionBar: some View {
+        HStack(spacing: 12) {
+            Text("\(selectedIssueIDs.count) ticket\(selectedIssueIDs.count == 1 ? "" : "s") selected")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(CorveilTheme.textSecondary)
+
+            Spacer()
+
+            Button {
+                isSelectionMode = false
+                selectedIssueIDs.removeAll()
+            } label: {
+                Text("Cancel")
+                    .font(.system(size: 13))
+                    .foregroundStyle(CorveilTheme.textSecondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                let urls = appState.assignedIssues
+                    .filter { selectedIssueIDs.contains($0.id) }
+                    .map(\.url)
+                appState.onBatchWorkOnIssues?(urls)
+                selectedIssueIDs.removeAll()
+                isSelectionMode = false
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "play.fill")
+                        .font(.system(size: 10))
+                    Text("Start Working (\(selectedIssueIDs.count))")
+                        .font(.system(size: 13, weight: .semibold))
+                }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 6)
+                .background(CorveilTheme.gold)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(CorveilTheme.bgSurface)
+        .overlay(alignment: .top) {
+            Divider().overlay(CorveilTheme.borderSubtle)
+        }
     }
 }
 
@@ -214,6 +304,8 @@ struct PipelineSegment: View {
 /// Scrollable list of ticket cards, filtered by the selected pipeline stage.
 struct TicketListView: View {
     @Bindable var appState: AppState
+    var isSelectionMode: Bool
+    @Binding var selectedIssueIDs: Set<String>
 
     var body: some View {
         let issues = appState.filteredSortedIssues
@@ -226,7 +318,16 @@ struct TicketListView: View {
                         TicketCard(
                             issue: issue,
                             appState: appState,
-                            isDone: issue.projectStatus == .done
+                            isDone: issue.projectStatus == .done,
+                            isSelectionMode: isSelectionMode,
+                            isSelected: selectedIssueIDs.contains(issue.id),
+                            onToggleSelection: {
+                                if selectedIssueIDs.contains(issue.id) {
+                                    selectedIssueIDs.remove(issue.id)
+                                } else {
+                                    selectedIssueIDs.insert(issue.id)
+                                }
+                            }
                         )
                     }
                 }
@@ -278,60 +379,73 @@ struct TicketCard: View {
     let issue: AssignedIssue
     @Bindable var appState: AppState
     let isDone: Bool
+    var isSelectionMode: Bool = false
+    var isSelected: Bool = false
+    var onToggleSelection: (() -> Void)?
 
     private var linkedSession: Session? {
         appState.activeSession(for: issue)
     }
 
+    private var isSelectable: Bool {
+        linkedSession == nil && !isDone
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            // Row 1: Repo + issue number + PR badge + timestamp
-            HStack(spacing: 6) {
-                Text(issue.repo)
-                    .font(.caption)
-                    .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textSecondary)
-
-                Text("#\(String(issue.number))")
-                    .font(.system(size: 12, weight: .medium))
-                    .monospacedDigit()
-                    .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textPrimary)
-
-                if let prNum = issue.prNumber {
-                    ticketPRBadge(number: prNum, url: issue.prURL)
-                }
-
-                Spacer()
-
-                if isDone {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.green.opacity(0.6))
-                }
-
-                if let date = issue.updatedAt {
-                    Text(date, style: .relative)
-                        .font(.caption2)
-                        .foregroundStyle(CorveilTheme.textMuted)
-                }
+        HStack(spacing: 8) {
+            if isSelectionMode {
+                selectionIndicator
             }
 
-            // Row 2: Title
-            Text(issue.title)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textPrimary)
-                .lineLimit(2)
+            VStack(alignment: .leading, spacing: 6) {
+                // Row 1: Repo + issue number + PR badge + timestamp
+                HStack(spacing: 6) {
+                    Text(issue.repo)
+                        .font(.caption)
+                        .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textSecondary)
 
-            // Row 3: Labels + status badge + session link
-            HStack(spacing: 6) {
-                if !issue.labels.isEmpty {
-                    labelRow
+                    Text("#\(String(issue.number))")
+                        .font(.system(size: 12, weight: .medium))
+                        .monospacedDigit()
+                        .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textPrimary)
+
+                    if let prNum = issue.prNumber {
+                        ticketPRBadge(number: prNum, url: issue.prURL)
+                    }
+
+                    Spacer()
+
+                    if isDone {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.green.opacity(0.6))
+                    }
+
+                    if let date = issue.updatedAt {
+                        Text(date, style: .relative)
+                            .font(.caption2)
+                            .foregroundStyle(CorveilTheme.textMuted)
+                    }
                 }
 
-                statusBadge
+                // Row 2: Title
+                Text(issue.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textPrimary)
+                    .lineLimit(2)
 
-                Spacer()
+                // Row 3: Labels + status badge + session link
+                HStack(spacing: 6) {
+                    if !issue.labels.isEmpty {
+                        labelRow
+                    }
 
-                worktreeAction
+                    statusBadge
+
+                    Spacer()
+
+                    worktreeAction
+                }
             }
         }
         .padding(.horizontal, 10)
@@ -345,6 +459,12 @@ struct TicketCard: View {
                 )
         )
         .opacity(isDone ? 0.7 : 1.0)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if isSelectionMode && isSelectable {
+                onToggleSelection?()
+            }
+        }
     }
 
     private var cardBackground: Color {
@@ -355,6 +475,9 @@ struct TicketCard: View {
     }
 
     private var cardBorder: Color {
+        if isSelectionMode && isSelected {
+            return CorveilTheme.gold.opacity(0.6)
+        }
         if linkedSession != nil {
             return Color.green.opacity(0.2)
         }
@@ -362,6 +485,13 @@ struct TicketCard: View {
     }
 
     // MARK: - Subviews
+
+    private var selectionIndicator: some View {
+        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+            .font(.system(size: 18))
+            .foregroundStyle(isSelected ? CorveilTheme.gold : CorveilTheme.textMuted.opacity(0.4))
+            .opacity(isSelectable ? 1.0 : 0.3)
+    }
 
     private func ticketPRBadge(number: Int, url: String?) -> some View {
         HStack(spacing: 3) {
@@ -412,7 +542,9 @@ struct TicketCard: View {
 
     @ViewBuilder
     private var worktreeAction: some View {
-        if let session = linkedSession {
+        if isSelectionMode {
+            EmptyView()
+        } else if let session = linkedSession {
             Button {
                 appState.selectedSessionID = session.id
             } label: {

--- a/Resources/CLAUDE.md.template
+++ b/Resources/CLAUDE.md.template
@@ -44,6 +44,17 @@ crow send --session <uuid> --terminal <uuid> "text to send"
 - The Manager session UUID is always `00000000-0000-0000-0000-000000000000` — do not delete it
 - Use `/crow-workspace` skill for full workspace setup (worktrees + session + Claude Code)
 
+## Concurrency Safety
+
+The crow CLI is safe for concurrent use. Multiple `crow` commands can run simultaneously without race conditions:
+
+- **Socket Server**: Each CLI connection is dispatched to GCD's global concurrent queue. Multiple connections are accepted and processed in parallel.
+- **State Mutations**: All RPC handlers use `await MainActor.run { ... }`, serializing all AppState mutations on the main thread. This prevents data races even when multiple CLI commands arrive simultaneously.
+- **Persistence**: JSONStore uses NSLock to serialize disk writes. Concurrent `mutate()` calls are safe.
+- **Git Operations**: Each `setup.sh` creates its own worktree at a unique path, its own session (unique UUID), and its own terminal. There are no shared resources between parallel workspace setups.
+
+Use `/crow-batch-workspace` to set up multiple workspaces in parallel.
+
 ## Known Issues / Corrections
 
 <!-- Claude Code appends corrections here when crow commands fail -->

--- a/Resources/crow-batch-workspace-SKILL.md.template
+++ b/Resources/crow-batch-workspace-SKILL.md.template
@@ -1,0 +1,218 @@
+# Crow Batch Workspace Setup Skill
+
+## Purpose
+
+Sets up **multiple** crow workspaces in parallel, dramatically reducing total setup time. Delegates to the existing `/crow-workspace` skill's `setup.sh` for each workspace but fires all executions simultaneously.
+
+## Important: Sandbox Bypass
+
+All `crow`, `gh`, `glab`, and `git worktree` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket, need network/TLS access, or write outside the sandbox-allowed directories.
+
+## Activation
+
+This skill activates when:
+- User invokes `/crow-batch-workspace` command
+- User asks to "set up multiple workspaces", "batch workspace setup", or provides multiple ticket URLs at once
+
+## Concurrency Safety
+
+The crow CLI is safe for concurrent use. Multiple `crow` commands can run simultaneously without race conditions:
+
+- **Socket Server**: Each CLI connection is dispatched to GCD's global concurrent queue. Multiple connections are accepted and processed in parallel.
+- **State Mutations**: All RPC handlers use `await MainActor.run { ... }`, serializing all AppState mutations on the main thread.
+- **Persistence**: JSONStore uses NSLock to serialize disk writes. Concurrent `mutate()` calls are safe.
+- **Git Operations**: Each `setup.sh` creates its own worktree at a unique path, its own session (unique UUID), and its own terminal. There are no shared resources between parallel workspace setups.
+
+## Autonomous Execution
+
+This skill runs autonomously without permission prompts because:
+1. All `crow`, `gh`, `glab`, and `git` commands are pre-approved in `{devRoot}/.claude/settings.json`
+2. All commands use `dangerouslyDisableSandbox: true` (sandbox excludes these binaries)
+3. `setup.sh` is pre-approved via `Bash(bash .claude/skills/crow-workspace/setup.sh *)`
+
+No additional permission configuration is needed.
+
+## Configuration
+
+Same as `/crow-workspace`. Configuration is at `{devRoot}/.claude/config.json` (managed by the Crow app).
+
+## Input Format
+
+One or more ticket URLs, separated by newlines:
+
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://github.com/RadiusMethod/citadel/issues/45
+https://github.com/RadiusMethod/crow/issues/99
+```
+
+Or a mix of ticket URLs and natural language:
+
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+"update citadel authentication"
+https://gitlab.example.com/org/repo/-/issues/42
+```
+
+## Execution Flow
+
+### Phase 1: Parse Inputs
+
+Split the user's input into individual workspace specs. Each spec is either:
+- A ticket URL (GitHub or GitLab)
+- A natural language description
+
+Validate each is a recognizable format.
+
+### Phase 2: Resolve Each Workspace (sequential)
+
+For each workspace spec, perform the same resolution as `/crow-workspace`:
+
+1. **Read config**: `cat {devRoot}/.claude/config.json`
+2. **Detect provider** from URL (see Provider Detection table in `/crow-workspace` skill)
+3. **Scan repos**: Find repos in all configured workspaces
+4. **Match repo**: Score repos against ticket content
+5. **Fetch ticket**: `gh issue view {url} --json title,body,labels` (with `dangerouslyDisableSandbox: true`)
+6. **Check for existing PR**: `gh pr list --repo {owner}/{repo} --search "{issue_number}" --state open --json number,title,headRefName,url --limit 5` (with `dangerouslyDisableSandbox: true`)
+7. **Generate names**: slug, branch, worktree path, session name (following `/crow-workspace` naming conventions)
+8. **Compose prompt**: Use the First Prompt Template from `/crow-workspace`
+9. **Write prompt file**: `cat > {devRoot}/.claude/prompts/crow-prompt-{session_name}.md`
+
+This phase is sequential because each resolution involves LLM reasoning (scoring repos, generating slugs). It's fast (~2-3 seconds per workspace).
+
+**Collect all resolved parameters into a list** before proceeding to Phase 3.
+
+### Phase 3: Parallel Execution
+
+**CRITICAL: Launch ALL `setup.sh` calls in a SINGLE message using multiple Bash tool calls.**
+
+Claude Code supports making multiple independent Bash calls simultaneously in a single response. Since each workspace creates its own independent session, there are no dependencies between them.
+
+Record the start time:
+```bash
+date +%s
+```
+
+Then, in a **single message**, fire one Bash tool call per workspace:
+
+```bash
+.claude/skills/crow-workspace/setup.sh \
+  --dev-root "{devRoot}" \
+  --workspace "{workspace}" \
+  --repo "{repo}" \
+  --repo-path "{repo_path}" \
+  --slug "{slug}" \
+  --branch "{branch}" \
+  --worktree-path "{worktree_path}" \
+  --session-name "{session_name}" \
+  --provider "{provider}" \
+  --cli "{cli}" \
+  --ticket-url "{ticket_url}" \
+  --ticket-title "{ticket_title}" \
+  --ticket-number {ticket_number} \
+  --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
+  --claude-binary "$(which claude)" \
+  --primary
+```
+
+Each call must use `dangerouslyDisableSandbox: true`.
+
+If a workspace has an existing PR, also pass `--pr-number`, `--pr-url`, `--pr-branch`.
+For GitLab workspaces, also pass `--host "{gitlab_host}"`.
+
+Every workspace uses `--primary` because each is an independent session with its own Claude Code instance.
+
+Record the end time after all calls complete:
+```bash
+date +%s
+```
+
+### Phase 4: Report Results
+
+Parse the JSON output from each `setup.sh` call and present a summary:
+
+```
+## Batch Workspace Setup Complete
+
+| # | Workspace | Session ID | Status | Branch |
+|---|-----------|------------|--------|--------|
+| 1 | crow-101-parallel-exec | a1b2c3d4-... | ok | feature/crow-101-parallel-exec |
+| 2 | citadel-45-jwt-validation | e5f6a7b8-... | ok | feature/citadel-45-jwt-validation |
+| 3 | crow-99-fix-terminal-focus | c9d0e1f2-... | error: git_worktree_add | - |
+
+### Timing
+- Parallel execution: 18s (3 workspaces)
+- Estimated sequential: ~45s (3 x ~15s avg)
+- Speedup: ~2.5x
+```
+
+For any failures, include the error message and suggest remediation (see Error Handling below).
+
+## Naming Conventions
+
+Same as `/crow-workspace`. See that skill for full details.
+
+**CRITICAL: Worktrees go DIRECTLY under the workspace folder, at the same level as the main repo clone. NOT in a subfolder.**
+
+```
+{devRoot}/{workspace}/{repo}-{ticket_number}-{brief_slug}
+```
+
+## Error Handling
+
+If any `setup.sh` call returns `"status": "error"`:
+
+1. Report the failure in the summary table
+2. Include the `step` and `message` from the error JSON
+3. If `partial.session_id` is present, note it for potential cleanup
+4. Do NOT retry automatically — report failures and let the user decide
+5. Successful workspaces are not affected by individual failures
+
+Common errors:
+| Error | Likely Cause | Remediation |
+|-------|-------------|-------------|
+| `git_worktree_add` | Branch already exists | Use a different slug or delete the conflicting branch |
+| `new_session` | Crow app not running | Ask user to start Crow |
+| `git_fetch` | Network issue or bad repo path | Check repo path and network |
+
+## crow CLI Reference
+
+Same as `/crow-workspace`. See that skill for the full CLI reference.
+
+## Examples
+
+### Three GitHub Issues
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://github.com/RadiusMethod/citadel/issues/45
+https://github.com/RadiusMethod/crow/issues/99
+```
+- Resolves all 3 sequentially (fetches tickets, detects PRs, generates names)
+- Fires 3 `setup.sh` calls simultaneously
+- Reports results with timing comparison
+
+### Mixed Providers
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://gitlab.example.com/org/my-project/-/issues/42
+```
+- Detects GitHub and GitLab providers from URLs
+- Uses `gh` for first, `glab` for second
+- Both `setup.sh` calls fire in parallel
+
+### Five Workspaces (Stress Test)
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://github.com/RadiusMethod/crow/issues/102
+https://github.com/RadiusMethod/crow/issues/103
+https://github.com/RadiusMethod/citadel/issues/45
+https://github.com/RadiusMethod/citadel/issues/46
+```
+- 5 parallel `setup.sh` calls
+- Each blocks one GCD thread in the socket server (well within the 64+ thread pool)
+- `sleep 3` calls in each script overlap — total wait is ~3s, not 15s

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -186,6 +186,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.appState.selectedSessionID = AppState.managerSessionID
         }
 
+        // Wire batch "Work on" issues action — sends multiple URLs to Manager terminal
+        appState.onBatchWorkOnIssues = { [weak self] issueURLs in
+            guard let self, let managerTerminals = self.appState.terminals[AppState.managerSessionID],
+                  let managerTerminal = managerTerminals.first else { return }
+            let urls = issueURLs.joined(separator: "\n")
+            TerminalManager.shared.send(
+                id: managerTerminal.id,
+                text: "/crow-batch-workspace\n\(urls)\n"
+            )
+            self.appState.selectedSessionID = AppState.managerSessionID
+        }
+
         // Wire "Start Review" action — creates review session for a PR
         appState.onStartReview = { [weak self] prURL in
             guard let self else { return }

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -25,6 +25,9 @@ struct Scaffolder {
         let reviewSkillsDir = (claudeDir as NSString).appendingPathComponent("skills/crow-review-pr")
         try fm.createDirectory(atPath: reviewSkillsDir, withIntermediateDirectories: true)
 
+        let batchSkillsDir = (claudeDir as NSString).appendingPathComponent("skills/crow-batch-workspace")
+        try fm.createDirectory(atPath: batchSkillsDir, withIntermediateDirectories: true)
+
         // Create crow-reviews directory for PR review clones
         let reviewsDir = (devRoot as NSString).appendingPathComponent("crow-reviews")
         try fm.createDirectory(atPath: reviewsDir, withIntermediateDirectories: true)
@@ -70,6 +73,11 @@ struct Scaffolder {
         let reviewSkillPath = (reviewSkillsDir as NSString).appendingPathComponent("SKILL.md")
         let reviewSkillTemplate = Self.bundledReviewSkill()
         try reviewSkillTemplate.write(toFile: reviewSkillPath, atomically: true, encoding: .utf8)
+
+        // Always overwrite the batch-workspace skill with the latest version
+        let batchSkillPath = (batchSkillsDir as NSString).appendingPathComponent("SKILL.md")
+        let batchSkillTemplate = Self.bundledBatchSkill()
+        try batchSkillTemplate.write(toFile: batchSkillPath, atomically: true, encoding: .utf8)
 
         // Always overwrite settings.json (permissions for crow, gh, git commands)
         let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.json")
@@ -160,6 +168,27 @@ struct Scaffolder {
 
         ## Important
         All `gh` commands require `dangerouslyDisableSandbox: true`.
+        """
+    }
+
+    /// The crow-batch-workspace SKILL.md template bundled with the app.
+    static func bundledBatchSkill() -> String {
+        if let content = loadFromRepo("skills/crow-batch-workspace/SKILL.md") {
+            return content
+        }
+        if let url = Bundle.main.url(forResource: "crow-batch-workspace-SKILL.md", withExtension: "template"),
+           let content = try? String(contentsOf: url) {
+            return content
+        }
+        return """
+        # Crow Batch Workspace Setup Skill
+
+        ## Activation
+        This skill activates when user invokes `/crow-batch-workspace` command.
+
+        ## Important
+        All `crow` CLI and `git worktree` commands require `dangerouslyDisableSandbox: true`.
+        See the CLAUDE.md in this directory for the full crow CLI reference.
         """
     }
 

--- a/skills/crow-batch-workspace/SKILL.md
+++ b/skills/crow-batch-workspace/SKILL.md
@@ -1,0 +1,218 @@
+# Crow Batch Workspace Setup Skill
+
+## Purpose
+
+Sets up **multiple** crow workspaces in parallel, dramatically reducing total setup time. Delegates to the existing `/crow-workspace` skill's `setup.sh` for each workspace but fires all executions simultaneously.
+
+## Important: Sandbox Bypass
+
+All `crow`, `gh`, `glab`, and `git worktree` commands require `dangerouslyDisableSandbox: true` because they communicate via Unix socket, need network/TLS access, or write outside the sandbox-allowed directories.
+
+## Activation
+
+This skill activates when:
+- User invokes `/crow-batch-workspace` command
+- User asks to "set up multiple workspaces", "batch workspace setup", or provides multiple ticket URLs at once
+
+## Concurrency Safety
+
+The crow CLI is safe for concurrent use. Multiple `crow` commands can run simultaneously without race conditions:
+
+- **Socket Server**: Each CLI connection is dispatched to GCD's global concurrent queue. Multiple connections are accepted and processed in parallel.
+- **State Mutations**: All RPC handlers use `await MainActor.run { ... }`, serializing all AppState mutations on the main thread.
+- **Persistence**: JSONStore uses NSLock to serialize disk writes. Concurrent `mutate()` calls are safe.
+- **Git Operations**: Each `setup.sh` creates its own worktree at a unique path, its own session (unique UUID), and its own terminal. There are no shared resources between parallel workspace setups.
+
+## Autonomous Execution
+
+This skill runs autonomously without permission prompts because:
+1. All `crow`, `gh`, `glab`, and `git` commands are pre-approved in `{devRoot}/.claude/settings.json`
+2. All commands use `dangerouslyDisableSandbox: true` (sandbox excludes these binaries)
+3. `setup.sh` is pre-approved via `Bash(bash .claude/skills/crow-workspace/setup.sh *)`
+
+No additional permission configuration is needed.
+
+## Configuration
+
+Same as `/crow-workspace`. Configuration is at `{devRoot}/.claude/config.json` (managed by the Crow app).
+
+## Input Format
+
+One or more ticket URLs, separated by newlines:
+
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://github.com/RadiusMethod/citadel/issues/45
+https://github.com/RadiusMethod/crow/issues/99
+```
+
+Or a mix of ticket URLs and natural language:
+
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+"update citadel authentication"
+https://gitlab.example.com/org/repo/-/issues/42
+```
+
+## Execution Flow
+
+### Phase 1: Parse Inputs
+
+Split the user's input into individual workspace specs. Each spec is either:
+- A ticket URL (GitHub or GitLab)
+- A natural language description
+
+Validate each is a recognizable format.
+
+### Phase 2: Resolve Each Workspace (sequential)
+
+For each workspace spec, perform the same resolution as `/crow-workspace`:
+
+1. **Read config**: `cat {devRoot}/.claude/config.json`
+2. **Detect provider** from URL (see Provider Detection table in `/crow-workspace` skill)
+3. **Scan repos**: Find repos in all configured workspaces
+4. **Match repo**: Score repos against ticket content
+5. **Fetch ticket**: `gh issue view {url} --json title,body,labels` (with `dangerouslyDisableSandbox: true`)
+6. **Check for existing PR**: `gh pr list --repo {owner}/{repo} --search "{issue_number}" --state open --json number,title,headRefName,url --limit 5` (with `dangerouslyDisableSandbox: true`)
+7. **Generate names**: slug, branch, worktree path, session name (following `/crow-workspace` naming conventions)
+8. **Compose prompt**: Use the First Prompt Template from `/crow-workspace`
+9. **Write prompt file**: `cat > {devRoot}/.claude/prompts/crow-prompt-{session_name}.md`
+
+This phase is sequential because each resolution involves LLM reasoning (scoring repos, generating slugs). It's fast (~2-3 seconds per workspace).
+
+**Collect all resolved parameters into a list** before proceeding to Phase 3.
+
+### Phase 3: Parallel Execution
+
+**CRITICAL: Launch ALL `setup.sh` calls in a SINGLE message using multiple Bash tool calls.**
+
+Claude Code supports making multiple independent Bash calls simultaneously in a single response. Since each workspace creates its own independent session, there are no dependencies between them.
+
+Record the start time:
+```bash
+date +%s
+```
+
+Then, in a **single message**, fire one Bash tool call per workspace:
+
+```bash
+.claude/skills/crow-workspace/setup.sh \
+  --dev-root "{devRoot}" \
+  --workspace "{workspace}" \
+  --repo "{repo}" \
+  --repo-path "{repo_path}" \
+  --slug "{slug}" \
+  --branch "{branch}" \
+  --worktree-path "{worktree_path}" \
+  --session-name "{session_name}" \
+  --provider "{provider}" \
+  --cli "{cli}" \
+  --ticket-url "{ticket_url}" \
+  --ticket-title "{ticket_title}" \
+  --ticket-number {ticket_number} \
+  --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
+  --claude-binary "$(which claude)" \
+  --primary
+```
+
+Each call must use `dangerouslyDisableSandbox: true`.
+
+If a workspace has an existing PR, also pass `--pr-number`, `--pr-url`, `--pr-branch`.
+For GitLab workspaces, also pass `--host "{gitlab_host}"`.
+
+Every workspace uses `--primary` because each is an independent session with its own Claude Code instance.
+
+Record the end time after all calls complete:
+```bash
+date +%s
+```
+
+### Phase 4: Report Results
+
+Parse the JSON output from each `setup.sh` call and present a summary:
+
+```
+## Batch Workspace Setup Complete
+
+| # | Workspace | Session ID | Status | Branch |
+|---|-----------|------------|--------|--------|
+| 1 | crow-101-parallel-exec | a1b2c3d4-... | ok | feature/crow-101-parallel-exec |
+| 2 | citadel-45-jwt-validation | e5f6a7b8-... | ok | feature/citadel-45-jwt-validation |
+| 3 | crow-99-fix-terminal-focus | c9d0e1f2-... | error: git_worktree_add | - |
+
+### Timing
+- Parallel execution: 18s (3 workspaces)
+- Estimated sequential: ~45s (3 x ~15s avg)
+- Speedup: ~2.5x
+```
+
+For any failures, include the error message and suggest remediation (see Error Handling below).
+
+## Naming Conventions
+
+Same as `/crow-workspace`. See that skill for full details.
+
+**CRITICAL: Worktrees go DIRECTLY under the workspace folder, at the same level as the main repo clone. NOT in a subfolder.**
+
+```
+{devRoot}/{workspace}/{repo}-{ticket_number}-{brief_slug}
+```
+
+## Error Handling
+
+If any `setup.sh` call returns `"status": "error"`:
+
+1. Report the failure in the summary table
+2. Include the `step` and `message` from the error JSON
+3. If `partial.session_id` is present, note it for potential cleanup
+4. Do NOT retry automatically — report failures and let the user decide
+5. Successful workspaces are not affected by individual failures
+
+Common errors:
+| Error | Likely Cause | Remediation |
+|-------|-------------|-------------|
+| `git_worktree_add` | Branch already exists | Use a different slug or delete the conflicting branch |
+| `new_session` | Crow app not running | Ask user to start Crow |
+| `git_fetch` | Network issue or bad repo path | Check repo path and network |
+
+## crow CLI Reference
+
+Same as `/crow-workspace`. See that skill for the full CLI reference.
+
+## Examples
+
+### Three GitHub Issues
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://github.com/RadiusMethod/citadel/issues/45
+https://github.com/RadiusMethod/crow/issues/99
+```
+- Resolves all 3 sequentially (fetches tickets, detects PRs, generates names)
+- Fires 3 `setup.sh` calls simultaneously
+- Reports results with timing comparison
+
+### Mixed Providers
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://gitlab.example.com/org/my-project/-/issues/42
+```
+- Detects GitHub and GitLab providers from URLs
+- Uses `gh` for first, `glab` for second
+- Both `setup.sh` calls fire in parallel
+
+### Five Workspaces (Stress Test)
+```
+/crow-batch-workspace
+https://github.com/RadiusMethod/crow/issues/101
+https://github.com/RadiusMethod/crow/issues/102
+https://github.com/RadiusMethod/crow/issues/103
+https://github.com/RadiusMethod/citadel/issues/45
+https://github.com/RadiusMethod/citadel/issues/46
+```
+- 5 parallel `setup.sh` calls
+- Each blocks one GCD thread in the socket server (well within the 64+ thread pool)
+- `sleep 3` calls in each script overlap — total wait is ~3s, not 15s


### PR DESCRIPTION
## Summary
- Adds new `/crow-batch-workspace` skill that sets up multiple workspaces in parallel via concurrent `setup.sh` calls
- Documents crow CLI concurrency safety (MainActor serialization + NSLock persistence)
- Documents autonomous execution capabilities (existing permission allowlists already cover all needed commands)
- Updates Scaffolder to scaffold the new skill directory

## Test plan
- [x] `make build` passes (verified)
- [x] Run the app and verify `skills/crow-batch-workspace/SKILL.md` is scaffolded in devRoot
- [x] Invoke `/crow-batch-workspace` with 2-3 ticket URLs and verify parallel execution
- [x] Verify `crow list-sessions` shows all sessions created without corruption
- [x] Measure timing: parallel vs sequential for 3+ workspaces

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)