### PR TITLE
Add canonical review attribution and snapshot lock

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum CrowAttribution {
+    public static let repoURL = "https://github.com/radiusmethod/crow"
+
+    public static let reviewMarkdownLink =
+        "[🤖 Reviewed by Crow via Claude Code](\(repoURL))"
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Test func crowAttributionRepoURLIsCanonical() {
+    #expect(CrowAttribution.repoURL == "https://github.com/radiusmethod/crow")
+}
+
+@Test func crowAttributionReviewLinkIsCanonical() {
+    #expect(CrowAttribution.reviewMarkdownLink ==
+            "[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)")
+}
+
+@Test func crowAttributionReviewLinkEmbedsRepoURL() {
+    #expect(CrowAttribution.reviewMarkdownLink.contains(CrowAttribution.repoURL))
+}
+
+@Test func crowAttributionContainsNoForkReferences() {
+    #expect(!CrowAttribution.reviewMarkdownLink.contains("nicholasgasior"))
+    #expect(!CrowAttribution.reviewMarkdownLink.lowercased().contains("corveil"))
+}

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -126,7 +126,24 @@ Use this format for the review:
 | Green | Consider items |
 
 **Recommendation:** [Approve / Request Changes / Comment — with reasoning]
+
+---
+
+[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
 ```
+
+### Step 5b: Attribution (REQUIRED)
+
+The review body passed to `gh pr review --body` MUST end with a blank line followed by exactly this line:
+
+```
+[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+```
+
+- Do not modify the link text.
+- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
+- This line MUST appear in every review body, regardless of whether you used `--approve`, `--request-changes`, or `--comment`.
 
 ### Important Notes
 

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import Crow
+
+/// Snapshot tests for the `/crow-review-pr` skill attribution line.
+///
+/// These tests intentionally hardcode the expected attribution string rather
+/// than importing `CrowCore.CrowAttribution`. The unit test in
+/// `Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift` verifies
+/// that the Swift constant matches this literal, so any drift between the
+/// markdown skill file and the Swift constant is caught from both sides.
+@Suite("Review attribution snapshot")
+struct AttributionSkillTests {
+
+    private static let canonicalRepoURL = "https://github.com/radiusmethod/crow"
+    private static let canonicalReviewLink =
+        "[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)"
+
+    /// Walk up from this test source file until we find Package.swift.
+    /// Returns the repo root URL.
+    private static func repoRoot(file: StaticString = #file) -> URL {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0..<10 {
+            if FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("Package.swift").path
+            ) {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        Issue.record("Could not locate Package.swift walking up from \(file)")
+        return URL(fileURLWithPath: "/")
+    }
+
+    private static func liveSkill() throws -> String {
+        let url = repoRoot()
+            .appendingPathComponent("skills/crow-review-pr/SKILL.md")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func bundledTemplate() throws -> String {
+        let url = repoRoot()
+            .appendingPathComponent("Resources/crow-review-pr-SKILL.md.template")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test func liveSkillContainsCanonicalAttributionLink() throws {
+        let content = try Self.liveSkill()
+        #expect(content.contains(Self.canonicalReviewLink))
+    }
+
+    @Test func bundledTemplateContainsCanonicalAttributionLink() throws {
+        let content = try Self.bundledTemplate()
+        #expect(content.contains(Self.canonicalReviewLink))
+    }
+
+    @Test func liveSkillAndBundledTemplateAreByteIdentical() throws {
+        let live = try Self.liveSkill()
+        let bundled = try Self.bundledTemplate()
+        #expect(live == bundled,
+                "skills/crow-review-pr/SKILL.md and Resources/crow-review-pr-SKILL.md.template must stay in sync — Scaffolder.bundledReviewSkill() picks one or the other depending on build type.")
+    }
+
+    @Test func attributionFilesContainNoForkReferences() throws {
+        let live = try Self.liveSkill()
+        let bundled = try Self.bundledTemplate()
+
+        #expect(!live.contains("nicholasgasior"))
+        #expect(!bundled.contains("nicholasgasior"))
+
+        // Lowercase `corveil` — to skip the unrelated `CorveilTheme.swift`
+        // design-system file which uses capital `C`.
+        #expect(!live.contains("corveil"))
+        #expect(!bundled.contains("corveil"))
+    }
+
+    @Test func liveSkillLinksOnlyToCanonicalRepo() throws {
+        // Any github.com link in the review skill must point at radiusmethod/crow.
+        // This catches drift where a contributor pastes a fork URL.
+        let content = try Self.liveSkill()
+        let pattern = #"https://github\.com/[A-Za-z0-9._/-]+"#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(content.startIndex..., in: content)
+        let matches = regex.matches(in: content, range: range)
+        #expect(!matches.isEmpty, "expected at least one github.com link (the attribution line) in the skill")
+        for match in matches {
+            guard let r = Range(match.range, in: content) else { continue }
+            let url = String(content[r])
+            #expect(url == Self.canonicalRepoURL,
+                    "review skill contains non-canonical github.com link: \(url)")
+        }
+    }
+}

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -126,7 +126,24 @@ Use this format for the review:
 | Green | Consider items |
 
 **Recommendation:** [Approve / Request Changes / Comment — with reasoning]
+
+---
+
+[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
 ```
+
+### Step 5b: Attribution (REQUIRED)
+
+The review body passed to `gh pr review --body` MUST end with a blank line followed by exactly this line:
+
+```
+[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+```
+
+- Do not modify the link text.
+- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
+- This line MUST appear in every review body, regardless of whether you used `--approve`, `--request-changes`, or `--comment`.
 
 ### Important Notes
 


### PR DESCRIPTION
Closes #254.

## Summary

- The `/crow-review-pr` skill now appends a fixed attribution line to every review body so the link can't drift to a personal fork:

  `[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)`

- Adds `CrowAttribution` in `CrowCore` as the single source of truth for the canonical repo URL and the markdown link.
- Snapshot tests pin the live skill (`skills/crow-review-pr/SKILL.md`) and the bundled `.template` (used by `.app` builds via `Scaffolder.bundledReviewSkill()`) byte-identical, with regex coverage proving every `github.com` link in the skill targets `radiusmethod/crow` and asserts no `nicholasgasior` / lowercase `corveil` references exist.

## Context

Ticket #254 reported a bug where the attribution link pointed to a personal fork. An exhaustive audit (Swift sources, skill markdown, bundled templates, tests) found that the "Reviewed by Crow via Claude Code" line **did not exist anywhere** in the codebase — the branch was at the same SHA as `main`, and the only attribution Crow emitted was the unrelated `Crow-Session:` commit trailer. Per direction, #254 was treated as a new feature: introduce the missing review-attribution line, wire it to a single canonical URL, and lock it down with snapshot tests so a fork can never leak in.

## Test plan

- [x] `swift build` — compiles clean
- [x] CrowCore tests (150) — including 4 new `crowAttribution*` unit tests
- [x] Root CrowTests (68) — including 5 new `AttributionSkill` snapshot tests
- [x] `grep -rn nicholasgasior` — only matches the audit assertions in test files
- [ ] Manual: trigger `/crow-review-pr <PR#>` on an open PR and verify the body posted to `gh pr review --body` ends with `[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)` and renders as a hyperlink to `radiusmethod/crow` in GitHub's UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)