### PR TITLE
Docs: refresh README, promote make build, fix GitHub project scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,9 @@ crow list-worktrees --session <uuid>
 
 ### Terminal Commands
 ```
-crow new-terminal --session <uuid> --cwd "/path" [--name "Claude Code"] [--command "claude ..."]
+crow new-terminal --session <uuid> --cwd "/path" [--name "Claude Code"] [--command "claude ..."] [--managed]
 crow list-terminals --session <uuid>
+crow close-terminal --session <uuid> --terminal <uuid>
 crow send --session <uuid> --terminal <uuid> "text to send"
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ A native macOS application for managing AI-powered development sessions. Orchest
 
 ### Build Dependencies
 
-| Tool | Version | Purpose | Install |
-|------|---------|---------|---------|
-| Swift | 6.0+ | Compiler (ships with Xcode) | `xcode-select --install` |
-| Zig | 0.15.2 | Builds the Ghostty terminal framework | `brew install zig` or [ziglang.org](https://ziglang.org/download/) |
-| mise | latest | Task runner (optional) | `brew install mise` |
+| Tool  | Version | Purpose                                | Install                                                                           |
+| ----- | ------- | -------------------------------------- | --------------------------------------------------------------------------------- |
+| Swift | 6.0+    | Compiler (ships with Xcode)            | `xcode-select --install`                                                          |
+| Zig   | 0.15.2  | Builds the Ghostty terminal framework  | `brew install zig` or [ziglang.org](https://ziglang.org/download/)                |
+| mise  | latest  | Task runner (optional)                 | `brew install mise`                                                               |
 
 ### Runtime Dependencies
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| `gh` | GitHub CLI — issue tracking, PR status, project boards | `brew install gh` |
-| `git` | Worktree management | Ships with Xcode CLT |
-| `claude` | Claude Code — AI coding assistant | [claude.ai/download](https://claude.ai/download) |
-| `glab` | GitLab CLI (optional, for GitLab repos) | `brew install glab` |
+| Tool     | Purpose                                                       | Install                                               |
+| -------- | ------------------------------------------------------------- | ----------------------------------------------------- |
+| `gh`     | GitHub CLI — issue tracking, PR status, project boards        | `brew install gh`                                     |
+| `git`    | Worktree management                                           | Ships with Xcode CLT                                  |
+| `claude` | Claude Code — AI coding assistant                             | [claude.ai/download](https://claude.ai/download)      |
+| `glab`   | GitLab CLI (optional, for GitLab repos)                       | `brew install glab`                                   |
 
 ## Quick Start
 
@@ -34,265 +34,38 @@ A native macOS application for managing AI-powered development sessions. Orchest
 git clone --recurse-submodules https://github.com/radiusmethod/crow.git
 cd crow
 
-# 2. Build the Ghostty terminal framework
-./scripts/build-ghostty.sh
+# 2. Build (submodules + GhosttyKit + swift build in one shot)
+make build
 
-# 3. Build the app
-swift build
-
-# 4. Authenticate GitHub CLI
+# 3. Authenticate GitHub CLI — the write `project` scope is required
 gh auth login
-gh auth refresh -s read:project   # Required for project board status
+gh auth refresh -s project,read:org,repo
 
-# 5. Run
+# 4. Run
 .build/debug/CrowApp
 ```
 
-On first launch, a setup wizard guides you through choosing your development root directory and configuring workspaces.
-
-Alternatively, configure via the CLI without launching the GUI:
+On first launch, a setup wizard guides you through choosing your development root directory and configuring workspaces. Alternatively, configure via the CLI without launching the GUI:
 
 ```bash
 .build/debug/crow setup
 ```
 
