### PR TITLE
Silently skip hook-event when Crow app is not running

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/HookEventCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/HookEventCommand.swift
@@ -24,10 +24,23 @@ public struct HookEventCmd: ParsableCommand {
 
     public func run() throws {
         let payload = parseHookPayload(from: FileHandle.standardInput.readDataToEndOfFile())
+        try forwardHookEvent(sessionID: session, eventName: event, payload: payload)
+    }
+}
 
+/// Forward a parsed hook event over the Unix socket.
+///
+/// Silently no-ops when the Crow app is not running (socket connection
+/// refused or socket file absent). Hooks are fire-and-forget — a missing
+/// listener is an expected state, not an error, so we must not exit
+/// non-zero or write to stderr (it pollutes Claude Code's hook output).
+/// Other socket errors (timeout, write/read failures) and JSON-RPC
+/// errors still propagate so genuine misbehavior is visible.
+func forwardHookEvent(sessionID: String, eventName: String, payload: [String: JSONValue]) throws {
+    do {
         let result = try rpc("hook-event", params: [
-            "session_id": .string(session),
-            "event_name": .string(event),
+            "session_id": .string(sessionID),
+            "event_name": .string(eventName),
             "payload": .object(payload),
         ])
 
@@ -35,6 +48,8 @@ public struct HookEventCmd: ParsableCommand {
         if result["error"] != nil {
             printJSON(result)
         }
+    } catch SocketError.connectionFailed {
+        return
     }
 }
 

--- a/Packages/CrowCLI/Tests/CrowCLITests/HookEventTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/HookEventTests.swift
@@ -48,3 +48,20 @@ import CrowIPC
     let payload = parseHookPayload(from: data)
     #expect(payload.isEmpty)
 }
+
+// MARK: - Connection Refused Handling
+
+/// Regression test for #227: when the Crow app is not running, the hook-event
+/// command must silently no-op instead of exiting non-zero. Otherwise Claude
+/// Code surfaces "Stop hook error: …" on every session exit.
+@Test func forwardHookEventSilentWhenAppNotRunning() throws {
+    let nonExistent = NSTemporaryDirectory() + "crow-test-\(UUID().uuidString).sock"
+    setenv("CROW_SOCKET", nonExistent, 1)
+    defer { unsetenv("CROW_SOCKET") }
+
+    try forwardHookEvent(
+        sessionID: UUID().uuidString,
+        eventName: "Stop",
+        payload: [:]
+    )
+}


### PR DESCRIPTION
## Summary

- `crow hook-event` now silently exits 0 when the Crow app isn't running, instead of failing with "Socket connection failed: Connection refused".
- Catch is scoped to `SocketError.connectionFailed` inside `HookEventCmd` only — other CLI commands (`new-session`, `set-status`, etc.) still fail loudly when the socket is unavailable, since those are user-initiated.
- Other socket errors (timeout, write/read failures) and JSON-RPC errors continue to propagate so genuine misbehavior stays visible.

Closes #227

## Test plan

- [x] `make build` succeeds.
- [x] `swift test --package-path Packages/CrowCLI` — 35 tests pass, including new `forwardHookEventSilentWhenAppNotRunning`.
- [x] Repro: `echo '{}' | CROW_SOCKET=/tmp/missing.sock .build/debug/crow hook-event --session $(uuidgen) --event Stop` → no output, exit 0.
- [x] Sanity: `CROW_SOCKET=/tmp/missing.sock .build/debug/crow list-sessions` still prints "Socket connection failed: …" and exits 1.
- [x] Happy path with live app: `echo '{...}' | .build/debug/crow hook-event --session <real-uuid> --event Stop` → exit 0, event reaches the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)