### PR TITLE
Silence noisy console logs from Ghostty and IssueTracker

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -102,6 +102,10 @@ public final class AppState {
     /// Runtime dependencies that were not found at startup (e.g., "gh", "git", "claude").
     public var missingDependencies: [String] = []
 
+    /// Non-fatal GitHub auth warning surfaced in Settings. `nil` means no warning.
+    /// Set by `IssueTracker` when the token lacks a required scope; cleared on next success.
+    public var githubScopeWarning: String?
+
     /// Terminal readiness state per terminal ID.
     public var terminalReadiness: [UUID: TerminalReadiness] = [:]
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
@@ -87,12 +87,20 @@ public final class GhosttyApp {
         }
     }
 
+    /// Raw action tags that fire constantly during normal focus/scroll/tab-switch.
+    /// GhosttyKit is a precompiled xcframework, so the enum names aren't available
+    /// in Swift — we silence by raw value. Unknown tags still log so new actions
+    /// remain discoverable.
+    nonisolated private static let silencedActionTags: Set<UInt32> = [26, 32, 36, 56]
+
     nonisolated static func handleAction(
         app: ghostty_app_t?,
         target: ghostty_target_s,
         action: ghostty_action_s
     ) -> Bool {
-        NSLog("[GhosttyApp] Unhandled action: tag=\(action.tag)")
+        if !silencedActionTags.contains(UInt32(action.tag.rawValue)) {
+            NSLog("[GhosttyApp] Unhandled action: tag=\(action.tag)")
+        }
         return false
     }
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -7,6 +7,7 @@ import CrowCore
 /// and Notifications (global + per-event config). Every change is persisted immediately
 /// via the `onSave` callback — there is no explicit "Apply" button.
 public struct SettingsView: View {
+    let appState: AppState
     @State var devRoot: String
     @State var config: AppConfig
     @State private var isAddingWorkspace = false
@@ -15,9 +16,10 @@ public struct SettingsView: View {
     public var onSave: ((String, AppConfig) -> Void)?
     public var onRescaffold: ((String) -> Void)?
 
-    public init(devRoot: String, config: AppConfig,
+    public init(appState: AppState, devRoot: String, config: AppConfig,
                 onSave: ((String, AppConfig) -> Void)? = nil,
                 onRescaffold: ((String) -> Void)? = nil) {
+        self.appState = appState
         self._devRoot = State(initialValue: devRoot)
         self._config = State(initialValue: config)
         self.onSave = onSave
@@ -64,8 +66,28 @@ public struct SettingsView: View {
 
     // MARK: - General Tab
 
+    @ViewBuilder
+    private var githubScopeWarningBanner: some View {
+        if let warning = appState.githubScopeWarning {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(warning)
+                    .font(.caption)
+                    .textSelection(.enabled)
+                Spacer()
+            }
+            .padding(10)
+            .background(Color.orange.opacity(0.12))
+            .cornerRadius(6)
+        }
+    }
+
     private var generalTab: some View {
         Form {
+            if appState.githubScopeWarning != nil {
+                Section { githubScopeWarningBanner }
+            }
             Section("Development Root") {
                 HStack {
                     TextField("Path", text: $devRoot)

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -357,6 +357,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let settingsView = SettingsView(
+            appState: appState,
             devRoot: devRoot,
             config: appConfig,
             onSave: { [weak self] newDevRoot, newConfig in

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -18,6 +18,10 @@ final class IssueTracker {
     private var previousReviewRequestIDs: Set<String> = []
     private var isFirstFetch = true
 
+    /// Guards the GitHub-scope console warning so it fires once per session.
+    /// Reset by `clearScopeWarning()` when a subsequent poll succeeds.
+    private var didLogGitHubScopeWarning = false
+
     init(appState: AppState) {
         self.appState = appState
     }
@@ -37,6 +41,25 @@ final class IssueTracker {
     func stop() {
         timer?.invalidate()
         timer = nil
+    }
+
+    /// Surface a missing-scope warning: console once per session, UI banner every time.
+    private func reportScopeWarning(_ scope: String) {
+        let msg = "GitHub token missing '\(scope)' scope — run 'gh auth refresh -s \(scope)'"
+        if !didLogGitHubScopeWarning {
+            print("[IssueTracker] \(msg)")
+            didLogGitHubScopeWarning = true
+        }
+        appState.githubScopeWarning = msg
+    }
+
+    /// Drop the warning after a successful poll. Re-arms the once-per-session log
+    /// so a future regression will print again.
+    private func clearScopeWarning() {
+        if appState.githubScopeWarning != nil {
+            appState.githubScopeWarning = nil
+        }
+        didLogGitHubScopeWarning = false
     }
 
     func refresh() async {
@@ -598,7 +621,7 @@ final class IssueTracker {
             )
             if testResult.exitCode != 0 {
                 if testResult.stderr.contains("INSUFFICIENT_SCOPES") || testResult.stderr.contains("read:project") {
-                    print("[IssueTracker] GitHub token missing 'read:project' scope — run 'gh auth refresh -s read:project'")
+                    reportScopeWarning("read:project")
                 } else {
                     print("[IssueTracker] GraphQL project status query failed (exit \(testResult.exitCode)): \(testResult.stderr.prefix(200))")
                 }
@@ -643,6 +666,8 @@ final class IssueTracker {
                 }
             }
         }
+
+        clearScopeWarning()
     }
 
     // MARK: - Mark In Review
@@ -701,7 +726,7 @@ final class IssueTracker {
 
         if queryResult.exitCode != 0 {
             if queryResult.stderr.contains("INSUFFICIENT_SCOPES") || queryResult.stderr.contains("read:project") || queryResult.stderr.contains("project") {
-                print("[IssueTracker] GitHub token missing 'project' scope — run 'gh auth refresh -s project'")
+                reportScopeWarning("project")
             } else {
                 print("[IssueTracker] GraphQL query failed: \(queryResult.stderr.prefix(200))")
             }
@@ -778,7 +803,7 @@ final class IssueTracker {
 
         if mutationResult.exitCode != 0 {
             if mutationResult.stderr.contains("INSUFFICIENT_SCOPES") {
-                print("[IssueTracker] GitHub token missing 'project' scope — run 'gh auth refresh -s project'")
+                reportScopeWarning("project")
             } else {
                 print("[IssueTracker] Failed to update project status: \(mutationResult.stderr.prefix(200))")
             }


### PR DESCRIPTION
## Summary
- `GhosttyApp.handleAction` now silences raw tag values `26, 32, 36, 56` — the ones that fire constantly during window focus, scroll, and tab-switch. Unknown tags still log so new Ghostty bindings remain discoverable.
- `IssueTracker` scope warnings now log once per session (guarded by an instance flag), clear on a subsequent successful poll, and surface to the UI via a new `AppState.githubScopeWarning`.
- `SettingsView` accepts `AppState` and renders an orange scope-warning banner at the top of the General tab when a warning is set. Message is selectable so users can copy the `gh auth refresh` command.

Closes #158

## Test plan
- [ ] Revoke `read:project` via `gh auth refresh -s "repo,read:org"` (omit project scopes); relaunch Crow.
- [ ] Leave the app running ≥3 poll cycles (~3 min); confirm only **one** `[IssueTracker] GitHub token missing 'read:project' scope …` line in the console.
- [ ] Open Settings (Cmd+,) → General; confirm the orange banner renders at the top with the fix command, and the text is copy-selectable.
- [ ] Run `gh auth refresh -s project -s read:project`; wait one poll cycle; reopen Settings and confirm the banner is gone.
- [ ] Trigger a subsequent scope regression and confirm the console re-logs exactly once (log-once flag reset).
- [ ] Open a terminal session; switch tabs, scroll, drag/focus between windows for ~30s; confirm no `[GhosttyApp] Unhandled action: tag=(26|32|36|56)` lines.
- [ ] Confirm any genuinely new unhandled tag still logs (i.e. unknowns remain discoverable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)