### PR TITLE
Fix glab fetch failures from non-repo cwd and nested-group slug truncation

### DIFF
--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -1337,8 +1337,8 @@ final class IssueTracker {
             var url = output.trimmingCharacters(in: .whitespacesAndNewlines)
             if url.hasSuffix(".git") { url = String(url.dropLast(4)) }
             let host = Self.extractHost(fromRemote: url)
-            if let match = url.range(of: #"[:/]([^/:]+/[^/:]+)$"#, options: .regularExpression) {
-                let slug = String(url[match]).trimmingCharacters(in: CharacterSet(charactersIn: "/:"))
+            let slug = Self.extractSlug(fromRemote: url)
+            if !slug.isEmpty {
                 return RepoInfo(slug: slug, host: host)
             }
         }
@@ -1365,6 +1365,30 @@ final class IssueTracker {
             let trimmed = match
                 .replacingOccurrences(of: #"^https?://"#, with: "", options: .regularExpression)
             return trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        }
+        return ""
+    }
+
+    /// Extract the project slug ("org/repo", "group/sub/repo", ...) from a git
+    /// remote URL. Handles both SSH (`git@host:path`) and HTTPS
+    /// (`https://host/path`), and preserves nested-group paths so that GitLab
+    /// projects under nested groups (e.g.
+    /// `big-bang/product/packages/elasticsearch-kibana`) keep their full path.
+    /// Strips a trailing `.git` if present. Returns "" when the URL can't be
+    /// parsed.
+    nonisolated static func extractSlug(fromRemote url: String) -> String {
+        var trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasSuffix(".git") { trimmed = String(trimmed.dropLast(4)) }
+
+        // SSH: git@host:org/repo or user@host:group/sub/repo
+        if let range = trimmed.range(of: #"^[^@/\s]+@[^:/\s]+:"#, options: .regularExpression) {
+            let path = String(trimmed[range.upperBound...])
+            return path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        }
+        // HTTPS: https://host/org/repo
+        if let range = trimmed.range(of: #"^https?://[^/]+/"#, options: .regularExpression) {
+            let path = String(trimmed[range.upperBound...])
+            return path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         }
         return ""
     }
@@ -1706,10 +1730,13 @@ final class IssueTracker {
     private func fetchGitLabIssues(host: String) async -> [AssignedIssue] {
         let output: String
         do {
+            // Use `glab api` rather than `glab issue list`: the latter shells
+            // out to `git` even when no repo is involved and aborts with
+            // "fatal: not a git repository" when cwd isn't a git working tree.
             output = try await shell(
                 env: ["GITLAB_HOST": host],
                 cwd: NSHomeDirectory(),
-                "glab", "issue", "list", "-a", "@me", "--output-format", "json"
+                "glab", "api", "issues?scope=assigned_to_me&state=opened&per_page=100"
             )
         } catch {
             print("[IssueTracker] fetchGitLabIssues(host: \(host)) failed: \(error)")

--- a/Tests/CrowTests/IssueTrackerReconcileTests.swift
+++ b/Tests/CrowTests/IssueTrackerReconcileTests.swift
@@ -108,3 +108,51 @@ struct IssueTrackerRemoteHostTests {
         #expect(IssueTracker.extractHost(fromRemote: "") == "")
     }
 }
+
+@Suite("IssueTracker remote slug extraction")
+struct IssueTrackerRemoteSlugTests {
+    @Test func parsesGitHubSSH() {
+        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:radiusmethod/corveil") == "radiusmethod/corveil")
+    }
+
+    @Test func parsesGitHubHTTPS() {
+        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/radiusmethod/corveil") == "radiusmethod/corveil")
+    }
+
+    @Test func parsesGitLabTwoLevel() {
+        #expect(IssueTracker.extractSlug(fromRemote: "https://gitlab.internal.example/acme/api") == "acme/api")
+        #expect(IssueTracker.extractSlug(fromRemote: "git@gitlab.corp.example:acme/api") == "acme/api")
+    }
+
+    @Test func parsesGitLabNestedGroupsHTTPS() {
+        // Regression test for #232: nested-group paths must not be truncated.
+        #expect(
+            IssueTracker.extractSlug(
+                fromRemote: "https://gitlab.example.com/big-bang/product/packages/elasticsearch-kibana"
+            ) == "big-bang/product/packages/elasticsearch-kibana"
+        )
+    }
+
+    @Test func parsesGitLabNestedGroupsSSH() {
+        #expect(
+            IssueTracker.extractSlug(
+                fromRemote: "git@gitlab.example.com:big-bang/product/packages/elasticsearch-kibana"
+            ) == "big-bang/product/packages/elasticsearch-kibana"
+        )
+    }
+
+    @Test func stripsTrailingDotGit() {
+        #expect(IssueTracker.extractSlug(fromRemote: "https://github.com/radiusmethod/corveil.git") == "radiusmethod/corveil")
+        #expect(IssueTracker.extractSlug(fromRemote: "git@github.com:radiusmethod/corveil.git") == "radiusmethod/corveil")
+        #expect(
+            IssueTracker.extractSlug(
+                fromRemote: "https://gitlab.example.com/big-bang/product/packages/elasticsearch-kibana.git"
+            ) == "big-bang/product/packages/elasticsearch-kibana"
+        )
+    }
+
+    @Test func returnsEmptyForUnrecognized() {
+        #expect(IssueTracker.extractSlug(fromRemote: "/tmp/local/repo") == "")
+        #expect(IssueTracker.extractSlug(fromRemote: "") == "")
+    }
+}


### PR DESCRIPTION
## Summary

- `fetchGitLabIssues` was running `glab issue list -a @me --output-format json` with `cwd: NSHomeDirectory()`. `glab issue list` shells out to `git` even when no repo is involved and aborts with *"fatal: not a git repository"* when the cwd is not a git working tree. Swap to `glab api "issues?scope=assigned_to_me&state=opened&per_page=100"` — same JSON fields the existing parser already reads (`iid`, `title`, `web_url`, `state`, `labels`, `references.full`), no git-repo dependency. Same pattern Crow already uses in `fetchGitLabMRsForReconcile`.
- `resolveRepoInfo` truncated nested-group GitLab slugs because its regex `[:/]([^/:]+/[^/:]+)$` only captured the last two path segments. `big-bang/product/packages/elasticsearch-kibana` collapsed to `packages/elasticsearch-kibana`, then the reconcile path hit a 404 against a non-existent project. Replaced with a new `IssueTracker.extractSlug(fromRemote:)` helper (parallel to `extractHost`) that returns the full path after the host for both SSH and HTTPS remotes and strips a trailing `.git`.
- Added a `IssueTrackerRemoteSlugTests` Swift Testing suite mirroring the existing `IssueTrackerRemoteHostTests`: GitHub SSH/HTTPS, two-level GitLab, nested-group GitLab (HTTPS and SSH — the regression for #232), `.git` stripping, and unrecognized inputs.

Closes #232

## Test plan

- [x] `swift test` — all 38 tests in 5 suites pass, including the new `IssueTracker remote slug extraction` suite (7 tests).
- [ ] Manual: with no GitLab repo cloned at `~`, confirm Crow's GitLab issue tracker now returns assigned issues instead of an empty list.
- [ ] Manual: register a worktree whose origin points at a nested GitLab group (e.g. `big-bang/product/packages/elasticsearch-kibana`) and confirm the merged-MR reconcile flow finds the project (no 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)