### PR TITLE
Log gh stderr on IssueTracker shell failures

### DIFF
--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -362,19 +362,30 @@ final class IssueTracker {
 
     private func shellSync(_ args: String...) throws -> String {
         let process = Process()
-        let pipe = Pipe()
+        let outPipe = Pipe()
+        let errPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = args
         process.environment = ShellEnvironment.shared.env
-        process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
         try process.run()
         process.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
         guard process.terminationStatus == 0 else {
-            throw NSError(domain: "IssueTracker", code: Int(process.terminationStatus))
+            let stderr = (String(data: errData, encoding: .utf8) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let cmd = args.joined(separator: " ")
+            let desc = "`\(cmd)` exited \(process.terminationStatus)"
+                + (stderr.isEmpty ? "" : ": \(stderr)")
+            throw NSError(
+                domain: "IssueTracker",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: desc]
+            )
         }
-        return String(data: data, encoding: .utf8) ?? ""
+        return String(data: outData, encoding: .utf8) ?? ""
     }
 
     // MARK: - PR Status Enrichment
@@ -917,21 +928,32 @@ final class IssueTracker {
         let env = env
         return try await Task.detached {
             let process = Process()
-            let pipe = Pipe()
+            let outPipe = Pipe()
+            let errPipe = Pipe()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
             process.arguments = args
             process.environment = env.isEmpty
                 ? ShellEnvironment.shared.env
                 : ShellEnvironment.shared.merging(env)
-            process.standardOutput = pipe
-            process.standardError = Pipe()
+            process.standardOutput = outPipe
+            process.standardError = errPipe
             try process.run()
             process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
             guard process.terminationStatus == 0 else {
-                throw NSError(domain: "IssueTracker", code: Int(process.terminationStatus))
+                let stderr = (String(data: errData, encoding: .utf8) ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let cmd = args.joined(separator: " ")
+                let desc = "`\(cmd)` exited \(process.terminationStatus)"
+                    + (stderr.isEmpty ? "" : ": \(stderr)")
+                throw NSError(
+                    domain: "IssueTracker",
+                    code: Int(process.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: desc]
+                )
             }
-            return String(data: data, encoding: .utf8) ?? ""
+            return String(data: outData, encoding: .utf8) ?? ""
         }.value
     }
 


### PR DESCRIPTION
## Summary
- `IssueTracker.shell()` and `shellSync()` now capture `gh` stderr and embed it in the thrown `NSError` via `NSLocalizedDescriptionKey`, so existing `print("... failed: \(error)")` call sites render the real failure cause instead of `Code=1 "(null)"`.
- Fix applies uniformly to all 9 polling call sites (GitHub issues/PRs/project statuses, PR/issue close checks, GitLab issues) with no call-site edits.
- Bonus `gh auth` failure → one-time notification is deferred per plan — log-first, then target the follow-up once real stderr patterns are known.

Closes #170

## Test plan
- [x] `make build` succeeds.
- [ ] Trigger a controlled `gh` failure (e.g. temporarily move `~/.config/gh`), wait for a poll cycle, confirm `[IssueTracker] ... failed:` lines include the real stderr (`HTTP 401`, `authentication required`, etc.).
- [ ] Restore auth, confirm steady-state polling is clean with no spurious error logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)