-## Detailed Setup
+> **Note:** The required GitHub scope is the **write** `project` scope — `read:project` is insufficient because Crow updates ticket status via the `updateProjectV2ItemFieldValue` GraphQL mutation. See [docs/getting-started.md](docs/getting-started.md#3-github-authentication) for details.
 
-### 1. Clone the Repository
+## Documentation
 
-```bash
-git clone --recurse-submodules https://github.com/radiusmethod/crow.git
-cd crow
-```
-
-If you already cloned without `--recurse-submodules`:
-
-```bash
-git submodule update --init vendor/ghostty
-```
-
-### 2. Build the Ghostty Framework
-
-The app embeds [Ghostty](https://ghostty.org) as a terminal emulator via libghostty. This must be built before the app:
-
-```bash
-./scripts/build-ghostty.sh
-```
-
-This compiles libghostty from the vendored source using Zig, producing:
-- `Frameworks/GhosttyKit.xcframework/` — the compiled framework
-- `Frameworks/ghostty-resources/` — terminal resources (themes, etc.)
-
-**Troubleshooting:**
-- Verify Zig version: `zig version` should show `0.15.2`
-- Verify Metal toolchain: `xcrun -sdk macosx metal --version`
-
-### 3. Build the App
-
-```bash
-# Debug build
-swift build
-
-# Release build
-swift build -c release
-
-# Create .app bundle (release)
-./scripts/bundle.sh
-```
-
-The build produces two executables:
-- `CrowApp` — the main application
-- `crow` — the CLI for session management
-
-### 4. GitHub Authentication
-
-The app uses the GitHub CLI to fetch issues, PRs, and project board status.
-
-```bash
-# Initial login
-gh auth login
-
-# Add project board scope (required for ticket pipeline status)
-gh auth refresh -s read:project
-```
-
-**Required scopes:** `repo`, `read:org`, `read:project`
-
-Verify with: `gh auth status`
-
-### 5. GitLab Authentication (Optional)
-
-For self-hosted GitLab instances:
-
-```bash
-glab auth login --hostname gitlab.example.com
-```
-
-### 6. First Launch
-
-```bash
-.build/debug/CrowApp
-```
-
-The setup wizard will:
-1. Ask for your **development root** directory (e.g., `~/Dev`)
-2. Let you **configure workspaces** — each workspace is a subfolder containing git repos
-3. Set the **provider** per workspace (GitHub or GitLab)
-4. Scaffold the directory structure and configuration files
-
-### Using mise (Optional)
-
-If you have `mise` installed, you can use the predefined tasks:
-
-```bash
-mise build           # Build debug
-mise build:release   # Build release
-mise build:ghostty   # Build GhosttyKit framework
-mise bundle          # Create .app bundle
-mise clean           # Clean build artifacts
-```
-
-## Architecture
-
-### Package Structure
-
-```
-crow/
-├── Sources/
-│   ├── Crow/              # Main app target
-│   │   ├── App/
-│   │   │   ├── main.swift           # Entry point
-│   │   │   ├── AppDelegate.swift    # Window management, IPC server, startup
-│   │   │   ├── SessionService.swift # Session CRUD, orphan detection
-│   │   │   ├── IssueTracker.swift   # GitHub/GitLab polling (60s interval)
-│   │   │   └── Scaffolder.swift     # First-run directory setup
-│   │   └── Resources/
-│   │       ├── AppIcon.png
-│   │       └── CorveilBrandmark.png
-│   └── CrowCLI/            # crow CLI target
-│       └── CrowCLI.swift
-├── Packages/
-│   ├── CrowCore/           # Data models, AppState (observable)
-│   ├── CrowUI/             # SwiftUI views, Corveil theme
-│   ├── CrowTerminal/       # Ghostty terminal surface management
-│   ├── CrowGit/            # Git operations
-│   ├── CrowProvider/       # GitHub/GitLab provider abstraction
-│   ├── CrowPersistence/    # JSON store, config persistence
-│   ├── CrowClaude/         # Claude binary resolution
-│   └── CrowIPC/            # Unix socket RPC protocol
-├── Frameworks/              # Built GhosttyKit (gitignored)
-├── vendor/ghostty/          # Ghostty submodule
-├── scripts/
-│   ├── build-ghostty.sh     # Builds GhosttyKit from source
-│   └── bundle.sh            # Creates .app bundle
-└── skills/
-    └── crow-workspace/
-        └── SKILL.md         # Claude Code skill for workspace setup
-```
-
-### Key Components
-
-| Component | Description |
-|-----------|-------------|
-| **AppDelegate** | Initializes the app, creates the main window, starts the IPC socket server and issue tracker |
-| **SessionService** | CRUD for sessions/worktrees/terminals, terminal readiness tracking, orphan detection |
-| **IssueTracker** | Polls GitHub/GitLab every 60 seconds for assigned issues, PR status, project board status, auto-completes sessions on merged PRs |
-| **TerminalManager** | Manages Ghostty terminal surfaces with lifecycle tracking (uninitialized → surfaceCreated → shellReady → claudeLaunched) |
-| **SocketServer** | Unix socket at `~/.local/share/crow/crow.sock` — receives JSON-RPC commands from the `crow` CLI |
-
-### Data Flow
-
-```
-User clicks session tab
-  → SwiftUI renders TerminalSurfaceView
-  → GhosttySurfaceView.createSurface() spawns shell
-  → TerminalManager detects readiness (2s after surface creation)
-  → Auto-sends `claude --continue` to resume Claude Code
-  → Status dot turns green
-```
-
-```
-User invokes /crow-workspace in Manager tab
-  → Claude Code runs crow CLI commands via Unix socket
-  → crow new-session → crow add-worktree → crow new-terminal
-  → App creates session, registers worktree, spawns terminal
-  → User clicks new session tab → Claude launches automatically
-```
-
-## Configuration
-
-### File Locations
-
-| Path | Purpose |
-|------|---------|
-| `~/Library/Application Support/crow/devroot` | Pointer to development root directory |
-| `~/Library/Application Support/crow/store.json` | Persisted sessions, worktrees, links, terminals |
-| `{devRoot}/.claude/config.json` | Workspace configuration |
-| `{devRoot}/.claude/CLAUDE.md` | Manager tab context (crow CLI reference) |
-| `{devRoot}/.claude/settings.json` | Claude Code permission settings |
-| `{devRoot}/.claude/skills/crow-workspace/SKILL.md` | Workspace setup skill |
-
-### Workspace Configuration
-
-`{devRoot}/.claude/config.json`:
-
-```json
-{
-  "workspaces": [
-    {
-      "id": "uuid",
-      "name": "RadiusMethod",
-      "provider": "github",
-      "cli": "gh",
-      "host": null
-    },
-    {
-      "id": "uuid",
-      "name": "MyGitLab",
-      "provider": "gitlab",
-      "cli": "glab",
-      "host": "gitlab.example.com"
-    }
-  ],
-  "defaults": {
-    "provider": "github",
-    "cli": "gh",
-    "branchPrefix": "feature/",
-    "excludeDirs": ["node_modules", ".git", "vendor", "dist", "build", "target"]
-  }
-}
-```
-
-### Directory Structure
-
-The app expects repos organized under workspace folders:
-
-```
-~/Dev/                          # Development root
-├── RadiusMethod/               # Workspace (GitHub)
-│   ├── citadel/                # Main repo checkout
-│   ├── citadel-134-sensor/     # Worktree for issue #134
-│   └── citadel-209-review/     # Worktree for issue #209
-└── MyGitLab/                # Workspace (GitLab)
-    ├── my-project/
-    └── overrides/
-```
-
-Worktrees are created at the same level as the main repo, **not** in subdirectories.
-
-## Environment Variables
-
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `CROW_SOCKET` | Override the Unix socket path for CLI ↔ App IPC | `~/.local/share/crow/crow.sock` |
-| `TMPDIR` | Temporary file directory (used by the terminal subsystem) | System default |
-| `GITLAB_HOST` | GitLab instance hostname (set automatically per workspace config) | — |
+- [**Getting Started**](docs/getting-started.md) — Clone, build, authenticate, and launch
+- [**CLI Reference**](docs/cli-reference.md) — Every `crow` subcommand and its flags
+- [**Architecture**](docs/architecture.md) — Packages, key components, data flow
+- [**Configuration**](docs/configuration.md) — File locations, workspace config, directory layout, session lifecycle
+- [**Troubleshooting**](docs/troubleshooting.md) — Build and runtime errors
 
 ## Usage
 
 ### The Sidebar
 
-- **Tickets** — Shows assigned issues grouped by project board status (Backlog, Ready, In Progress, In Review, Done in last 24h). Click to open the full ticket board.
+- **Tickets** — Assigned issues grouped by project board status (Backlog, Ready, In Progress, In Review, Done in last 24h). Click a status to filter.
 - **Manager** — A persistent Claude Code terminal for orchestrating work. Use `/crow-workspace` here to create new sessions.
 - **Active Sessions** — One per work context. Shows repo, branch, issue/PR badges with pipeline and review status.
 - **Completed Sessions** — Sessions whose PRs have been merged or issues closed.
@@ -312,99 +85,41 @@ Or use natural language:
 ```
 
 This will:
+
 1. Create a git worktree with a feature branch
 2. Create a session with ticket metadata
 3. Launch Claude Code in plan mode with the issue context
 4. Auto-assign the issue and set its project status to "In Progress"
 
-### Session Lifecycle
-
-| State | Trigger | Sidebar |
-|-------|---------|---------|
-| Active | Created via `/crow-workspace` | Green dot (or gray/yellow/blue during terminal init) |
-| Completed | PR merged or issue closed (auto-detected), or manual "Mark as Completed" | Gold checkmark |
-| Archived | Manual | Gray archive icon |
-
-### Terminal Readiness
-
-When you click a session tab, the terminal goes through:
-1. **Gray dot** — Terminal not yet initialized
-2. **Yellow dot** — Surface created, shell starting
-3. **Blue dot** — Shell ready
-4. **Green dot** — `claude --continue` sent, Claude is running
-
-A loading overlay shows during initialization and disappears when Claude launches.
-
-## crow CLI Reference
-
-The `crow` CLI communicates with the running app via Unix socket. The app must be running for commands to work.
-
-### Session Commands
-
-```bash
-crow new-session --name "feature-name"
-crow rename-session --session <uuid> "new-name"
-crow select-session --session <uuid>
-crow list-sessions
-crow get-session --session <uuid>
-crow set-status --session <uuid> active|paused|inReview|completed|archived
-crow delete-session --session <uuid>
-```
-
-### Metadata Commands
-
-```bash
-crow set-ticket --session <uuid> --url "..." [--title "..."] [--number N]
-crow add-link --session <uuid> --label "Issue" --url "..." --type ticket|pr|repo|custom
-crow list-links --session <uuid>
-```
-
-### Worktree Commands
-
-```bash
-crow add-worktree --session <uuid> \
-  --repo "repo-name" \
-  --repo-path "/path/to/main/repo" \
-  --path "/path/to/worktree" \
-  --branch "feature/name" \
-  [--primary]
-crow list-worktrees --session <uuid>
-```
-
-### Terminal Commands
-
-```bash
-crow new-terminal --session <uuid> --cwd "/path" [--name "Claude Code"]
-crow list-terminals --session <uuid>
-crow send --session <uuid> --terminal <uuid> "text to send\n"
-```
-
-All commands return JSON. The `crow send` command converts `\n` in the text to Enter keypresses.
-
 ## Features
 
 ### Ticket Board
+
 - Pipeline view showing issues by project board status
 - Click a status to filter the list
 - "Start Working" button creates a workspace directly from an issue
 - Issues linked to active sessions show a navigation button
 
 ### PR Status Tracking
+
 - Pipeline checks (passing/failing/pending)
 - Review status (approved/changes requested/needs review)
 - Merge readiness (mergeable/conflicting/merged)
 - Purple badge with checkmark for merged PRs
 
 ### Auto-Complete
+
 - Sessions automatically move to "Completed" when their linked PR is merged or issue is closed
 - Checked every 60 seconds during the issue polling cycle
 
 ### Orphan Recovery
+
 - On startup, scans git worktrees across all repos
 - Worktrees not tracked in the store are automatically recovered as sessions
 - Fetches ticket metadata and PR links from GitHub for recovered sessions
 
 ### Safe Deletion
+
 - Deleting a session on a protected branch (main, master, develop) only removes the session metadata — the repo folder and branch are preserved
 - The delete confirmation dialog reflects this, showing "Remove Session" instead of "Delete Everything"
 
@@ -419,45 +134,10 @@ All commands return JSON. The `crow send` command converts `\n` in the text to E
 ### Testing
 
 ```bash
-swift test        # or: mise test
+make test     # or: swift test, or: mise test
 ```
 
-Tests use the [Swift Testing](https://developer.apple.com/documentation/testing/) framework (`@Test` macros). Test files are under `Packages/*/Tests/`.
-
-### Debugging
-
-The app logs diagnostic information to stderr:
-- `[TerminalManager]` — Surface creation and readiness transitions
-- `[SessionService]` — Orphan detection and session lifecycle
-- `[IssueTracker]` — GitHub API errors, scope issues
-- `[JSONStore]` — Decode failures (store data loss prevention)
-- `[Ghostty]` — Surface creation success/failure
-
-Run with log filtering:
-```bash
-.build/debug/CrowApp 2>&1 | grep "\[TerminalManager\]\|\[SessionService\]"
-```
-
-## Troubleshooting
-
-### Build Issues
-
-| Problem | Solution |
-|---------|----------|
-| `zig` not found | Install with `brew install zig` or from [ziglang.org](https://ziglang.org/download/) |
-| Zig version mismatch | Version 0.15.2 is required. Check with `zig version` |
-| Metal toolchain not found | Run `xcodebuild -downloadComponent MetalToolchain` |
-| Ghostty submodule missing | Run `git submodule update --init vendor/ghostty` |
-| Swift build fails with linker errors | Ensure GhosttyKit is built first: `./scripts/build-ghostty.sh` |
-
-### Runtime Issues
-
-| Problem | Solution |
-|---------|----------|
-| `crow` CLI: "Connection refused" | The Crow app must be running — the CLI communicates via Unix socket |
-| GitHub API errors / empty responses | Check auth: `gh auth status`. Add project scope: `gh auth refresh -s read:project` |
-| Terminal not starting | Check stderr logs for `[TerminalManager]` or `[Ghostty]` messages |
-| Issue tracker shows no tickets | Verify `gh auth status` shows `repo`, `read:org`, `read:project` scopes |
+Tests use the [Swift Testing](https://developer.apple.com/documentation/testing/) framework (`@Test` macros). Test files live under `Packages/*/Tests/`.
 
 ## Contributing
 
@@ -467,7 +147,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines 
 
 Official releases are signed and notarized via GitHub Actions. Download the latest DMG from the [Releases](https://github.com/radiusmethod/crow/releases) page — it will install without Gatekeeper warnings.
 
-**Building from source:** Code signing is only required for distribution. Developers building from source do not need a signing certificate — `make build` and `make release` produce unsigned but fully functional builds. If macOS quarantines an unsigned .app, remove it with:
+**Building from source:** Code signing is only required for distribution. Developers building from source do not need a signing certificate — `make build` and `make release` produce unsigned but fully functional builds. If macOS quarantines an unsigned `.app`, remove it with:
 
 ```bash
 xattr -cr Crow.app

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,105 @@
+# Architecture
+
+Crow is a native macOS app that coordinates AI-assisted development sessions. Each session is a git worktree + a Claude Code terminal + ticket metadata, all tracked in a persistent store and surfaced in a SwiftUI sidebar. A CLI (`crow`) talks to the running app over a Unix socket so that Claude Code can create sessions programmatically.
+
+## Repository Layout
+
+```
+crow/
+├── Sources/
+│   ├── Crow/                  # Main application target
+│   │   ├── App/
+│   │   │   ├── main.swift           # Entry point
+│   │   │   ├── AppDelegate.swift    # Window, IPC server, startup
+│   │   │   ├── SessionService.swift # Session CRUD, orphan detection
+│   │   │   ├── IssueTracker.swift   # GitHub/GitLab polling (60s)
+│   │   │   └── Scaffolder.swift     # First-run dev-root scaffold
+│   │   └── Resources/
+│   └── CrowCLI/               # crow CLI binary target
+│       └── main.swift               # Thin executable that calls CrowCommand.main()
+├── Packages/                  # SwiftPM library packages
+│   ├── CrowCore/                    # Data models, AppState (observable)
+│   ├── CrowCLI/                     # CLI command definitions (CrowCommand + subcommands)
+│   ├── CrowClaude/                  # Claude binary resolution
+│   ├── CrowGit/                     # Git operations
+│   ├── CrowIPC/                     # Unix socket RPC protocol
+│   ├── CrowPersistence/             # JSON store, config persistence
+│   ├── CrowProvider/                # GitHub/GitLab provider abstraction
+│   ├── CrowTerminal/                # Ghostty terminal surface management
+│   └── CrowUI/                      # SwiftUI views, Corveil theme
+├── Frameworks/                # Built GhosttyKit (gitignored)
+├── vendor/ghostty/            # Ghostty submodule
+├── scripts/                   # Build helpers (build-ghostty.sh, bundle.sh, …)
+└── skills/                    # Bundled Claude Code skills (crow-workspace, etc.)
+```
+
+### About `Sources/CrowCLI` vs `Packages/CrowCLI`
+
+There are two `CrowCLI` directories:
+
+- **`Packages/CrowCLI/`** is a library package (`CrowCLILib`) that defines every subcommand as a `ParsableCommand` struct plus the `CrowCommand` root. This is where you add new commands or edit existing ones.
+- **`Sources/CrowCLI/main.swift`** is a thin executable target that imports `CrowCLILib` and calls `CrowCommand.main()`. Keeping the command logic in a package lets tests in `Packages/CrowCLI/Tests/` exercise commands directly without building the executable.
+
+## Key Components
+
+| Component                 | Lives in                                           | Description                                                                                                       |
+| ------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **AppDelegate**           | `Sources/Crow/App/AppDelegate.swift`               | Initializes the app, creates the main window, starts the IPC socket server and issue tracker                     |
+| **SessionService**        | `Sources/Crow/App/SessionService.swift`            | CRUD for sessions/worktrees/terminals, terminal readiness tracking, orphan recovery on startup                    |
+| **IssueTracker**          | `Sources/Crow/App/IssueTracker.swift`              | Polls GitHub/GitLab every 60 seconds for assigned issues, PR status, project board status, auto-completes merged sessions |
+| **Scaffolder**            | `Sources/Crow/App/Scaffolder.swift`                | First-run devRoot scaffold: `.claude/` + bundled skills + settings.json                                           |
+| **TerminalManager**       | `Packages/CrowTerminal/.../TerminalManager.swift`  | Manages Ghostty `ghostty_surface_t` lifecycle; emits state transitions consumed by `TerminalReadiness`            |
+| **TerminalReadiness**     | `Packages/CrowCore/Sources/CrowCore/Models/Enums.swift:41` | Four-state enum (uninitialized → surfaceCreated → shellReady → claudeLaunched) driving the sidebar status dot |
+| **SocketServer**          | `Packages/CrowIPC/`                                | Unix socket server at `~/.local/share/crow/crow.sock` — receives JSON-RPC commands from the `crow` CLI            |
+| **CrowCommand**           | `Packages/CrowCLI/.../CrowCommand.swift`           | ArgumentParser root command registering every subcommand                                                          |
+| **JSONStore**             | `Packages/CrowPersistence/`                        | NSLock-serialized JSON persistence for sessions, worktrees, links, terminals                                      |
+
+## Data Flow
+
+### Opening a session tab
+
+```
+User clicks session tab
+  → SwiftUI renders TerminalSurfaceView
+  → GhosttySurfaceView.createSurface() spawns shell
+  → TerminalManager transitions created → shellReady
+  → TerminalReadiness: uninitialized → surfaceCreated → shellReady → claudeLaunched
+  → Auto-sends `claude --continue` when shell becomes ready
+  → Sidebar status dot turns green
+```
+
+### Creating a session from Manager
+
+```
+User invokes /crow-workspace in Manager tab
+  → Claude Code runs crow CLI commands through the Unix socket
+  → crow new-session → crow add-worktree → crow new-terminal --managed
+  → App creates session, registers worktree, spawns managed terminal
+  → User clicks the new session tab → Claude launches automatically
+```
+
+### Issue tracker polling
+
+```
+Every 60 seconds:
+  → IssueTracker.fetchAssignedIssues (gh search issues --assignee @me)
+  → IssueTracker.fetchPRStatus for linked PRs
+  → IssueTracker.fetchGitHubProjectStatuses (GraphQL, needs read:project)
+  → Auto-complete sessions whose PR is merged or issue is closed
+```
+
+### Moving a ticket to "In Progress" / "In Review"
+
+```
+User starts a session via /crow-workspace (or clicks "Mark In Review")
+  → IssueTracker.markInReview builds a GraphQL query for the Status field
+  → Calls updateProjectV2ItemFieldValue mutation
+  → Requires the write `project` scope — NOT `read:project`
+  → On INSUFFICIENT_SCOPES, logs a hint to run `gh auth refresh -s project`
+```
+
+See `Sources/Crow/App/IssueTracker.swift:636-774` for the full `markInReview` implementation.
+
+## Why Ghostty?
+
+Crow embeds [Ghostty](https://ghostty.org) as a terminal emulator via a compiled `libghostty` XCFramework. Ghostty gives each session tab a real GPU-accelerated terminal surface with the same behavior as the standalone Ghostty app, and its C API exposes the `ghostty_surface_t` lifecycle so Crow can track when the shell is ready and auto-launch `claude --continue`. The framework is built from the vendored submodule by `scripts/build-ghostty.sh` (invoked by `make ghostty`).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,258 @@
+# `crow` CLI Reference
+
+The `crow` CLI communicates with the running Crow app via a Unix socket at `~/.local/share/crow/crow.sock` (override with `CROW_SOCKET`). The app must be running for RPC commands to succeed; `crow setup` is the only subcommand that works without a running app.
+
+All commands print JSON to stdout on success. Session and terminal identifiers are full UUIDs (e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`) — short names are not accepted.
+
+Every subcommand source lives in `Packages/CrowCLI/Sources/CrowCLILib/Commands/`.
+
+---
+
+## Setup
+
+### `crow setup`
+
+First-time setup wizard. Checks for runtime dependencies (`git`, `gh`, `claude`), prompts for a development root and workspaces, then writes `~/Library/Application Support/crow/devroot` and scaffolds `{devRoot}/.claude/`.
+
+```bash
+crow setup
+crow setup --dev-root ~/Dev
+```
+
+| Flag         | Required | Description                                 |
+| ------------ | -------- | ------------------------------------------- |
+| `--dev-root` | no       | Skip the interactive dev-root prompt        |
+
+This is the only subcommand that does not require a running app.
+
+---
+
+## Session Commands
+
+### `crow new-session`
+
+Create a new session.
+
+```bash
+crow new-session --name "feature-name"
+```
+
+| Flag     | Required | Description   |
+| -------- | -------- | ------------- |
+| `--name` | yes      | Session name  |
+
+Returns `{"session_id": "<uuid>", "name": "..."}`.
+
+### `crow rename-session`
+
+```bash
+crow rename-session --session <uuid> "new-name"
+```
+
+| Arg / Flag  | Required | Description     |
+| ----------- | -------- | --------------- |
+| `--session` | yes      | Session UUID    |
+| *(positional)* `NAME` | yes | New name |
+
+### `crow select-session`
+
+Make the given session the active tab in the app.
+
+```bash
+crow select-session --session <uuid>
+```
+
+### `crow list-sessions`
+
+Print all sessions.
+
+```bash
+crow list-sessions
+```
+
+### `crow get-session`
+
+```bash
+crow get-session --session <uuid>
+```
+
+Returns full session details: id, name, status, ticket metadata, worktrees, terminals, and links.
+
+### `crow set-status`
+
+```bash
+crow set-status --session <uuid> active
+crow set-status --session <uuid> paused
+crow set-status --session <uuid> inReview
+crow set-status --session <uuid> completed
+crow set-status --session <uuid> archived
+```
+
+| Arg / Flag                | Required | Description                                             |
+| ------------------------- | -------- | ------------------------------------------------------- |
+| `--session`               | yes      | Session UUID                                            |
+| *(positional)* `STATUS`   | yes      | `active`, `paused`, `inReview`, `completed`, `archived` |
+
+### `crow delete-session`
+
+```bash
+crow delete-session --session <uuid>
+```
+
+Deletes the session metadata. Sessions on protected branches (main/master/develop) preserve the repo folder and branch — see [Configuration › Safe Deletion](configuration.md#safe-deletion).
+
+---
+
+## Metadata Commands
+
+### `crow set-ticket`
+
+Attach ticket metadata (URL, title, number) to a session. At least one of `--url`, `--title`, or `--number` must be provided.
+
+```bash
+crow set-ticket --session <uuid> --url "https://github.com/org/repo/issues/123" --title "Fix bug" --number 123
+```
+
+| Flag         | Required | Description    |
+| ------------ | -------- | -------------- |
+| `--session`  | yes      | Session UUID   |
+| `--url`      | no¹      | Ticket URL     |
+| `--title`    | no¹      | Ticket title   |
+| `--number`   | no¹      | Ticket number  |
+
+¹ At least one of `--url`, `--title`, `--number` is required.
+
+### `crow add-link`
+
+Add a link (issue, PR, repo, or custom) to a session.
+
+```bash
+crow add-link --session <uuid> --label "Issue #123" --url "https://..." --type ticket
+```
+
+| Flag        | Required | Description                                        |
+| ----------- | -------- | -------------------------------------------------- |
+| `--session` | yes      | Session UUID                                       |
+| `--label`   | yes      | Display label                                      |
+| `--url`     | yes      | Target URL                                         |
+| `--type`    | no       | `ticket`, `pr`, `repo`, or `custom` (default: `custom`) |
+
+### `crow list-links`
+
+```bash
+crow list-links --session <uuid>
+```
+
+---
+
+## Worktree Commands
+
+### `crow add-worktree`
+
+Register a git worktree for a session. The app uses `--repo-path` to run git commands against the main repo when needed.
+
+```bash
+crow add-worktree \
+  --session <uuid> \
+  --repo "citadel" \
+  --repo-path "/Users/you/Dev/RadiusMethod/citadel" \
+  --path "/Users/you/Dev/RadiusMethod/citadel-123-feature" \
+  --branch "feature/citadel-123" \
+  --primary
+```
+
+| Flag          | Required | Description                                                                |
+| ------------- | -------- | -------------------------------------------------------------------------- |
+| `--session`   | yes      | Session UUID                                                               |
+| `--repo`      | yes      | Repo name                                                                  |
+| `--path`      | yes      | Worktree path                                                              |
+| `--branch`    | yes      | Branch name                                                                |
+| `--repo-path` | no       | Main repo path (used when shelling out to git against the primary repo)    |
+| `--primary`   | no       | Flag — mark this as the primary worktree for the session                   |
+
+> Note: `add-worktree` does **not** support a `--workspace` flag. Workspace association is derived from `--repo-path`.
+
+### `crow list-worktrees`
+
+```bash
+crow list-worktrees --session <uuid>
+```
+
+---
+
+## Terminal Commands
+
+### `crow new-terminal`
+
+Create a new terminal tab inside a session. Use `--managed` for the primary Claude Code terminal that Crow auto-starts and tracks readiness for.
+
+```bash
+crow new-terminal --session <uuid> --cwd "/path/to/worktree" --name "Claude Code" --command "claude" --managed
+```
+
+| Flag        | Required | Description                                                              |
+| ----------- | -------- | ------------------------------------------------------------------------ |
+| `--session` | yes      | Session UUID                                                             |
+| `--cwd`     | yes      | Working directory                                                        |
+| `--name`    | no       | Terminal display name                                                    |
+| `--command` | no       | Command to run once the shell is ready                                   |
+| `--managed` | no       | Flag — mark as a managed Claude Code terminal (readiness tracking, auto-launch) |
+
+### `crow list-terminals`
+
+```bash
+crow list-terminals --session <uuid>
+```
+
+### `crow close-terminal`
+
+Close a terminal tab in a session.
+
+```bash
+crow close-terminal --session <uuid> --terminal <uuid>
+```
+
+### `crow send`
+
+Write text to a terminal. Newlines in `TEXT` are converted to Enter keypresses; include a trailing newline to submit a command.
+
+```bash
+crow send --session <uuid> --terminal <uuid> "claude --continue"$'\n'
+```
+
+| Arg / Flag              | Required | Description       |
+| ----------------------- | -------- | ----------------- |
+| `--session`             | yes      | Session UUID      |
+| `--terminal`            | yes      | Terminal UUID     |
+| *(positional)* `TEXT`   | yes      | Text to send      |
+
+---
+
+## Hooks (Internal)
+
+### `crow hook-event`
+
+Forwards a Claude Code hook event (e.g. `Stop`, `Notification`, `PreToolUse`) to the app. The JSON payload is read from stdin and wrapped in an RPC call. This is wired up automatically by Claude Code's hook system — you do not invoke it by hand.
+
+```bash
+echo '{"tool":"Bash"}' | crow hook-event --session <uuid> --event PreToolUse
+```
+
+On success it is silent; on error it prints JSON to stdout.
+
+---
+
+## Exit Codes
+
+- `0` — success
+- non-zero — connection error, validation failure, or RPC error (details on stderr)
+
+## Error Responses
+
+When the app returns an RPC error, the command prints JSON of the form:
+
+```json
+{"error": "..."}
+```
+
+and exits non-zero. Common causes: the app is not running (socket connection refused), an invalid UUID, or a session/terminal that does not exist.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,112 @@
+# Configuration
+
+This page covers where Crow stores data, how workspaces are configured, the on-disk directory layout it expects, and runtime behavior you can tune via environment variables.
+
+## File Locations
+
+All persistent state lives under `~/Library/Application Support/crow/` (see `Packages/CrowPersistence/Sources/CrowPersistence/AppSupportDirectory.swift`). On first run, if a legacy `rm-ai-ide` directory exists in the same parent, its contents are copied over automatically.
+
+| Path                                                                  | Purpose                                                       |
+| --------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `~/Library/Application Support/crow/devroot`                          | Pointer file containing the development root path            |
+| `~/Library/Application Support/crow/store.json`                       | Persisted sessions, worktrees, links, terminals               |
+| `~/.local/share/crow/crow.sock`                                       | Unix socket for CLI ↔ app IPC                                 |
+| `{devRoot}/.claude/config.json`                                       | Workspace configuration (see below)                          |
+| `{devRoot}/.claude/CLAUDE.md`                                         | Manager-tab context with the `crow` CLI reference             |
+| `{devRoot}/.claude/settings.json`                                     | Pre-approved permissions for Claude Code sessions             |
+| `{devRoot}/.claude/prompts/`                                          | Prompt files used by the `/crow-workspace` skill              |
+| `{devRoot}/.claude/skills/crow-workspace/SKILL.md`                    | Workspace setup skill invoked via `/crow-workspace`           |
+| `{devRoot}/.claude/skills/crow-workspace/setup.sh`                    | Deterministic setup script called by the skill                |
+| `{devRoot}/.claude/skills/crow-review-pr/SKILL.md`                    | PR review skill invoked via `/crow-review-pr`                 |
+| `{devRoot}/.claude/skills/crow-batch-workspace/SKILL.md`              | Batch workspace setup skill                                   |
+| `{devRoot}/crow-reviews/`                                             | Temporary clones used when reviewing PRs                      |
+
+## Workspace Configuration
+
+`{devRoot}/.claude/config.json` describes the workspaces Crow manages and the defaults used when scaffolding new worktrees:
+
+```json
+{
+  "workspaces": [
+    {
+      "id": "uuid",
+      "name": "RadiusMethod",
+      "provider": "github",
+      "cli": "gh",
+      "host": null
+    },
+    {
+      "id": "uuid",
+      "name": "MyGitLab",
+      "provider": "gitlab",
+      "cli": "glab",
+      "host": "gitlab.example.com"
+    }
+  ],
+  "defaults": {
+    "provider": "github",
+    "cli": "gh",
+    "branchPrefix": "feature/",
+    "excludeDirs": ["node_modules", ".git", "vendor", "dist", "build", "target"]
+  }
+}
+```
+
+- **`provider`** — `github` or `gitlab`. Determines which CLI and which issue-tracker code path runs.
+- **`cli`** — `gh` or `glab`. The binary that Crow shells out to.
+- **`host`** — set for self-hosted GitLab; exported as `GITLAB_HOST` when invoking `glab`.
+- **`branchPrefix`** — used by the `/crow-workspace` skill when creating new branches.
+- **`excludeDirs`** — ignored when scanning repos for git worktrees.
+
+## Directory Structure
+
+Crow expects repositories organized under workspace folders:
+
+```
+~/Dev/                             # Development root
+├── RadiusMethod/                  # Workspace (GitHub)
+│   ├── citadel/                   # Main repo checkout
+│   ├── citadel-134-sensor/        # Worktree for issue #134
+│   └── citadel-209-review/        # Worktree for issue #209
+└── MyGitLab/                      # Workspace (GitLab)
+    ├── my-project/
+    └── overrides/
+```
+
+Worktrees are created **at the same level as the main repo**, not in a `worktrees/` subdirectory. The path convention is `{devRoot}/{workspace}/{repo}-{ticketNumber}-{slug}`.
+
+## Environment Variables
+
+| Variable      | Purpose                                                          | Default                        |
+| ------------- | ---------------------------------------------------------------- | ------------------------------ |
+| `CROW_SOCKET` | Override the Unix socket path for CLI ↔ app IPC                  | `~/.local/share/crow/crow.sock` |
+| `TMPDIR`      | Temporary file directory (used by the terminal subsystem)       | System default                 |
+| `GITLAB_HOST` | GitLab instance hostname (set automatically per workspace)      | —                              |
+
+## Session Lifecycle
+
+| State       | Trigger                                                                    | Sidebar indicator                                             |
+| ----------- | -------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `active`    | Created via `/crow-workspace` or `crow new-session`                        | Green dot (or gray / yellow / blue during terminal init)      |
+| `inReview`  | PR opened or manually marked in review                                     | Gold eye icon                                                 |
+| `completed` | PR merged or issue closed (auto-detected), or manual "Mark as Completed"   | Gold checkmark                                                |
+| `archived`  | Manual                                                                     | Gray archive icon                                             |
+| `paused`    | Manual                                                                     | Yellow indicator                                              |
+
+## Terminal Readiness
+
+`TerminalReadiness` (`Packages/CrowCore/Sources/CrowCore/Models/Enums.swift:41`) tracks how far each managed terminal has progressed through startup. The sidebar dot in `Packages/CrowUI/Sources/CrowUI/SessionListView.swift:325-372` reflects the current state:
+
+1. **Gray dot (`uninitialized`)** — `GhosttySurfaceView` exists but `createSurface()` has not been called yet.
+2. **Yellow dot (`surfaceCreated`)** — `ghostty_surface_t` exists, the shell process is spawning.
+3. **Blue dot (`shellReady`)** — Shell prompt detected (probe file appeared).
+4. **Green dot (`claudeLaunched`)** — `claude --continue` has been sent. The dot shows:
+   - Solid green when Claude is idle
+   - Pulsing green when Claude is working
+   - Pulsing orange when Claude is awaiting input
+
+A loading overlay shows "Waiting for terminal..." or "Shell starting..." until `shellReady` is reached.
+
+## Safe Deletion
+
+Deleting a session whose worktree is on a protected branch (`main`, `master`, `develop`) only removes the session metadata — the repo folder and branch are preserved. The delete confirmation dialog reflects this by showing "Remove Session" instead of "Delete Everything".

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,174 @@
+# Getting Started
+
+This guide walks you from a fresh clone to a running Crow app with GitHub (or GitLab) authentication and a scaffolded workspace.
+
+## 1. Clone the Repository
+
+```bash
+git clone --recurse-submodules https://github.com/radiusmethod/crow.git
+cd crow
+```
+
+If you already cloned without `--recurse-submodules`:
+
+```bash
+git submodule update --init vendor/ghostty
+```
+
+## 2. Build
+
+The one-shot build path uses the Makefile:
+
+```bash
+make build
+```
+
+This runs `setup` (initializes submodules and checks prerequisites), `ghostty` (builds the `GhosttyKit` XCFramework with Zig), and `app` (runs `swift build`). The result is two binaries in `.build/debug/`:
+
+- `CrowApp` — the main macOS application
+- `crow` — the CLI used by Claude Code sessions
+
+### Makefile Targets
+
+| Target       | Purpose                                                                       |
+| ------------ | ----------------------------------------------------------------------------- |
+| `build`      | Full build: submodules + ghostty + `swift build` (default)                    |
+| `setup`      | Init submodules and verify build prerequisites (Zig 0.15.2, Metal toolchain)  |
+| `check`      | Verify all build and runtime prerequisites (includes `gh`, `claude`)          |
+| `ghostty`    | Build the `GhosttyKit.xcframework` only                                       |
+| `app`        | Run `swift build` (debug) without touching ghostty                            |
+| `release`    | Release build + `.app` bundle via `scripts/bundle.sh`                         |
+| `sign`       | Sign, create DMG, and notarize (requires `DEVELOPER_ID_APPLICATION`)          |
+| `test`       | Run all package tests                                                         |
+| `clean`      | Remove `.build/` (keeps the ghostty framework)                                |
+| `clean-all`  | Remove `.build/` and `Frameworks/` (full rebuild)                             |
+| `help`       | Print the target list                                                         |
+
+### Advanced / Manual Build
+
+If you need finer-grained control, you can run the individual steps that `make build` orchestrates:
+
+```bash
+# Build the Ghostty framework only (writes Frameworks/GhosttyKit.xcframework)
+./scripts/build-ghostty.sh
+
+# Debug build
+swift build
+
+# Release build
+swift build -c release
+
+# Create the .app bundle from a release build
+./scripts/bundle.sh
+
+# Sign and notarize the bundled .app
+./scripts/sign-and-notarize.sh
+```
+
+**Build troubleshooting:**
+
+- Check Zig: `zig version` must show `0.15.2`
+- Check Metal toolchain: `xcrun -sdk macosx metal --version`
+- Install the Metal toolchain if missing: `xcodebuild -downloadComponent MetalToolchain`
+- If `swift build` fails with linker errors, run `./scripts/build-ghostty.sh` first (or just `make build`)
+
+### Using mise (Optional)
+
+If you have [`mise`](https://mise.jdx.dev) installed, the predefined tasks in `mise.toml` wrap the same operations:
+
+| Task                  | Runs                                       |
+| --------------------- | ------------------------------------------ |
+| `mise dev`            | `swift run CrowApp`                        |
+| `mise build`          | `make build` (full build)                  |
+| `mise build:release`  | `swift build -c release`                   |
+| `mise build:ghostty`  | `bash scripts/build-ghostty.sh`            |
+| `mise test`           | `swift test`                               |
+| `mise bundle`         | `bash scripts/bundle.sh`                   |
+| `mise sign`           | Depends on `bundle`, then sign + notarize  |
+| `mise clean`          | `rm -rf .build .derived-data Crow.app`     |
+| `mise xcode:generate` | `swift package generate-xcodeproj`         |
+
+## 3. GitHub Authentication
+
+Crow uses the `gh` CLI to read issues, PRs, and GitHub Projects (V2) board status, and to **write** project board status (moving tickets to "In Progress" / "In Review") via the `updateProjectV2ItemFieldValue` GraphQL mutation.
+
+```bash
+gh auth login
+gh auth refresh -s project,read:org,repo
+gh auth status   # verify the scopes above are listed
+```
+
+### Required Scopes
+
+| Scope          | Why it's needed                                                                                                                           | Used by                                                                                         |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `repo`         | Read/write issues, PRs, branches, commit statuses                                                                                         | `gh issue view/edit`, `gh pr view/create`, `gh search issues`                                   |
+| `read:org`     | Resolve org membership so `@me` assignee queries work across org repos                                                                    | `gh search issues --assignee @me`                                                               |
+| `project`      | **Read AND write** GitHub Projects V2 board status — required to update Status to "In Progress" / "In Review"                             | `IssueTracker.swift` `updateProjectStatus()`, the `/crow-workspace` skill when starting a session |
+
+> **Important:** `read:project` is **not** sufficient. The in-code error messages will tell you to run `gh auth refresh -s project` — this is the write `project` scope, which is a superset of `read:project`. See `Sources/Crow/App/IssueTracker.swift:691-692` and `:768-769`.
+>
+> If you see `[IssueTracker] GitHub token missing 'project' scope` in stderr or `INSUFFICIENT_SCOPES` from a GraphQL call, re-run `gh auth refresh -s project` and retry.
+
+### Runtime CLI Permissions
+
+Crow shells out to several CLIs at runtime. This table consolidates what each one needs:
+
+| Tool     | Auth / Scopes                                                                          | Notes                                                                              |
+| -------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `gh`     | `repo`, `read:org`, `project` (see above)                                              | Set via `gh auth login` and `gh auth refresh -s project,read:org,repo`             |
+| `glab`   | `api`, `read_user`, `read_repository` (verify for your instance)                       | Only required for GitLab workspaces. Issue/MR reads. Write scopes needed if you expect MR status updates. |
+| `git`    | Local only — no external auth                                                          | Ships with Xcode Command Line Tools                                                |
+| `claude` | No network auth; binary must be on `PATH`                                              | Install from [claude.ai/download](https://claude.ai/download)                      |
+
+## 4. GitLab Authentication (Optional)
+
+If any of your workspaces use self-hosted GitLab:
+
+```bash
+glab auth login --hostname gitlab.example.com
+```
+
+Crow will invoke `glab` with `GITLAB_HOST` set from the workspace config. The app does not enforce specific scopes on the GitLab token; check your instance's documentation for what your user account needs.
+
+## 5. First Launch
+
+```bash
+.build/debug/CrowApp
+```
+
+On first launch, the setup wizard asks for:
+
+1. A **development root** directory (e.g. `~/Dev`) — where Crow scaffolds workspaces and stores worktrees.
+2. One or more **workspaces** — each is a subdirectory under the dev root with a name, provider (`github` or `gitlab`), and (for GitLab) a host.
+
+When you finish the wizard, Crow scaffolds the following under the dev root (see `Sources/Crow/App/Scaffolder.swift`):
+
+```
+{devRoot}/
+├── {workspace}/                      # one directory per workspace
+├── crow-reviews/                     # temporary clones for PR reviews
+└── .claude/
+    ├── CLAUDE.md                     # manager-tab context (crow CLI reference)
+    ├── settings.json                 # pre-approved permissions for crow/gh/git
+    ├── config.json                   # workspace config (workspaces + defaults)
+    ├── prompts/                      # prompt files for crow-workspace sessions
+    └── skills/
+        ├── crow-workspace/           # /crow-workspace skill + setup.sh
+        ├── crow-review-pr/           # /crow-review-pr skill
+        └── crow-batch-workspace/     # /crow-batch-workspace skill
+```
+
+Alternatively, you can scaffold without launching the GUI by running the CLI setup wizard:
+
+```bash
+.build/debug/crow setup            # prompts interactively
+.build/debug/crow setup --dev-root ~/Dev   # skip the devRoot prompt
+```
+
+## Next Steps
+
+- [CLI reference](cli-reference.md) — every `crow` subcommand and its flags
+- [Configuration](configuration.md) — file locations, workspace config schema, directory layout
+- [Architecture](architecture.md) — packages, key components, data flow
+- [Troubleshooting](troubleshooting.md) — common errors and fixes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,58 @@
+# Troubleshooting
+
+## Build Issues
+
+| Problem                                                  | Solution                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `zig` not found                                          | `brew install zig` or download from [ziglang.org](https://ziglang.org/download/) |
+| Zig version mismatch                                     | Version **0.15.2** is required. Check with `zig version`                 |
+| Metal toolchain not found                                | Run `xcodebuild -downloadComponent MetalToolchain`                       |
+| Ghostty submodule missing                                | Run `git submodule update --init vendor/ghostty`                         |
+| `swift build` fails with linker errors                   | Build `GhosttyKit` first: `./scripts/build-ghostty.sh` (or just run `make build`) |
+| `make build` reports "Prerequisites OK" then fails later | Run `make clean-all && make build` to force a full rebuild of `Frameworks/` |
+
+## Runtime Issues
+
+| Problem                                                  | Solution                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `crow` CLI: "Connection refused"                         | The Crow app must be running — the CLI communicates via Unix socket at `~/.local/share/crow/crow.sock` |
+| GitHub API errors / empty issue list                     | Check auth: `gh auth status`. Ensure scopes include `repo`, `read:org`, `project`. If missing, run `gh auth refresh -s project,read:org,repo`. |
+| `INSUFFICIENT_SCOPES` in `[IssueTracker]` stderr         | Run `gh auth refresh -s project`. **`read:project` is NOT sufficient** — the write `project` scope is required to update ticket status via `updateProjectV2ItemFieldValue`. See `Sources/Crow/App/IssueTracker.swift:691-692,768-769`. |
+| Ticket stays "Backlog" when starting a session           | Same as above — the `markInReview` code path requires the write `project` scope |
+| Terminal not starting                                    | Check stderr for `[TerminalManager]` or `[Ghostty]` messages             |
+| Issue tracker shows no tickets                           | Verify `gh auth status` shows `repo`, `read:org`, `project` scopes       |
+| GitLab tickets missing                                   | Run `glab auth status --hostname <your-host>`; ensure `GITLAB_HOST` matches what's in `{devRoot}/.claude/config.json` |
+| Sidebar status dot stuck gray                            | Terminal never initialized — click the session tab to trigger `createSurface()` |
+| Sidebar status dot stuck yellow                          | Shell is spawning but the probe file never appeared. Check `[TerminalManager]` logs for shell-startup errors |
+
+## Debugging
+
+The app logs diagnostic information to stderr with component tags:
+
+- `[TerminalManager]` — Surface creation, shell readiness transitions
+- `[SessionService]` — Orphan detection, session lifecycle changes
+- `[IssueTracker]` — GitHub/GitLab API errors, scope issues, project status queries
+- `[JSONStore]` — Decode failures (store data loss prevention)
+- `[Ghostty]` — Surface creation success/failure
+- `[AppSupportDirectory]` — One-time `rm-ai-ide` → `crow` migration events
+- `[Scaffolder]` — Template file loading (development builds)
+
+Run with log filtering to focus on a subsystem:
+
+```bash
+.build/debug/CrowApp 2>&1 | grep '\[TerminalManager\]\|\[SessionService\]'
+```
+
+Filter for scope / auth errors while you're iterating on `gh` permissions:
+
+```bash
+.build/debug/CrowApp 2>&1 | grep '\[IssueTracker\]'
+```
+
+## Quarantine Warnings on an Unsigned Build
+
+Developers building from source do not need a signing certificate — `make build` and `make release` produce unsigned but fully functional binaries. If macOS quarantines an unsigned `.app`, remove the quarantine attribute:
+
+```bash
+xattr -cr Crow.app
+```


### PR DESCRIPTION
Closes radiusmethod/crow#154

## Summary

- Promotes `make build` to the default Quick Start path (was walking users through `./scripts/build-ghostty.sh` + `swift build` manually)
- Corrects the GitHub auth guidance: the **write** `project` scope is required (not `read:project`) because `IssueTracker.markInReview` calls the `updateProjectV2ItemFieldValue` mutation — users following the old instructions hit `INSUFFICIENT_SCOPES` the first time a ticket moved to In Progress
- Splits long reference material into a new `docs/` directory so the README can focus on overview + getting started

## New docs

| File | Covers |
|---|---|
| `docs/getting-started.md` | Clone, `make build` (+ all Makefile targets), advanced/manual fallback, correct GitHub scopes, CLI permissions table (`gh`/`glab`/`git`/`claude`), all 9 `mise.toml` tasks, first-launch wizard aligned with `Scaffolder.swift` |
| `docs/cli-reference.md` | Every subcommand from `Packages/CrowCLI/Sources/CrowCLILib/Commands/*.swift` — including the previously-missing `setup`, `close-terminal`, and the `--managed`/`--command` flags on `new-terminal` |
| `docs/architecture.md` | Full 9-package tree, `Sources/CrowCLI` vs `Packages/CrowCLI` split, key components with file paths, `markInReview` data flow |
| `docs/configuration.md` | File locations verified against `AppSupportDirectory.swift`, 4-state `TerminalReadiness` tied to `CrowCore/Models/Enums.swift:41` and `SessionListView.swift:325-372` |
| `docs/troubleshooting.md` | Build + runtime tables; new row for `INSUFFICIENT_SCOPES` pointing at `IssueTracker.swift:691-692,768-769` |

## README changes

- Replaced manual build steps with `make build`
- Replaced `gh auth refresh -s read:project` with `gh auth refresh -s project,read:org,repo`
- Added a callout about `read:project` being insufficient
- Moved Detailed Setup, Architecture, Configuration, CLI Reference, Development, and Troubleshooting sections into `docs/`
- Left Features, Contributing, Releases, and License in place

## CLAUDE.md changes

- Added `close-terminal` to the Terminal Commands list
- Added the `--managed` flag to `new-terminal`

Keeps the Manager-tab CLI reference in sync with `Packages/CrowCLI`.

## Acceptance criteria from crow#154

- [x] README Quick Start uses `make build` as the primary build path
- [x] Makefile targets documented (table in `docs/getting-started.md`)
- [x] GitHub auth section lists correct scopes (`repo`, `read:org`, `project`) and exact `gh auth refresh` command
- [x] Troubleshooting note clarifying that `read:project` is insufficient
- [x] CLI tool permissions (`gh`, `glab`, `git`, `claude`) documented in one place
- [x] `mise.toml` tasks in docs match actual file (all 9 listed)
- [x] CLI reference matches `Packages/CrowCLI` source
- [x] Directory structure, file locations, session lifecycle, and terminal readiness verified against current code

## Test plan

- [ ] From a scratch clone, run just `make build` per the new Quick Start and confirm it produces `.build/debug/CrowApp` and `.build/debug/crow`
- [ ] Run `gh auth refresh -s project,read:org,repo` and confirm `gh auth status` lists `project` (not `read:project`)
- [ ] Move a ticket to In Progress via a session and confirm no `INSUFFICIENT_SCOPES` in `[IssueTracker]` stderr
- [ ] Confirm every relative link from `README.md` → `docs/*.md` resolves in the rendered PR view
- [ ] Spot-check `crow <cmd> --help` against `docs/cli-reference.md` for 2-3 subcommands (e.g. `add-worktree`, `new-terminal`, `set-ticket`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)