### PR TITLE
Add filtering for tickets list

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -104,6 +104,7 @@ public final class AppState {
     public var isLoadingReviews: Bool = false
 
     public var excludeReviewRepos: [String] = []
+    public var excludeTicketRepos: [String] = []
 
     public var filteredReviewRequests: [ReviewRequest] {
         guard !excludeReviewRepos.isEmpty else { return reviewRequests }
@@ -273,19 +274,26 @@ public final class AppState {
 
     // MARK: - Ticket Board Helpers
 
+    /// Issues after applying repo exclusion filter.
+    public var filteredAssignedIssues: [AssignedIssue] {
+        guard !excludeTicketRepos.isEmpty else { return assignedIssues }
+        let excludeSet = Set(excludeTicketRepos.map { $0.lowercased() })
+        return assignedIssues.filter { !excludeSet.contains($0.repo.lowercased()) }
+    }
+
     /// Count of issues in a given pipeline status. Treats `.unknown` as `.backlog`.
     public func issueCount(for status: TicketStatus) -> Int {
-        assignedIssues.filter { effectiveStatus($0) == status }.count
+        filteredAssignedIssues.filter { effectiveStatus($0) == status }.count
     }
 
     /// Issues filtered by the given pipeline status. Treats `.unknown` as `.backlog`.
     public func issues(for status: TicketStatus) -> [AssignedIssue] {
-        assignedIssues.filter { effectiveStatus($0) == status }
+        filteredAssignedIssues.filter { effectiveStatus($0) == status }
     }
 
     /// Filtered and sorted issues for the ticket board, applying status filter, search, and sort.
     public var filteredSortedIssues: [AssignedIssue] {
-        var result = assignedIssues
+        var result = filteredAssignedIssues
 
         // Status filter
         if let status = selectedTicketStatus {

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -1,5 +1,25 @@
 import Foundation
 
+/// Check whether a repo name matches any of the exclude patterns.
+/// Supports exact matches and simple glob patterns with `*` (e.g., `org/*`, `*/repo`).
+public func repoMatchesExcludePatterns(_ repo: String, patterns: [String]) -> Bool {
+    let lowerRepo = repo.lowercased()
+    for pattern in patterns {
+        let lowerPattern = pattern.lowercased()
+        if lowerPattern.contains("*") {
+            let parts = lowerPattern.split(separator: "*", maxSplits: 1, omittingEmptySubsequences: false)
+            let prefix = String(parts[0])
+            let suffix = parts.count > 1 ? String(parts[1]) : ""
+            if lowerRepo.hasPrefix(prefix) && lowerRepo.hasSuffix(suffix) {
+                return true
+            }
+        } else if lowerRepo == lowerPattern {
+            return true
+        }
+    }
+    return false
+}
+
 /// Observable application state shared across the app.
 @MainActor
 @Observable
@@ -108,8 +128,7 @@ public final class AppState {
 
     public var filteredReviewRequests: [ReviewRequest] {
         guard !excludeReviewRepos.isEmpty else { return reviewRequests }
-        let excludeSet = Set(excludeReviewRepos.map { $0.lowercased() })
-        return reviewRequests.filter { !excludeSet.contains($0.repo.lowercased()) }
+        return reviewRequests.filter { !repoMatchesExcludePatterns($0.repo, patterns: excludeReviewRepos) }
     }
 
     /// IDs of review requests the user has already seen (for badge count).
@@ -277,8 +296,7 @@ public final class AppState {
     /// Issues after applying repo exclusion filter.
     public var filteredAssignedIssues: [AssignedIssue] {
         guard !excludeTicketRepos.isEmpty else { return assignedIssues }
-        let excludeSet = Set(excludeTicketRepos.map { $0.lowercased() })
-        return assignedIssues.filter { !excludeSet.contains($0.repo.lowercased()) }
+        return assignedIssues.filter { !repoMatchesExcludePatterns($0.repo, patterns: excludeTicketRepos) }
     }
 
     /// Count of issues in a given pipeline status. Treats `.unknown` as `.backlog`.

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -133,6 +133,7 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
     public var branchPrefix: String
     public var excludeDirs: [String]
     public var excludeReviewRepos: [String]
+    public var excludeTicketRepos: [String]
 
     /// Characters that are invalid in git ref names (see `git check-ref-format`).
     private static let invalidBranchChars = CharacterSet(charactersIn: " ~^:?*[\\")
@@ -157,13 +158,15 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         cli: String = "gh",
         branchPrefix: String = "feature/",
         excludeDirs: [String] = ["node_modules", ".git", "vendor", "dist", "build", "target"],
-        excludeReviewRepos: [String] = []
+        excludeReviewRepos: [String] = [],
+        excludeTicketRepos: [String] = []
     ) {
         self.provider = provider
         self.cli = cli
         self.branchPrefix = branchPrefix
         self.excludeDirs = excludeDirs
         self.excludeReviewRepos = excludeReviewRepos
+        self.excludeTicketRepos = excludeTicketRepos
     }
 
     public init(from decoder: Decoder) throws {
@@ -173,10 +176,11 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         branchPrefix = try container.decodeIfPresent(String.self, forKey: .branchPrefix) ?? "feature/"
         excludeDirs = try container.decodeIfPresent([String].self, forKey: .excludeDirs) ?? ["node_modules", ".git", "vendor", "dist", "build", "target"]
         excludeReviewRepos = try container.decodeIfPresent([String].self, forKey: .excludeReviewRepos) ?? []
+        excludeTicketRepos = try container.decodeIfPresent([String].self, forKey: .excludeTicketRepos) ?? []
     }
 
     private enum CodingKeys: String, CodingKey {
-        case provider, cli, branchPrefix, excludeDirs, excludeReviewRepos
+        case provider, cli, branchPrefix, excludeDirs, excludeReviewRepos, excludeTicketRepos
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -191,3 +191,42 @@ import Testing
     #expect(ConfigDefaults.isValidBranchPrefix("feature.") == false)         // trailing dot
     #expect(ConfigDefaults.isValidBranchPrefix("feature@{/") == false)       // @{
 }
+
+// MARK: - Repo Exclude Pattern Matching
+
+@Test func repoExcludeExactMatch() {
+    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["org/repo"]) == true)
+    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["org/other"]) == false)
+}
+
+@Test func repoExcludeCaseInsensitive() {
+    #expect(repoMatchesExcludePatterns("Org/Repo", patterns: ["org/repo"]) == true)
+    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["ORG/REPO"]) == true)
+}
+
+@Test func repoExcludeWildcardSuffix() {
+    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["org/*"]) == true)
+    #expect(repoMatchesExcludePatterns("org/other", patterns: ["org/*"]) == true)
+    #expect(repoMatchesExcludePatterns("different/repo", patterns: ["org/*"]) == false)
+}
+
+@Test func repoExcludeWildcardPrefix() {
+    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["*/repo"]) == true)
+    #expect(repoMatchesExcludePatterns("other/repo", patterns: ["*/repo"]) == true)
+    #expect(repoMatchesExcludePatterns("org/other", patterns: ["*/repo"]) == false)
+}
+
+@Test func repoExcludeWildcardOnly() {
+    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["*"]) == true)
+}
+
+@Test func repoExcludeMultiplePatterns() {
+    let patterns = ["org/specific", "other-org/*"]
+    #expect(repoMatchesExcludePatterns("org/specific", patterns: patterns) == true)
+    #expect(repoMatchesExcludePatterns("other-org/anything", patterns: patterns) == true)
+    #expect(repoMatchesExcludePatterns("org/different", patterns: patterns) == false)
+}
+
+@Test func repoExcludeEmptyPatterns() {
+    #expect(repoMatchesExcludePatterns("org/repo", patterns: []) == false)
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -8,7 +8,7 @@ import Testing
             WorkspaceInfo(name: "TestOrg", provider: "github", cli: "gh", alwaysInclude: ["repo1"]),
             WorkspaceInfo(name: "GitLabOrg", provider: "gitlab", cli: "glab", host: "gitlab.example.com"),
         ],
