### PR TITLE
Ignore subagent hook events fired after a turn's Stop (#199)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -353,6 +353,12 @@ public final class SessionHookState {
     public var lastToolActivity: ToolActivity?
     public var hookEvents: [HookEvent] = []
     public var analytics: SessionAnalytics?
+    /// Timestamp of the most recent top-level Stop / StopFailure for this session.
+    /// Used to suppress state elevation from background activity (e.g. the
+    /// `awaySummaryEnabled` recap subagent in Claude Code ≥ 2.1.108) that
+    /// fires after the user's turn has ended. Cleared on the next
+    /// UserPromptSubmit, which marks the start of a new real turn.
+    public var lastTopLevelStopAt: Date?
 
     public init() {}
 }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -468,6 +468,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let capturedNotifManager = notificationManager
         let capturedService = sessionService
         let capturedTelemetryPort = sessionService.telemetryPort
+        let hookDebug = ProcessInfo.processInfo.environment["CROW_HOOK_DEBUG"] == "1"
 
         let router = CommandRouter(handlers: [
             "new-session": { @Sendable params in
@@ -809,6 +810,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 let payload = params["payload"]?.objectValue ?? [:]
 
+                if hookDebug {
+                    let shortID = String(sessionIDStr.prefix(8))
+                    let keys = payload.keys.sorted().joined(separator: ",")
+                    NSLog("[hook-event] session=\(shortID) event=\(eventName) payload-keys=[\(keys)]")
+                }
+
                 // Build a human-readable summary from the event
                 let summary: String = {
                     switch eventName {
@@ -858,6 +865,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                 return await MainActor.run {
                     let state = capturedAppState.hookState(for: sessionID)
+                    let stateBefore = state.claudeState
 
                     // Append to ring buffer (keep last 50 events per session)
                     state.hookEvents.append(event)
@@ -931,13 +939,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                     case "UserPromptSubmit":
                         state.claudeState = .working
+                        // A new real turn has begun — clear the post-Stop guard so
+                        // legitimate subagents in this turn can elevate state again.
+                        state.lastTopLevelStopAt = nil
 
                     case "Stop":
                         state.claudeState = .done
                         state.lastToolActivity = nil
+                        state.lastTopLevelStopAt = Date()
 
                     case "StopFailure":
                         state.claudeState = .waiting
+                        state.lastTopLevelStopAt = Date()
 
                     case "SessionStart":
                         let source = payload["source"]?.stringValue ?? "startup"
@@ -946,17 +959,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         } else {
                             state.claudeState = .idle
                         }
+                        state.lastTopLevelStopAt = nil
 
                     case "SessionEnd":
                         state.claudeState = .idle
                         state.lastToolActivity = nil
+                        state.lastTopLevelStopAt = nil
 
                     case "SubagentStart":
-                        state.claudeState = .working
+                        // If a top-level Stop has already fired for this turn, the
+                        // subagent is background work (e.g. the recap generator from
+                        // Claude Code ≥ 2.1.108's awaySummaryEnabled feature). Don't
+                        // elevate state — the user is genuinely done.
+                        if state.lastTopLevelStopAt == nil {
+                            state.claudeState = .working
+                        }
 
                     case "TaskCreated", "TaskCompleted", "SubagentStop":
-                        // Stay in working state
-                        if state.claudeState != .waiting {
+                        // Stay in working state, but only while the turn is still live.
+                        // After a top-level Stop, treat these as background activity
+                        // and leave claudeState alone.
+                        if state.claudeState != .waiting && state.lastTopLevelStopAt == nil {
                             state.claudeState = .working
                         }
 
@@ -976,6 +999,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         payload: payload,
                         summary: summary
                     )
+
+                    if hookDebug && state.claudeState != stateBefore {
+                        let shortID = String(sessionIDStr.prefix(8))
+                        NSLog("[hook-event] session=\(shortID) event=\(eventName) state=\(stateBefore.rawValue)→\(state.claudeState.rawValue)")
+                    }
 
                     return [
                         "received": .bool(true),

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,6 +24,7 @@
 | GitLab tickets missing                                   | Run `glab auth status --hostname <your-host>`; ensure `GITLAB_HOST` matches what's in `{devRoot}/.claude/config.json` |
 | Sidebar status dot stuck gray                            | Terminal never initialized — click the session tab to trigger `createSurface()` |
 | Sidebar status dot stuck yellow                          | Shell is spawning but the probe file never appeared. Check `[TerminalManager]` logs for shell-startup errors |
+| Sidebar shows "working" forever after a `※ recap:` line  | The Claude Code session recap (`awaySummaryEnabled`, on by default in v2.1.108+) fires hook events after a turn's `Stop`. Crow now ignores those — if you're on an older build, disable the recap by setting `"awaySummaryEnabled": false` in `~/.claude/settings.json`, toggling "Session recap" off via `/config` inside Claude Code, or exporting `CLAUDE_CODE_ENABLE_AWAY_SUMMARY=0`. |
 
 ## Debugging
 
@@ -36,6 +37,7 @@ The app logs diagnostic information to stderr with component tags:
 - `[Ghostty]` — Surface creation success/failure
 - `[AppSupportDirectory]` — One-time `rm-ai-ide` → `crow` migration events
 - `[Scaffolder]` — Template file loading (development builds)
+- `[hook-event]` — Claude Code hook event arrivals and `ClaudeState` transitions. Off by default. Set `CROW_HOOK_DEBUG=1` before launching to enable; useful when diagnosing why the sidebar status dot is in the wrong state.
 
 Run with log filtering to focus on a subsystem:
 


### PR DESCRIPTION
## Summary

Fixes #199. Claude Code 2.1.108's `awaySummaryEnabled` "session recap" generates a `SubagentStop` hook event ~minutes after the user's turn has ended. Crow's old `TaskCreated, TaskCompleted, SubagentStop` arm unconditionally drove `claudeState` back to `.working`, trapping the sidebar dot until session end.

The fix tracks `lastTopLevelStopAt: Date?` on `SessionHookState`. When set, the dispatcher suppresses state elevation in the `SubagentStart` and `TaskCreated/TaskCompleted/SubagentStop` arms — those events are treated as background. The flag is cleared on `UserPromptSubmit` (next real turn), `SessionStart`, and `SessionEnd`, so legitimate mid-turn subagents (`/explore`, sub-tasks, etc.) are unaffected.

This generalizes beyond recap: any future "Claude wakes up after a turn ends" scenario (background telemetry, async cleanup hooks) will be correctly ignored.

## Evidence the fix works

Captured with the new `CROW_HOOK_DEBUG=1` flag during a real session that produced a recap:

```
16:22:32  UserPromptSubmit  state=done→working      ← turn begins
16:22:45  Stop              state=working→done      ← lastTopLevelStopAt set
16:23:45  Notification      (no state change)
16:25:48  SubagentStop      payload=[agent_id, agent_transcript_path, agent_type, …]
          ↑ NO state-change line — guard suppressed it
```

Pre-fix: that `SubagentStop` would drive `done → working` and never recover. Post-fix: `lastTopLevelStopAt != nil`, so `claudeState` stays at `.done`. A separate session that was actively mid-turn during the same capture window correctly kept its state at `.working` while running `TaskCreated`/`TaskCompleted` events, confirming the guard is scoped to post-`Stop`.

## Why hook events, not terminal text

Per the ticket: text-pattern matching `※ recap:` would rot the next time Claude Code changes the recap glyph or copy. The fix lives in the hook dispatcher where the actual lifecycle bug is.

## Also included

- `CROW_HOOK_DEBUG=1`-gated `[hook-event]` NSLog stream — logs every event arrival + every `ClaudeState` transition. Off by default. Kept in for the next time Claude Code's hook schema shifts (it changes often). Documented in `docs/troubleshooting.md`.
- Troubleshooting docs row covering the user-side workaround for older builds (`awaySummaryEnabled = false` / `/config` / `CLAUDE_CODE_ENABLE_AWAY_SUMMARY=0`).

## Test plan

- [x] All 31 existing tests pass (`make test`)
- [x] Reproduced original bug behavior would have triggered (`SubagentStop` arrives 3 min after user-turn `Stop`)
- [x] Confirmed sidebar stays at done after recap renders
- [x] Confirmed mid-turn subagents still elevate state to working (regression check on a separate session in the same capture window)
- [ ] Reviewer: try a session with `/explore` or another subagent-heavy slash command — sidebar should still show working during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)