### PR TITLE
Fix batch "Work on" sending malformed /crow-batch-workspace line

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -190,10 +190,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.onBatchWorkOnIssues = { [weak self] issueURLs in
             guard let self, let managerTerminals = self.appState.terminals[AppState.managerSessionID],
                   let managerTerminal = managerTerminals.first else { return }
-            let urls = issueURLs.joined(separator: "\n")
+            let urls = issueURLs.joined(separator: " ")
             TerminalManager.shared.send(
                 id: managerTerminal.id,
-                text: "/crow-batch-workspace\n\(urls)\n"
+                text: "/crow-batch-workspace \(urls)\n"
             )
             self.appState.selectedSessionID = AppState.managerSessionID
         }


### PR DESCRIPTION
## Summary
- The batch "Work on" handler in `AppDelegate.onBatchWorkOnIssues` joined URLs with `\n` and placed them under the command with a leading `\n`. Because `TerminalManager.send` converts each `\n` into a Return keypress (see `GhosttySurfaceView.writeText`), `/crow-batch-workspace` submitted immediately with no arguments and each URL then ran as its own invalid command.
- Fix joins URLs with spaces and puts them on the same line as the command, with a single trailing `\n` that submits exactly once — mirroring the single-issue handler at `AppDelegate.swift:183`.

Closes #160

## Test plan
- [x] `make build` succeeds
- [ ] Select multiple issues in the tracker → batch "Work on" → Manager terminal shows one line: `/crow-batch-workspace <url1> <url2> ...` and the `/crow-batch-workspace` skill begins resolution
- [ ] Single-issue "Work on" still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)