### PR TITLE
Stop forging tmux .shellReady on first-prompt timeout

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -218,6 +218,10 @@ public final class AppState {
     /// Called when the user clicks "Retry" on a failed terminal surface.
     public var onRetryTerminal: ((UUID) -> Void)?  // receives terminal ID
 
+    /// Called when the user clicks "Retry" on a terminal whose tmux readiness
+    /// watch timed out before the shell signaled it was interactive.
+    public var onRetryReadiness: ((UUID) -> Void)?  // receives terminal ID
+
     /// Called to add a new plain-shell terminal tab to a session.
     public var onAddTerminal: ((UUID) -> Void)?  // receives session ID
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
@@ -42,6 +42,7 @@ public enum TerminalReadiness: String, Codable, Sendable, Comparable {
     case failed           // createSurface() exhausted retries; UI shows error overlay with Retry
     case uninitialized    // GhosttySurfaceView exists but createSurface() not called
     case surfaceCreated   // ghostty_surface_t exists, shell process spawning
+    case timedOut         // Sentinel never appeared within the readiness budget; UI shows Retry
     case shellReady       // Shell prompt detected (probe file appeared)
     case claudeLaunched   // claude --continue has been sent
 
@@ -50,8 +51,9 @@ public enum TerminalReadiness: String, Codable, Sendable, Comparable {
         case .failed: -1
         case .uninitialized: 0
         case .surfaceCreated: 1
-        case .shellReady: 2
-        case .claudeLaunched: 3
+        case .timedOut: 2
+        case .shellReady: 3
+        case .claudeLaunched: 4
         }
     }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/TerminalReadinessTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/TerminalReadinessTests.swift
@@ -9,7 +9,8 @@ struct TerminalReadinessTests {
 
     @Test func statesAreOrdered() {
         #expect(TerminalReadiness.uninitialized < .surfaceCreated)
-        #expect(TerminalReadiness.surfaceCreated < .shellReady)
+        #expect(TerminalReadiness.surfaceCreated < .timedOut)
+        #expect(TerminalReadiness.timedOut < .shellReady)
         #expect(TerminalReadiness.shellReady < .claudeLaunched)
     }
 
@@ -17,12 +18,22 @@ struct TerminalReadinessTests {
         #expect(TerminalReadiness.uninitialized < .claudeLaunched)
         #expect(TerminalReadiness.uninitialized < .shellReady)
         #expect(TerminalReadiness.surfaceCreated < .claudeLaunched)
+        #expect(TerminalReadiness.timedOut < .claudeLaunched)
+    }
+
+    @Test func timedOutGatesAutoPaste() {
+        // The launchClaude guard is `== .shellReady`, so .timedOut must NOT
+        // satisfy `< .shellReady ? false : true` equality checks. Verify the
+        // ordering keeps .timedOut strictly below .shellReady.
+        #expect(TerminalReadiness.timedOut < .shellReady)
+        #expect(TerminalReadiness.timedOut != .shellReady)
     }
 
     @Test func equalStatesAreNotLessThan() {
         #expect(!(TerminalReadiness.uninitialized < .uninitialized))
         #expect(!(TerminalReadiness.shellReady < .shellReady))
         #expect(!(TerminalReadiness.claudeLaunched < .claudeLaunched))
+        #expect(!(TerminalReadiness.timedOut < .timedOut))
     }
 
     // MARK: - Equality
@@ -44,6 +55,7 @@ struct TerminalReadinessTests {
     @Test func rawValues() {
         #expect(TerminalReadiness.uninitialized.rawValue == "uninitialized")
         #expect(TerminalReadiness.surfaceCreated.rawValue == "surfaceCreated")
+        #expect(TerminalReadiness.timedOut.rawValue == "timedOut")
         #expect(TerminalReadiness.shellReady.rawValue == "shellReady")
         #expect(TerminalReadiness.claudeLaunched.rawValue == "claudeLaunched")
     }
@@ -51,7 +63,7 @@ struct TerminalReadinessTests {
     // MARK: - Codable
 
     @Test func codableRoundTrip() throws {
-        let cases: [TerminalReadiness] = [.uninitialized, .surfaceCreated, .shellReady, .claudeLaunched]
+        let cases: [TerminalReadiness] = [.uninitialized, .surfaceCreated, .timedOut, .shellReady, .claudeLaunched]
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -335,14 +335,16 @@ public final class TmuxBackend {
     }
 
     private func startReadinessWatch(id: UUID, sentinelPath: String) {
+        startReadinessWatch(id: id, sentinelPath: sentinelPath, timeoutBudget: 30.0)
+    }
+
+    private func startReadinessWatch(id: UUID, sentinelPath: String, timeoutBudget: TimeInterval) {
         let waiter = SentinelWaiter()
         Task { [weak self] in
-            // 30s budget (was 5s). On app restart with many managed terminals
-            // hydrating concurrently, shell startup is CPU-contended and the
-            // wrapper's first precmd may not fire within 5s. The previous
-            // budget left the readiness UI permanently stuck on
-            // "Waiting for terminal..." in that case, with no recovery path.
-            let timeoutBudget: TimeInterval = 30.0
+            // 30s default budget (was 5s). On app restart with many managed
+            // terminals hydrating concurrently, shell startup is CPU-contended
+            // and the wrapper's first precmd may not fire within 5s. Callers
+            // can pass a longer budget for retries (see retryReadinessWatch).
             let elapsed = await waiter.waitForPrompt(
                 sentinelPath: sentinelPath,
                 timeout: timeoutBudget
@@ -356,20 +358,34 @@ public final class TmuxBackend {
                 } else {
                     // Genuine timeout. Most likely the shell is alive but its
                     // startup is pathologically slow (heavy zshrc + concurrent
-                    // hydrate); less likely the wrapper failed to install the
+                    // hydrate, cold tmux server + App Nap on a backgrounded
+                    // app); less likely the wrapper failed to install the
                     // precmd hook (exotic shell) or the shell crashed at start.
-                    // Advance to .shellReady anyway: a stuck "Waiting for
-                    // terminal..." spinner is strictly worse than letting
-                    // launchClaude proceed. If the shell is alive but slow,
-                    // the paste-buffered `claude --continue` will run when the
-                    // shell finally reads its tty. If the shell is dead, the
-                    // pane stays empty (which is the truthful state).
+                    //
+                    // Surface this via `.timedOut` rather than lying about
+                    // readiness. Auto-paste of the launch command relies on a
+                    // live `zle`, so pasting blind here can leave the pane in
+                    // an unrecoverable state (visible command, no Claude TUI,
+                    // bytes consumed by half-initialized subshells). The UI
+                    // renders a Retry affordance for `.timedOut`; the
+                    // `didBecomeActive` observer also re-arms automatically
+                    // when the app returns to the foreground.
                     let ms = Int(timeoutBudget * 1000)
-                    NSLog("[CrowTelemetry tmux:first_prompt_timeout terminal=\(id) budget_ms=\(ms) — advancing readiness anyway]")
-                    self.onReadinessChanged?(id, .shellReady)
+                    NSLog("[CrowTelemetry tmux:first_prompt_timeout terminal=\(id) budget_ms=\(ms)]")
+                    self.onReadinessChanged?(id, .timedOut)
                 }
             }
         }
+    }
+
+    /// Re-arm the readiness watch for a terminal whose first attempt timed
+    /// out. Clears the stale sentinel file (in case the wrapper now writes
+    /// to it asynchronously) and starts a fresh watch with a longer budget.
+    /// Safe to call repeatedly; previous watches resolve independently.
+    public func retryReadinessWatch(id: UUID, timeoutBudget: TimeInterval = 120.0) {
+        guard let sentinelPath = sentinels[id] else { return }
+        try? FileManager.default.removeItem(atPath: sentinelPath)
+        startReadinessWatch(id: id, sentinelPath: sentinelPath, timeoutBudget: timeoutBudget)
     }
 
     private func shellQuote(_ s: String) -> String {

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -124,4 +124,41 @@ struct TmuxBackendTests {
         // TmuxController's loadBufferAndPaste test.
         #expect(binding.windowIndex >= 0)
     }
+
+    @Test func retryReadinessEmitsTimedOutWhenSentinelMissing() async throws {
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+
+        // Register a terminal with trackReadiness=false so the default 30s
+        // watch isn't armed by registerTerminal. The wrapper still touches
+        // the sentinel on first prompt — retryReadinessWatch wipes it before
+        // the new watch begins, so the test deterministically observes a
+        // timeout.
+        let id = UUID()
+        _ = try backend.registerTerminal(
+            id: id, name: "no-watch", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+
+        // Capture every readiness event the backend emits for this terminal.
+        // No lock needed — TmuxBackend is @MainActor, the test struct is
+        // @MainActor, and the callback hops back to MainActor before firing,
+        // so all access here is serialized on the main actor.
+        var received: [TerminalReadiness] = []
+        backend.onReadinessChanged = { reportedID, state in
+            guard reportedID == id else { return }
+            received.append(state)
+        }
+
+        // 150ms is short enough that the idle shell won't fire another
+        // precmd while we wait, so the watch will time out.
+        backend.retryReadinessWatch(id: id, timeoutBudget: 0.15)
+
+        // Wait long enough for the watch to resolve and the MainActor hop
+        // to deliver the callback.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        #expect(received.contains(.timedOut))
+        #expect(!received.contains(.shellReady))
+    }
 }

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -551,6 +551,32 @@ struct ReadinessAwareTerminal: View {
                 .padding(24)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(CorveilTheme.bgDeep.opacity(0.95))
+            } else if readiness == .timedOut {
+                // Readiness watch expired before the shell signaled it was
+                // interactive. Common on cold tmux start + App Nap on a
+                // backgrounded app + heavy zshrc. The user can retry now, or
+                // the app will retry automatically next time it returns to
+                // the foreground.
+                VStack(spacing: 10) {
+                    Image(systemName: "clock.badge.exclamationmark")
+                        .font(.system(size: 28))
+                        .foregroundStyle(.yellow)
+                    Text("Terminal didn't become ready in time")
+                        .font(.headline)
+                    Text("The shell took longer than expected to start. This usually means the app was backgrounded while a tmux session was warming up.")
+                        .font(.caption)
+                        .foregroundStyle(CorveilTheme.textMuted)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button("Retry") {
+                        appState.onRetryReadiness?(terminal.id)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(CorveilTheme.bgDeep.opacity(0.95))
             } else if readiness < .shellReady {
                 // Loading overlay while terminal is not yet ready
                 VStack(spacing: 8) {

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -608,6 +608,16 @@ struct SessionRow: View {
                     .fill(.yellow)
                     .frame(width: 8, height: 8)
                     .accessibilityLabel("Terminal starting")
+            case .timedOut:
+                Circle()
+                    .fill(.yellow)
+                    .frame(width: 8, height: 8)
+                    .overlay(
+                        Circle()
+                            .stroke(.yellow.opacity(0.4), lineWidth: 2)
+                            .scaleEffect(1.6)
+                    )
+                    .accessibilityLabel("Terminal didn't become ready — click to retry")
             case .shellReady:
                 Circle()
                     .fill(.blue)

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -317,6 +317,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             service?.retryTerminal(terminalID: terminalID)
         }
 
+        appState.onRetryReadiness = { [weak service] terminalID in
+            service?.retryReadiness(terminalID: terminalID)
+        }
+
         // Wire terminal tab management
         appState.onAddTerminal = { [weak service] sessionID in
             service?.addTerminal(sessionID: sessionID)
@@ -548,6 +552,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let window = self?.window,
                       let screen = window.screen ?? NSScreen.main else { return }
                 window.maxSize = screen.visibleFrame.size
+            }
+        }
+
+        // Re-arm any tmux readiness watches that timed out while the app was
+        // backgrounded. App Nap throttles Crow.app's child processes (tmux
+        // server, shell wrapper, user shell) and Crow's own polling Task, so
+        // a 30s first-prompt budget can expire even though the shell is fine
+        // — it just hasn't run its first precmd yet. Once the app comes
+        // forward, the throttle lifts and a fresh watch usually succeeds
+        // within a second.
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.sessionService?.reArmStuckReadinessWatches()
             }
         }
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -289,7 +289,39 @@ final class SessionService {
             if readiness == .shellReady, currentState < .shellReady {
                 self.appState.terminalReadiness[terminalID] = .shellReady
                 self.launchClaude(terminalID: terminalID)
+            } else if readiness == .timedOut, currentState < .shellReady {
+                // First-prompt watch expired. Do NOT advance to .shellReady or
+                // auto-paste — the shell may still be starting and a paste now
+                // can land in a pane without a live line editor. The UI shows
+                // a Retry affordance; `didBecomeActive` also re-arms us
+                // automatically when the app returns to the foreground.
+                self.appState.terminalReadiness[terminalID] = .timedOut
             }
+        }
+    }
+
+    /// Re-arm the tmux readiness watch for a terminal whose first attempt
+    /// timed out. Reverts AppState back to `.surfaceCreated` so the UI
+    /// transitions out of the Retry overlay, and starts a longer-budget
+    /// watch on the backend. Leaves the terminal in `autoLaunchTerminals`
+    /// so a successful sentinel fire still triggers `launchClaude`.
+    func retryReadiness(terminalID: UUID) {
+        guard let current = appState.terminalReadiness[terminalID] else { return }
+        guard current == .timedOut || current < .shellReady else { return }
+        appState.terminalReadiness[terminalID] = .surfaceCreated
+        TmuxBackend.shared.retryReadinessWatch(id: terminalID)
+    }
+
+    /// Re-arm any tmux readiness watches that have stalled while the app
+    /// was backgrounded. Called from `NSApplication.didBecomeActiveNotification`
+    /// so a user who returns to a long-idle app doesn't have to click
+    /// Retry on every review session.
+    func reArmStuckReadinessWatches() {
+        for (terminalID, state) in appState.terminalReadiness {
+            guard appState.autoLaunchTerminals.contains(terminalID) else { continue }
+            guard state == .timedOut else { continue }
+            NSLog("[SessionService] re-arming stuck tmux readiness watch for terminal=\(terminalID)")
+            retryReadiness(terminalID: terminalID)
         }
     }
 


### PR DESCRIPTION
Closes #252.

## Summary
- TmuxBackend used to fire `.shellReady` after a 30 s sentinel timeout to dodge a stuck spinner. That was safe for `claude --continue` but pastes auto-review's multi-KB `"$(cat …prompt.md)"` into a possibly-unborn `zle`, producing the blank-pane / orphaned-command state our teammate hit.
- Add a `.timedOut` state, route timeouts through it without calling `launchClaude`, and expose Retry (manual button + automatic on `didBecomeActive` since App Nap is the dominant cause).
- All 9 changed files; no behavior change on the happy path.

## Test plan
- [x] `make build`
- [x] CrowCore tests (146), incl. new `timedOutGatesAutoPaste`
- [x] CrowTerminal tests (21), incl. new `retryReadinessEmitsTimedOutWhenSentinelMissing` — backend log confirms `tmux:first_prompt_timeout terminal=… budget_ms=150` fires
- [x] CrowUI tests (22)
- [x] Root tests (63)
- [ ] Manual: enable auto-review for a repo with a pending PR, fully quit and relaunch Crow, immediately `cmd-h`, let the poll fire while backgrounded, re-foreground and confirm either Claude is running or the new Retry overlay appears (never the bare-command paste)
- [ ] Manual: confirm Retry on the degraded case re-arms the watch and Claude launches
- [ ] Manual happy-path regression: non-review tmux session with a normal shell still hits `.shellReady` and runs `claude --continue` instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)