-        defaults: ConfigDefaults(provider: "gitlab", cli: "glab", branchPrefix: "fix/", excludeDirs: ["vendor"], excludeReviewRepos: ["zarf-dev/zarf", "bmlt-enabled/yap"]),
+        defaults: ConfigDefaults(provider: "gitlab", cli: "glab", branchPrefix: "fix/", excludeDirs: ["vendor"], excludeReviewRepos: ["zarf-dev/zarf", "bmlt-enabled/yap"], excludeTicketRepos: ["org/hidden-repo"]),
         notifications: NotificationSettings(globalMute: true),
         sidebar: SidebarSettings(hideSessionDetails: true)
     )
@@ -26,6 +26,7 @@ import Testing
     #expect(decoded.defaults.branchPrefix == "fix/")
     #expect(decoded.defaults.excludeDirs == ["vendor"])
     #expect(decoded.defaults.excludeReviewRepos == ["zarf-dev/zarf", "bmlt-enabled/yap"])
+    #expect(decoded.defaults.excludeTicketRepos == ["org/hidden-repo"])
     #expect(decoded.notifications.globalMute == true)
     #expect(decoded.sidebar.hideSessionDetails == true)
 }
@@ -38,6 +39,7 @@ import Testing
     #expect(config.defaults.provider == "github")
     #expect(config.defaults.branchPrefix == "feature/")
     #expect(config.defaults.excludeReviewRepos.isEmpty)
