### PR TITLE
Fix Settings workspace add/edit sheets silently no-op-ing

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -11,6 +11,7 @@ import CrowTelemetry
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var window: NSWindow?
     private var settingsWindow: NSWindow?
+    private var settingsWindowCloseObserver: NSObjectProtocol?
     private var aboutWindow: NSWindow?
     private let appState = AppState()
     private var store: JSONStore?
@@ -589,9 +590,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func showSettings() {
         guard let devRoot, let appConfig else { return }
 
-        // Settings is app-modal — the user must dismiss it before returning
-        // to the main app. (`NSApp.runModal(for:)` blocks until stopModal
-        // is called; we trigger that on the window's willClose notification.)
+        if let existing = settingsWindow {
+            existing.makeKeyAndOrderFront(nil)
+            return
+        }
+
         let settingsView = SettingsView(
             appState: appState,
             devRoot: devRoot,
@@ -617,21 +620,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         win.isReleasedWhenClosed = false
         win.contentView = hostingView
         win.center()
+        win.makeKeyAndOrderFront(nil)
         self.settingsWindow = win
 
-        let token = NotificationCenter.default.addObserver(
+        settingsWindowCloseObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: win,
             queue: .main
-        ) { _ in
-            // .main queue dispatches to the main thread, but Swift 6 doesn't
-            // statically know that's the MainActor's executor. NSApp is
+        ) { [weak self] _ in
+            // .main queue dispatches on the main thread, but Swift 6 doesn't
+            // statically know that's the MainActor's executor. AppDelegate is
             // MainActor-isolated; assume isolation explicitly.
-            MainActor.assumeIsolated { NSApp.stopModal() }
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.settingsWindow = nil
+                if let token = self.settingsWindowCloseObserver {
+                    NotificationCenter.default.removeObserver(token)
+                    self.settingsWindowCloseObserver = nil
+                }
+            }
         }
-        NSApp.runModal(for: win)
-        NotificationCenter.default.removeObserver(token)
-        self.settingsWindow = nil
     }
 
     private func saveSettings(devRoot: String, config: AppConfig) {


### PR DESCRIPTION
## Summary

- Commit 8827cf8 made the Settings window app-modal via `NSApp.runModal(for:)`. AppKit modal sessions take over event dispatch and prevent SwiftUI's `.sheet(...)` from presenting on the modal-hosted `NSWindow` — so clicking the pencil or Add buttons in Settings → Workspaces silently set state but never showed the form.
- Drop the modal session and present Settings as a regular key window, mirroring the existing `showAbout()` pattern in the same file.
- Re-add the existing-window short-circuit (so repeated Cmd+, brings the already-open Settings window forward instead of stacking duplicates), move `settingsWindow` cleanup into the willClose observer, and store the observer token on `AppDelegate` so the closure doesn't capture a mutable local var (which Swift 6 flags as a sendability warning).

Closes #236

## Test plan

- [x] `make build` — clean compile, no Sendable warnings
- [x] CrowUI tests pass (22/22)
- [ ] Cmd+, → Settings opens; Workspaces tab → click "+ Add" → `WorkspaceFormView` sheet appears
- [ ] Workspaces tab → click pencil on existing workspace → sheet appears, prefilled
- [ ] With Settings open, press Cmd+, again → no second window (existing brought to front)
- [ ] Close and reopen Settings → fresh window, no stale state
- [ ] Open Settings via the sidebar gear icon → same behavior
- [ ] While Settings is open, the main window remains interactive (modality is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)