### PR TITLE
Per-section select all and icon-only cancel button

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -213,6 +213,7 @@ public struct SessionListView: View {
             }
             .buttonStyle(.plain)
             .help("Cancel selection")
+            .accessibilityLabel("Cancel selection")
 
             if !selectedSessionIDs.isEmpty {
                 Button {
@@ -231,6 +232,7 @@ public struct SessionListView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 6))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Delete \(selectedSessionIDs.count) selected sessions")
             }
         }
         .padding(.horizontal, 12)
@@ -334,6 +336,7 @@ struct SectionDivider: View {
                 }
                 .buttonStyle(.plain)
                 .help(allSelected ? "Deselect all \(title.lowercased())" : "Select all \(title.lowercased())")
+                .accessibilityLabel(allSelected ? "Deselect all \(title.lowercased())" : "Select all \(title.lowercased())")
             }
         }
         .padding(.top, 10)

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -18,7 +18,7 @@ public struct SessionListView: View {
         VStack(spacing: 0) {
             sessionList
 
-            if isSelectionMode && !selectedSessionIDs.isEmpty {
+            if isSelectionMode {
                 bulkActionBar
             }
         }
@@ -76,7 +76,12 @@ public struct SessionListView: View {
 
             // Active sessions
             if !appState.activeSessions.isEmpty {
-                SectionDivider(title: "Active")
+                SectionDivider(
+                    title: "Active",
+                    isSelectionMode: isSelectionMode,
+                    sectionIDs: Set(filteredSessions(appState.activeSessions).map(\.id)),
+                    selectedSessionIDs: $selectedSessionIDs
+                )
                 ForEach(filteredSessions(appState.activeSessions)) { session in
                     SessionRow(
                         session: session,
@@ -95,7 +100,12 @@ public struct SessionListView: View {
 
             // Review sessions
             if !appState.reviewSessions.isEmpty {
-                SectionDivider(title: "Reviews")
+                SectionDivider(
+                    title: "Reviews",
+                    isSelectionMode: isSelectionMode,
+                    sectionIDs: Set(filteredSessions(appState.reviewSessions).map(\.id)),
+                    selectedSessionIDs: $selectedSessionIDs
+                )
                 ForEach(filteredSessions(appState.reviewSessions)) { session in
                     SessionRow(
                         session: session,
@@ -118,7 +128,12 @@ public struct SessionListView: View {
 
             // In Review sessions
             if !appState.inReviewSessions.isEmpty {
-                SectionDivider(title: "In Review")
+                SectionDivider(
+                    title: "In Review",
+                    isSelectionMode: isSelectionMode,
+                    sectionIDs: Set(filteredSessions(appState.inReviewSessions).map(\.id)),
+                    selectedSessionIDs: $selectedSessionIDs
+                )
                 ForEach(filteredSessions(appState.inReviewSessions)) { session in
                     SessionRow(
                         session: session,
@@ -137,7 +152,12 @@ public struct SessionListView: View {
 
             // Completed sessions
             if !appState.completedSessions.isEmpty {
-                SectionDivider(title: "Completed")
+                SectionDivider(
+                    title: "Completed",
+                    isSelectionMode: isSelectionMode,
+                    sectionIDs: Set(filteredSessions(appState.completedSessions).map(\.id)),
+                    selectedSessionIDs: $selectedSessionIDs
+                )
                 ForEach(filteredSessions(appState.completedSessions)) { session in
                     SessionRow(
                         session: session,
@@ -186,30 +206,32 @@ public struct SessionListView: View {
                 isSelectionMode = false
                 selectedSessionIDs.removeAll()
             } label: {
-                Text("Cancel")
-                    .font(.system(size: 12))
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(CorveilTheme.textSecondary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
+                    .padding(5)
             }
             .buttonStyle(.plain)
+            .help("Cancel selection")
 
-            Button {
-                showBulkDeleteConfirm = true
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "trash")
-                        .font(.system(size: 10))
-                    Text("Delete (\(selectedSessionIDs.count))")
-                        .font(.system(size: 12, weight: .semibold))
+            if !selectedSessionIDs.isEmpty {
+                Button {
+                    showBulkDeleteConfirm = true
+                } label: {
+                    HStack(spacing: 2) {
+                        Image(systemName: "trash")
+                            .font(.system(size: 11))
+                        Text("(\(selectedSessionIDs.count))")
+                            .font(.system(size: 11, weight: .semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(Color.red)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
                 }
-                .foregroundStyle(.white)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 5)
-                .background(Color.red)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -273,16 +295,50 @@ struct SidebarBrandmark: View {
 /// Uppercase section label used to group sessions in the sidebar.
 struct SectionDivider: View {
     let title: String
+    var isSelectionMode: Bool = false
+    var sectionIDs: Set<UUID> = []
+    @Binding var selectedSessionIDs: Set<UUID>
+
+    init(title: String, isSelectionMode: Bool = false, sectionIDs: Set<UUID> = [], selectedSessionIDs: Binding<Set<UUID>> = .constant([])) {
+        self.title = title
+        self.isSelectionMode = isSelectionMode
+        self.sectionIDs = sectionIDs
+        self._selectedSessionIDs = selectedSessionIDs
+    }
+
+    private var allSelected: Bool {
+        !sectionIDs.isEmpty && sectionIDs.isSubset(of: selectedSessionIDs)
+    }
 
     var body: some View {
-        Text(title)
-            .font(.system(size: 10, weight: .bold))
-            .tracking(1.5)
-            .textCase(.uppercase)
-            .foregroundStyle(CorveilTheme.goldDark)
-            .padding(.top, 10)
-            .padding(.bottom, 2)
-            .listRowSeparator(.hidden)
+        HStack {
+            Text(title)
+                .font(.system(size: 10, weight: .bold))
+                .tracking(1.5)
+                .textCase(.uppercase)
+                .foregroundStyle(CorveilTheme.goldDark)
+
+            Spacer()
+
+            if isSelectionMode && !sectionIDs.isEmpty {
+                Button {
+                    if allSelected {
+                        selectedSessionIDs.subtract(sectionIDs)
+                    } else {
+                        selectedSessionIDs.formUnion(sectionIDs)
+                    }
+                } label: {
+                    Image(systemName: allSelected ? "checkmark.circle.fill" : "checklist")
+                        .font(.system(size: 12))
+                        .foregroundStyle(allSelected ? CorveilTheme.gold : CorveilTheme.goldDark)
+                }
+                .buttonStyle(.plain)
+                .help(allSelected ? "Deselect all \(title.lowercased())" : "Select all \(title.lowercased())")
+            }
+        }
+        .padding(.top, 10)
+        .padding(.bottom, 2)
+        .listRowSeparator(.hidden)
     }
 }
 

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -75,14 +75,21 @@ mkdir -p "$XCFW_DIR"
 cp "$XCFW_SRC/Info.plist" "$FRAMEWORKS_DIR/GhosttyKit.xcframework/"
 cp -R "$XCFW_SRC/macos-arm64/Headers" "$XCFW_DIR/" 2>/dev/null || true  # Headers may not exist in all configurations
 
+# SPM 6.3+ requires module.modulemap at the library identifier level (not just in Headers/)
+if [ -f "$XCFW_DIR/Headers/module.modulemap" ] && [ ! -f "$XCFW_DIR/module.modulemap" ]; then
+    cp "$XCFW_DIR/Headers/module.modulemap" "$XCFW_DIR/module.modulemap"
+fi
+
 # Start with the dependency library from the xcframework
 OUTPUT="$XCFW_DIR/libghostty-fat.a"
 cp "$XCFW_SRC/macos-arm64/libghostty-fat.a" "$OUTPUT"
 
 # Find and add the Zig-compiled ghostty API object (libghostty_zcu.o)
-ZCU=$(find "$CACHE" -name "libghostty_zcu.o" -print -quit 2>/dev/null)
+# There may be multiple libghostty_zcu.o files in the cache; we need the one
+# containing the public API symbols (e.g. ghostty_app_new), not the SIMD-only one.
+ZCU=$(find "$CACHE" -name "libghostty_zcu.o" -exec sh -c 'nm "$1" 2>/dev/null | grep -q "T _ghostty_app_new" && echo "$1"' _ {} \; 2>/dev/null | head -1)
 if [ -z "$ZCU" ]; then
-    echo "WARNING: libghostty_zcu.o not found in Zig cache — fat library may be incomplete"
+    echo "WARNING: libghostty_zcu.o with API symbols not found in Zig cache — fat library may be incomplete"
 fi
 if [ -n "$ZCU" ]; then
     ar r "$OUTPUT" "$ZCU" 2>/dev/null


### PR DESCRIPTION
## Summary
- Move select-all from a global toggle to per-section buttons in each section header (Active, Reviews, In Review, Completed)
- Replace the text "Cancel" button with an `xmark` icon in the bulk action bar
- Fix `build-ghostty.sh` to select the correct `libghostty_zcu.o` containing API symbols (not the SIMD-only variant)
- Fix `build-ghostty.sh` to copy `module.modulemap` to the library identifier level for SPM 6.3+ compatibility

## Test plan
- [ ] Enter selection mode and verify each section header shows a select-all icon
- [ ] Tap section select-all, confirm all sessions in that section are selected and icon changes to filled checkmark
- [ ] Tap again to deselect all in section
- [ ] Verify cancel button is an xmark icon, not text
- [ ] Run `make ghostty && make` to verify build fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)