### PR TITLE
Allow ignoring PRs with specific labels from review

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -129,10 +129,20 @@ public final class AppState {
 
     public var excludeReviewRepos: [String] = []
     public var excludeTicketRepos: [String] = []
+    public var ignoreReviewLabels: [String] = []
 
     public var filteredReviewRequests: [ReviewRequest] {
-        guard !excludeReviewRepos.isEmpty else { return reviewRequests }
-        return reviewRequests.filter { !repoMatchesExcludePatterns($0.repo, patterns: excludeReviewRepos) }
+        var result = reviewRequests
+        if !excludeReviewRepos.isEmpty {
+            result = result.filter { !repoMatchesExcludePatterns($0.repo, patterns: excludeReviewRepos) }
+        }
+        if !ignoreReviewLabels.isEmpty {
+            let lowerLabels = Set(ignoreReviewLabels.map { $0.lowercased() })
+            result = result.filter { request in
+                !request.labels.contains(where: { lowerLabels.contains($0.lowercased()) })
+            }
+        }
+        return result
     }
 
     /// IDs of review requests the user has already seen (for badge count).

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -176,6 +176,7 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
     public var excludeDirs: [String]
     public var excludeReviewRepos: [String]
     public var excludeTicketRepos: [String]
+    public var ignoreReviewLabels: [String]
 
     /// Characters that are invalid in git ref names (see `git check-ref-format`).
     private static let invalidBranchChars = CharacterSet(charactersIn: " ~^:?*[\\")
@@ -201,7 +202,8 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         branchPrefix: String = "feature/",
         excludeDirs: [String] = ["node_modules", ".git", "vendor", "dist", "build", "target"],
         excludeReviewRepos: [String] = [],
-        excludeTicketRepos: [String] = []
+        excludeTicketRepos: [String] = [],
+        ignoreReviewLabels: [String] = []
     ) {
         self.provider = provider
         self.cli = cli
@@ -209,6 +211,7 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         self.excludeDirs = excludeDirs
         self.excludeReviewRepos = excludeReviewRepos
         self.excludeTicketRepos = excludeTicketRepos
+        self.ignoreReviewLabels = ignoreReviewLabels
     }
 
     public init(from decoder: Decoder) throws {
@@ -219,10 +222,11 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         excludeDirs = try container.decodeIfPresent([String].self, forKey: .excludeDirs) ?? ["node_modules", ".git", "vendor", "dist", "build", "target"]
         excludeReviewRepos = try container.decodeIfPresent([String].self, forKey: .excludeReviewRepos) ?? []
         excludeTicketRepos = try container.decodeIfPresent([String].self, forKey: .excludeTicketRepos) ?? []
+        ignoreReviewLabels = try container.decodeIfPresent([String].self, forKey: .ignoreReviewLabels) ?? []
     }
 
     private enum CodingKeys: String, CodingKey {
-        case provider, cli, branchPrefix, excludeDirs, excludeReviewRepos, excludeTicketRepos
+        case provider, cli, branchPrefix, excludeDirs, excludeReviewRepos, excludeTicketRepos, ignoreReviewLabels
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/ReviewRequest.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/ReviewRequest.swift
@@ -12,6 +12,7 @@ public struct ReviewRequest: Identifiable, Codable, Sendable {
     public var baseBranch: String
     public var isDraft: Bool
     public var requestedAt: Date?
+    public var labels: [String]
     public var provider: Provider
     public var reviewSessionID: UUID?  // set if a review session already exists
 
@@ -26,6 +27,7 @@ public struct ReviewRequest: Identifiable, Codable, Sendable {
         baseBranch: String,
         isDraft: Bool = false,
         requestedAt: Date? = nil,
+        labels: [String] = [],
         provider: Provider = .github,
         reviewSessionID: UUID? = nil
     ) {
@@ -39,6 +41,7 @@ public struct ReviewRequest: Identifiable, Codable, Sendable {
         self.baseBranch = baseBranch
         self.isDraft = isDraft
         self.requestedAt = requestedAt
+        self.labels = labels
         self.provider = provider
         self.reviewSessionID = reviewSessionID
     }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -245,3 +245,20 @@ import Testing
     let decoded2 = try JSONDecoder().decode(AppConfig.self, from: data2)
     #expect(decoded2.experimentalTmuxBackend == false)
 }
+
+@Test func ignoreReviewLabelsRoundTrip() throws {
+    let config = AppConfig(
+        defaults: ConfigDefaults(ignoreReviewLabels: ["dependencies", "renovate", "automated"])
+    )
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.defaults.ignoreReviewLabels == ["dependencies", "renovate", "automated"])
+}
+
+@Test func ignoreReviewLabelsDefaultsEmptyWhenKeyMissing() throws {
+    let json = """
+    {"defaults": {"provider": "github", "cli": "gh", "branchPrefix": "feature/", "excludeDirs": []}}
+    """.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.defaults.ignoreReviewLabels.isEmpty)
+}

