### PR TITLE
CI: warm Ghostty cache on main so PRs share it

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,46 @@
+name: Cache Warm
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: cache-warm-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ZIG_VERSION: '0.15.2'
+
+jobs:
+  warm-ghostty:
+    name: Warm Ghostty Cache
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16"
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Get Ghostty submodule SHA
+        id: ghostty-sha
+        run: echo "sha=$(git -C vendor/ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Ghostty framework
+        id: ghostty-cache
+        uses: actions/cache@v4
+        with:
+          path: Frameworks
+          key: ghostty-${{ runner.os }}-${{ runner.arch }}-${{ steps.ghostty-sha.outputs.sha }}
+
+      - name: Build Ghostty
+        if: steps.ghostty-cache.outputs.cache-hit != 'true'
+        run: |
+          unset ZIG_LOCAL_CACHE_DIR ZIG_GLOBAL_CACHE_DIR
+          make ghostty


### PR DESCRIPTION
Closes #177

## Summary
- Add `.github/workflows/cache-warm.yml` triggered on `push: main` that does checkout → setup-xcode → setup-zig → `actions/cache` lookup → `make ghostty` (guarded by `cache-hit != 'true'`). No `swift build` / tests.
- Uses the same cache key literal as `ci.yml` / `release.yml` (`ghostty-${runner.os}-${runner.arch}-${submodule-sha}`) so PRs and tag releases start hitting the warm slot automatically via the default-branch fallback.
- `concurrency: cancel-in-progress: false` so an in-flight real Ghostty build isn't killed by a later merge. No path filter — unchanged-SHA runs are ~1 min cache-hit no-ops anyway.

## Why option 2 (dedicated workflow) over adding `push: main` to `ci.yml`
Avoids re-running the full Build & Test matrix on every merge. When `vendor/ghostty` hasn't changed since the last warm, the job is effectively a no-op.

## Test plan
- [ ] After merge, confirm the "Cache Warm" run on `main` completes and its "Cache Ghostty framework" post-job step logs a cache write for `ghostty-macOS-ARM64-<sha>`.
- [ ] Open a follow-up PR (no Ghostty submodule bump) and verify its "Cache Ghostty framework" step reports `cache-hit: true` and "Build Ghostty" is skipped.
- [ ] Push a docs-only commit to `main` and confirm "Cache Warm" finishes in ~1 min with a cache hit (no new cache entry created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)