### PR TITLE
Fix GitLab fetch failing on GITLAB_HOST mismatch

### DIFF
--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -91,9 +91,9 @@ public actor ProviderManager {
             }
             let repoSlug = "\(parsed.org)/\(parsed.repo)"
             if parsed.isMR {
-                output = try await shell(env: env, "glab", "mr", "view", "\(parsed.number)", "--repo", repoSlug)
+                output = try await shell(env: env, cwd: NSHomeDirectory(), "glab", "mr", "view", "\(parsed.number)", "--repo", repoSlug)
             } else {
-                output = try await shell(env: env, "glab", "issue", "view", "\(parsed.number)", "--repo", repoSlug)
+                output = try await shell(env: env, cwd: NSHomeDirectory(), "glab", "issue", "view", "\(parsed.number)", "--repo", repoSlug)
             }
         }
 
@@ -122,7 +122,7 @@ public actor ProviderManager {
         return output.components(separatedBy: .newlines).first
     }
 
-    private func shell(env: [String: String] = [:], _ args: String...) async throws -> String {
+    private func shell(env: [String: String] = [:], cwd: String? = nil, _ args: String...) async throws -> String {
         let process = Process()
         let pipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -130,6 +130,7 @@ public actor ProviderManager {
         process.environment = env.isEmpty
             ? ShellEnvironment.shared.env
             : ShellEnvironment.shared.merging(env)
+        if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
         process.standardOutput = pipe
         process.standardError = pipe
         try process.run()

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -1144,7 +1144,7 @@ final class IssueTracker {
 
             let output: String
             do {
-                output = try await shell(env: ["GITLAB_HOST": host], "glab", "api", endpoint)
+                output = try await shell(env: ["GITLAB_HOST": host], cwd: NSHomeDirectory(), "glab", "api", endpoint)
             } catch {
                 print("[IssueTracker] Reconcile glab api failed for \(candidate.repoSlug)#\(candidate.branch) on \(host): \(error.localizedDescription.prefix(200))")
                 continue
@@ -1553,6 +1553,7 @@ final class IssueTracker {
         do {
             output = try await shell(
                 env: ["GITLAB_HOST": host],
+                cwd: NSHomeDirectory(),
                 "glab", "issue", "list", "-a", "@me", "--output-format", "json"
             )
         } catch {
@@ -1736,14 +1737,15 @@ final class IssueTracker {
 
     // MARK: - Shell
 
-    private func shell(env: [String: String] = [:], _ args: String...) async throws -> String {
-        return try await shell(env: env, args: args)
+    private func shell(env: [String: String] = [:], cwd: String? = nil, _ args: String...) async throws -> String {
+        return try await shell(env: env, cwd: cwd, args: args)
     }
 
-    private func shell(env: [String: String] = [:], args: [String]) async throws -> String {
+    private func shell(env: [String: String] = [:], cwd: String? = nil, args: [String]) async throws -> String {
         currentRefreshGhCalls += 1
         let args = args
         let env = env
+        let cwd = cwd
         return try await Task.detached {
             let process = Process()
             let outPipe = Pipe()
@@ -1753,6 +1755,7 @@ final class IssueTracker {
             process.environment = env.isEmpty
                 ? ShellEnvironment.shared.env
                 : ShellEnvironment.shared.merging(env)
+            if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
             process.standardOutput = outPipe
             process.standardError = errPipe
             try process.run()


### PR DESCRIPTION
## Summary

- `glab` refused to run when Crow's inherited CWD was a git repo whose remote didn't match `GITLAB_HOST`, aborting `IssueTracker.fetchGitLabIssues` and three sibling glab calls.
- Fix: add an optional `cwd:` parameter to the shell helpers in `IssueTracker` and `ProviderManager`, and invoke `glab` from `NSHomeDirectory()` so its auto-detection finds no conflicting remotes.

## Test plan

- [x] `make build` (clean)
- [x] `swift test` for top-level (31/31 passing) and `CrowProvider` package (25/25 passing)
- [ ] Manual: launch Crow with at least one GitLab workspace configured while the app's CWD is a GitHub-only repo; verify assigned GitLab issues now render in the sidebar and the `fetchGitLabIssues(host:) failed:` log line no longer appears.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)