--- a/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
@@ -12,6 +12,7 @@ public struct AutomationSettingsView: View {
     var onSave: (() -> Void)?
 
     @State private var excludeReviewReposText: String
+    @State private var ignoreReviewLabelsText: String
     @State private var excludeTicketReposText: String
 
     public init(
@@ -27,6 +28,7 @@ public struct AutomationSettingsView: View {
         self._autoRespond = autoRespond
         self.onSave = onSave
         self._excludeReviewReposText = State(initialValue: defaults.wrappedValue.excludeReviewRepos.joined(separator: ", "))
+        self._ignoreReviewLabelsText = State(initialValue: defaults.wrappedValue.ignoreReviewLabels.joined(separator: ", "))
         self._excludeTicketReposText = State(initialValue: defaults.wrappedValue.excludeTicketRepos.joined(separator: ", "))
     }
 
@@ -46,6 +48,19 @@ public struct AutomationSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Text("Per-workspace auto-review opt-ins are configured in Workspaces → edit a workspace.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                TextField("Ignored Labels", text: $ignoreReviewLabelsText)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: ignoreReviewLabelsText) { _, _ in
+                        defaults.ignoreReviewLabels = ignoreReviewLabelsText
+                            .split(separator: ",")
+                            .map { $0.trimmingCharacters(in: .whitespaces) }
+                            .filter { !$0.isEmpty }
+                        onSave?()
+                    }
+                Text("Comma-separated labels to ignore from the review board (e.g., dependencies, renovate, automated).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -263,6 +263,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
+        appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
 
         // Create session service and hydrate state
         let service = SessionService(store: store, appState: appState, telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil)
@@ -680,6 +681,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
+        appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
     }
 
     // MARK: - Socket Server

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -304,6 +304,13 @@ final class IssueTracker {
             if !reviewExcludePatterns.isEmpty {
                 reviews = reviews.filter { !repoMatchesExcludePatterns($0.repo, patterns: reviewExcludePatterns) }
             }
+            let ignoreLabels = config.defaults.ignoreReviewLabels
+            if !ignoreLabels.isEmpty {
+                let lowerLabels = Set(ignoreLabels.map { $0.lowercased() })
+                reviews = reviews.filter { request in
+                    !request.labels.contains(where: { lowerLabels.contains($0.lowercased()) })
+                }
+            }
             let currentIDs = Set(reviews.map(\.id))
             let newIDs = currentIDs.subtracting(previousReviewRequestIDs)
             previousReviewRequestIDs = allCurrentIDs
@@ -562,6 +569,7 @@ final class IssueTracker {
             number title url isDraft updatedAt headRefName baseRefName state
             author { login }
             repository { nameWithOwner }
+            labels(first: 20) { nodes { name } }
           }
         }
       }
@@ -1095,6 +1103,8 @@ final class IssueTracker {
             let headBranch = node["headRefName"] as? String ?? ""
             let baseBranch = node["baseRefName"] as? String ?? ""
             let updatedAt = (node["updatedAt"] as? String).flatMap { dateFormatter.date(from: $0) }
+            let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+                .compactMap { $0["name"] as? String } ?? []
 
             requests.append(ReviewRequest(
                 id: "github:\(repoName)#\(number)",
@@ -1107,6 +1117,7 @@ final class IssueTracker {
                 baseBranch: baseBranch,
                 isDraft: isDraft,
                 requestedAt: updatedAt,
+                labels: labels,
                 provider: .github
             ))
         }


### PR DESCRIPTION
Closes #244

## Summary

- Adds `ignoreReviewLabels` configuration option (comma-separated label names) to filter PRs from the review board
- Fetches PR labels via the GitHub GraphQL query (`labels(first: 20) { nodes { name } }`)
- Applies case-insensitive label matching alongside the existing repo-exclude filter
- PRs with any matching label are hidden from the review board, badge counts, and notifications
- Settings UI in Automation → Reviews mirrors the existing "Excluded Repos" pattern

## Test plan

- [x] CrowCore package builds cleanly
- [x] All 143 unit tests pass (including 2 new config round-trip tests)
- [ ] Manual: configure `ignoreReviewLabels: ["dependencies"]` and verify matching PRs are filtered from the review board
- [ ] Manual: verify existing PRs without matching labels still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)