### PR TITLE
Make TicketCard issue and PR chips clickable

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/LinkChip.swift
+++ b/Packages/CrowUI/Sources/CrowUI/LinkChip.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import CrowCore
+
+/// Clickable capsule that opens a URL (issue link, PR link, repo link).
+struct LinkChip: View {
+    let label: String
+    let url: String
+    let icon: String
+
+    var body: some View {
+        Button {
+            if let nsURL = URL(string: url) {
+                NSWorkspace.shared.open(nsURL)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.caption)
+                Text(label)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+            .foregroundStyle(CorveilTheme.gold)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(CorveilTheme.gold.opacity(0.1))
+            .overlay(
+                Capsule().strokeBorder(CorveilTheme.goldDark.opacity(0.3), lineWidth: 1)
+            )
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -356,38 +356,6 @@ struct StatusBadge: View {
     }
 }
 
-/// Clickable capsule that opens a URL (issue link, PR link, repo link).
-struct LinkChip: View {
-    let label: String
-    let url: String
-    let icon: String
-
-    var body: some View {
-        Button {
-            if let nsURL = URL(string: url) {
-                NSWorkspace.shared.open(nsURL)
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: icon)
-                    .font(.caption)
-                Text(label)
-                    .font(.caption)
-                    .fontWeight(.medium)
-            }
-            .foregroundStyle(CorveilTheme.gold)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(CorveilTheme.gold.opacity(0.1))
-            .overlay(
-                Capsule().strokeBorder(CorveilTheme.goldDark.opacity(0.3), lineWidth: 1)
-            )
-            .clipShape(Capsule())
-        }
-        .buttonStyle(.plain)
-    }
-}
-
 // MARK: - Readiness-Aware Terminal Wrapper
 
 /// Wraps a TerminalSurfaceView with readiness tracking.

--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -404,13 +404,18 @@ struct TicketCard: View {
                         .font(.caption)
                         .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textSecondary)
 
-                    Text("#\(String(issue.number))")
-                        .font(.system(size: 12, weight: .medium))
-                        .monospacedDigit()
-                        .foregroundStyle(isDone ? CorveilTheme.textMuted : CorveilTheme.textPrimary)
+                    LinkChip(
+                        label: "Issue #\(String(issue.number))",
+                        url: issue.url,
+                        icon: "link"
+                    )
 
-                    if let prNum = issue.prNumber {
-                        ticketPRBadge(number: prNum, url: issue.prURL)
+                    if let prNum = issue.prNumber, let prURL = issue.prURL {
+                        LinkChip(
+                            label: "PR #\(String(prNum))",
+                            url: prURL,
+                            icon: "arrow.triangle.pull"
+                        )
                     }
 
                     Spacer()
@@ -491,22 +496,6 @@ struct TicketCard: View {
             .font(.system(size: 18))
             .foregroundStyle(isSelected ? CorveilTheme.gold : CorveilTheme.textMuted.opacity(0.4))
             .opacity(isSelectable ? 1.0 : 0.3)
-    }
-
-    private func ticketPRBadge(number: Int, url: String?) -> some View {
-        HStack(spacing: 3) {
-            Image(systemName: "arrow.triangle.pull")
-                .font(.caption2)
-            Text("PR #\(String(number))")
-                .font(.caption2)
-                .fontWeight(.medium)
-        }
-        .foregroundStyle(.purple)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
-        .background(.purple.opacity(0.1))
-        .overlay(Capsule().strokeBorder(Color.purple.opacity(0.3), lineWidth: 0.5))
-        .clipShape(Capsule())
     }
 
     private var labelRow: some View {


### PR DESCRIPTION
## Summary

- Extract `LinkChip` from `SessionDetailView.swift` into its own file so it can be reused beyond the session header.
- Replace the static purple `ticketPRBadge` and the plain `#N` issue-number text in `TicketCard` with gold `LinkChip`s — every row now has a clickable **Issue #N** chip, and rows with a linked PR also show a **PR #N** chip. Both open the URL in the default browser, matching the session-header interaction.

Closes #171

## Test plan

- [x] `make build` succeeds
- [x] Open the ticket board: every row shows an **Issue #N** chip; rows with a linked PR also show a **PR #N** chip
- [x] Click **Issue #N** → opens the issue in the default browser
- [x] Click **PR #N** → opens the PR in the default browser
- [x] Rows without a linked PR show only the issue chip (no dead PR chip)
- [x] Chip styling matches the session-header chips (gold capsule, same icons)
- [x] Session detail view still renders Issue / PR / Repo chips correctly (regression check on the LinkChip move)

🤖 Generated with [Claude Code](https://claude.com/claude-code)