### PR TITLE
Fix PR review status not reflecting actual reviews

### DIFF
--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -367,7 +367,7 @@ final class IssueTracker {
             do {
                 output = try await shell(
                     "gh", "pr", "view", prLink.url,
-                    "--json", "state,mergeable,reviewDecision,statusCheckRollup"
+                    "--json", "state,mergeable,reviewDecision,statusCheckRollup,latestReviews"
                 )
             } catch {
                 print("[IssueTracker] fetchPRStatuses: failed for \(prLink.url): \(error)")
@@ -398,14 +398,26 @@ final class IssueTracker {
                 }
             }
 
-            // Parse review status
-            let reviewStatus: PRStatus.ReviewStatus
+            // Parse review status — reviewDecision reflects branch protection rules,
+            // so fall back to latestReviews for repos without required-reviews protection.
+            var reviewStatus: PRStatus.ReviewStatus
             switch json["reviewDecision"] as? String {
             case "APPROVED": reviewStatus = .approved
             case "CHANGES_REQUESTED": reviewStatus = .changesRequested
             case "REVIEW_REQUIRED": reviewStatus = .reviewRequired
             case "": reviewStatus = .reviewRequired  // empty string means no reviews yet
             default: reviewStatus = .unknown
+            }
+
+            // When reviewDecision is empty (no branch protection), derive from actual reviews
+            if reviewStatus == .reviewRequired || reviewStatus == .unknown,
+               let reviews = json["latestReviews"] as? [[String: Any]], !reviews.isEmpty {
+                let states = reviews.compactMap { $0["state"] as? String }
+                if states.contains("CHANGES_REQUESTED") {
+                    reviewStatus = .changesRequested
+                } else if states.contains("APPROVED") {
+                    reviewStatus = .approved
+                }
             }
 
             // Parse merge status — check PR state first for merged


### PR DESCRIPTION
## Summary
- Fall back to `latestReviews` when `reviewDecision` is empty, fixing repos without required-reviews branch protection where the field is always `""` regardless of actual reviews

Closes #151

## Test plan
- [x] Create a session with a PR that has an approving review — badge should show "Approved" (green)
- [x] Create a session with a PR that has changes requested — badge should show "Changes requested" (red)
- [x] Create a session with a PR that has no reviews — badge should show "Needs review" (orange)
- [x] Merged PRs should still show "Merged" (purple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)