+    #expect(config.defaults.excludeTicketRepos.isEmpty)
     #expect(config.notifications.globalMute == false)
     #expect(config.sidebar.hideSessionDetails == false)
     #expect(config.remoteControlEnabled == false)
@@ -113,6 +115,7 @@ import Testing
     """.data(using: .utf8)!
     let config = try JSONDecoder().decode(AppConfig.self, from: json)
     #expect(config.defaults.excludeReviewRepos.isEmpty)
+    #expect(config.defaults.excludeTicketRepos.isEmpty)
     #expect(config.defaults.excludeDirs == ["node_modules"])
 }
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -170,7 +170,7 @@ public struct SettingsView: View {
                             .filter { !$0.isEmpty }
                         save()
                     }
-                Text("Comma-separated list of repos to hide from the review board (e.g., zarf-dev/zarf, bmlt-enabled/yap).")
+                Text("Comma-separated repos to hide from the review board. Supports wildcards (e.g., zarf-dev/*, bmlt-enabled/yap).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -185,7 +185,7 @@ public struct SettingsView: View {
                             .filter { !$0.isEmpty }
                         save()
                     }
-                Text("Comma-separated list of repos to hide from the ticket board (e.g., zarf-dev/zarf, bmlt-enabled/yap).")
+                Text("Comma-separated repos to hide from the ticket board. Supports wildcards (e.g., zarf-dev/*, bmlt-enabled/yap).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -13,6 +13,7 @@ public struct SettingsView: View {
     @State private var isAddingWorkspace = false
     @State private var editingWorkspace: WorkspaceInfo?
     @State private var excludeReviewReposText: String
+    @State private var excludeTicketReposText: String
 
     public var onSave: ((String, AppConfig) -> Void)?
     public var onRescaffold: ((String) -> Void)?
@@ -24,6 +25,7 @@ public struct SettingsView: View {
         self._devRoot = State(initialValue: devRoot)
         self._config = State(initialValue: config)
         self._excludeReviewReposText = State(initialValue: config.defaults.excludeReviewRepos.joined(separator: ", "))
+        self._excludeTicketReposText = State(initialValue: config.defaults.excludeTicketRepos.joined(separator: ", "))
         self.onSave = onSave
         self.onRescaffold = onRescaffold
     }
@@ -169,6 +171,21 @@ public struct SettingsView: View {
                         save()
                     }
                 Text("Comma-separated list of repos to hide from the review board (e.g., zarf-dev/zarf, bmlt-enabled/yap).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Tickets") {
+                TextField("Excluded Repos", text: $excludeTicketReposText)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: excludeTicketReposText) { _, _ in
+                        config.defaults.excludeTicketRepos = excludeTicketReposText
+                            .split(separator: ",")
+                            .map { $0.trimmingCharacters(in: .whitespaces) }
+                            .filter { !$0.isEmpty }
+                        save()
+                    }
+                Text("Comma-separated list of repos to hide from the ticket board (e.g., zarf-dev/zarf, bmlt-enabled/yap).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -48,7 +48,7 @@ public struct TicketBoardView: View {
 
                 Spacer()
 
-                Text("\(appState.assignedIssues.count) issues")
+                Text("\(appState.filteredAssignedIssues.count) issues")
                     .font(.caption)
                     .foregroundStyle(CorveilTheme.textSecondary)
 
@@ -114,7 +114,7 @@ public struct TicketBoardView: View {
             .buttonStyle(.plain)
 
             Button {
-                let urls = appState.assignedIssues
+                let urls = appState.filteredAssignedIssues
                     .filter { selectedIssueIDs.contains($0.id) }
                     .map(\.url)
                 appState.onBatchWorkOnIssues?(urls)
@@ -197,7 +197,7 @@ struct PipelineView: View {
             HStack(spacing: 0) {
                 // "All" segment
                 AllPipelineSegment(
-                    count: appState.assignedIssues.count,
+                    count: appState.filteredAssignedIssues.count,
                     isSelected: appState.selectedTicketStatus == nil
                 ) {
                     appState.selectedTicketStatus = nil

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -115,6 +115,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
+        appState.excludeTicketRepos = config.defaults.excludeTicketRepos
 
         // Create session service and hydrate state
         let service = SessionService(store: store, appState: appState, telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil)
@@ -487,6 +488,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
+        appState.excludeTicketRepos = config.defaults.excludeTicketRepos
     }
 
     // MARK: - Socket Server

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -240,10 +240,10 @@ final class IssueTracker {
 
         appState.assignedIssues = allIssues
 
-        let ticketExcludeSet = Set(config.defaults.excludeTicketRepos.map { $0.lowercased() })
-        let autoCreateCandidates = ticketExcludeSet.isEmpty
+        let ticketExcludePatterns = config.defaults.excludeTicketRepos
+        let autoCreateCandidates = ticketExcludePatterns.isEmpty
             ? allIssues
-            : allIssues.filter { !ticketExcludeSet.contains($0.repo.lowercased()) }
+            : allIssues.filter { !repoMatchesExcludePatterns($0.repo, patterns: ticketExcludePatterns) }
         detectAutoCreateCandidates(issues: autoCreateCandidates, config: config)
 
         if let ghResult {
@@ -282,9 +282,9 @@ final class IssueTracker {
                 }
             }
             let allCurrentIDs = Set(reviews.map(\.id))
-            let excludeSet = Set(config.defaults.excludeReviewRepos.map { $0.lowercased() })
-            if !excludeSet.isEmpty {
-                reviews = reviews.filter { !excludeSet.contains($0.repo.lowercased()) }
+            let reviewExcludePatterns = config.defaults.excludeReviewRepos
+            if !reviewExcludePatterns.isEmpty {
+                reviews = reviews.filter { !repoMatchesExcludePatterns($0.repo, patterns: reviewExcludePatterns) }
             }
             let currentIDs = Set(reviews.map(\.id))
             let newIDs = currentIDs.subtracting(previousReviewRequestIDs)

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -240,7 +240,11 @@ final class IssueTracker {
 
         appState.assignedIssues = allIssues
 
-        detectAutoCreateCandidates(issues: allIssues, config: config)
+        let ticketExcludeSet = Set(config.defaults.excludeTicketRepos.map { $0.lowercased() })
+        let autoCreateCandidates = ticketExcludeSet.isEmpty
+            ? allIssues
+            : allIssues.filter { !ticketExcludeSet.contains($0.repo.lowercased()) }
+        detectAutoCreateCandidates(issues: autoCreateCandidates, config: config)
 
         if let ghResult {
             // Session PR link detection runs against open PRs only — we only

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,8 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
     "cli": "gh",
     "branchPrefix": "feature/",
     "excludeDirs": ["node_modules", ".git", "vendor", "dist", "build", "target"],
-    "excludeReviewRepos": ["zarf-dev/zarf", "bmlt-enabled/yap"]
+    "excludeReviewRepos": ["zarf-dev/zarf", "bmlt-enabled/yap"],
+    "excludeTicketRepos": []
   }
 }
 ```
@@ -59,6 +60,7 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
 - **`branchPrefix`** — used by the `/crow-workspace` skill when creating new branches.
 - **`excludeDirs`** — ignored when scanning repos for git worktrees.
 - **`excludeReviewRepos`** — repos to hide from the review board (e.g., `["zarf-dev/zarf"]`). Matching reviews are filtered out from the board, sidebar badge count, and notifications.
+- **`excludeTicketRepos`** — repos to hide from the ticket board (e.g., `["zarf-dev/zarf"]`). Matching issues are filtered out from the board, pipeline counts, and auto-create candidates.
 
 ## Manager Terminal
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,8 +59,8 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
 - **`host`** — set for self-hosted GitLab; exported as `GITLAB_HOST` when invoking `glab`.
 - **`branchPrefix`** — used by the `/crow-workspace` skill when creating new branches.
 - **`excludeDirs`** — ignored when scanning repos for git worktrees.
-- **`excludeReviewRepos`** — repos to hide from the review board (e.g., `["zarf-dev/zarf"]`). Matching reviews are filtered out from the board, sidebar badge count, and notifications.
-- **`excludeTicketRepos`** — repos to hide from the ticket board (e.g., `["zarf-dev/zarf"]`). Matching issues are filtered out from the board, pipeline counts, and auto-create candidates.
+- **`excludeReviewRepos`** — repos to hide from the review board (e.g., `["zarf-dev/zarf"]`). Supports `*` wildcards (e.g., `"zarf-dev/*"`). Matching reviews are filtered out from the board, sidebar badge count, and notifications.
+- **`excludeTicketRepos`** — repos to hide from the ticket board (e.g., `["zarf-dev/zarf"]`). Supports `*` wildcards (e.g., `"zarf-dev/*"`). Matching issues are filtered out from the board, pipeline counts, and auto-create candidates.
 
 ## Manager Terminal
 


### PR DESCRIPTION
Closes #219

## Summary
- Add `excludeTicketRepos` config field (persisted in `config.json`) to hide repos from the ticket board, mirroring the existing `excludeReviewRepos` pattern for the review board
- Filtered repos are excluded from the board listing, pipeline status counts, search results, and `crow:auto` auto-create candidates
- Session lifecycle tracking (auto-complete, PR sync) remains unfiltered so existing sessions for excluded repos continue to work
- Settings UI includes a new "Tickets" section with a comma-separated excluded repos text field

## Test plan
- [x] CrowCore builds and all 115 tests pass
- [ ] Verify Settings > General shows "Tickets" section with excluded repos field
- [ ] Enter a repo name in the field and confirm matching tickets disappear from the board and pipeline counts update
- [ ] Confirm existing sessions for excluded repos still auto-complete when their PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)