### PR TITLE
Auto-label PRs with crow:auto on open

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,24 @@
+name: Auto-label PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure crow:auto label exists
+        run: gh label create "crow:auto" --repo "$GITHUB_REPOSITORY" --color "1D76DB" --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply label
+        run: gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --add-label "crow:auto"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically applies the `crow:auto` label to every newly opened PR
- The label is created if it doesn't already exist
- Reviewer auto-assignment is already handled by the existing `.github/CODEOWNERS` file

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)