### PR TITLE
tmux readiness diagnostics: wrapper breadcrumbs + on-timeout capture

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -222,6 +222,12 @@ public final class AppState {
     /// watch timed out before the shell signaled it was interactive.
     public var onRetryReadiness: ((UUID) -> Void)?  // receives terminal ID
 
+    /// Called when the user clicks "Copy diagnostics" on a terminal whose
+    /// tmux readiness watch timed out. The handler captures a multi-section
+    /// bundle (wrapper log, pane capture, ps tree, sentinel state) and
+    /// places it on the clipboard (issue #256).
+    public var onCopyDiagnostics: ((UUID) -> Void)?  // receives terminal ID
+
     /// Called to add a new plain-shell terminal tab to a session.
     public var onAddTerminal: ((UUID) -> Void)?  // receives session ID
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
@@ -4,7 +4,9 @@
 # Bundled with Crow.app, copied to a temp path at terminal create time. The
 # Crow app sets CROW_SENTINEL in the env (per-terminal) before exec'ing this
 # script. Each prompt firing touches that file, which the Swift readiness
-# detector polls.
+# detector polls. Optional CROW_WRAPPER_LOG points at a per-terminal log file
+# the wrapper appends stage breadcrumbs to (issue #256) — Swift surfaces it
+# on .timedOut so a teammate can copy a one-clipboard diagnostic bundle.
 #
 # This wrapper is intentionally minimal:
 #   1. Source the user's normal shell startup (zsh: .zshrc; bash: .bashrc) so
@@ -27,7 +29,37 @@ if [ -z "${CROW_SENTINEL:-}" ]; then
 fi
 export CROW_SENTINEL
 
+# CROW_WRAPPER_LOG is optional. Default to /dev/null so the helper is always
+# safe to call without an unset-var guard. Issue #256.
+CROW_WRAPPER_LOG="${CROW_WRAPPER_LOG:-/dev/null}"
+export CROW_WRAPPER_LOG
+
+crow_log() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$CROW_WRAPPER_LOG" 2>/dev/null || true
+}
+
+# Opt-in verbose tracing for hard-to-repro setup bugs. Routes shell xtrace to
+# the same log file (issue #256).
+if [ "${CROW_WRAPPER_DEBUG:-}" = "1" ] && [ "$CROW_WRAPPER_LOG" != "/dev/null" ]; then
+  exec 2>>"$CROW_WRAPPER_LOG"
+  set -x
+fi
+
 if [ -z "${SHELL:-}" ]; then SHELL=/bin/zsh; fi
+
+crow_log "start pid=$$ shell=$SHELL tmux=${TMUX:+yes} sentinel=$CROW_SENTINEL log=$CROW_WRAPPER_LOG"
+
+# Cross-check $SHELL against directory services. Mismatch can mean the user
+# chsh'd to a brew-installed shell but the parent process inherited an old
+# $SHELL — surfacing this in the log helps diagnose the case in issue #256 §4.
+# We do NOT override $SHELL; just record the discrepancy.
+if command -v dscl >/dev/null 2>&1 && [ -n "${USER:-}" ]; then
+  _crow_dscl_shell=$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}')
+  if [ -n "$_crow_dscl_shell" ] && [ "$_crow_dscl_shell" != "$SHELL" ]; then
+    crow_log "shell_mismatch env_shell=$SHELL dscl_shell=$_crow_dscl_shell"
+  fi
+  unset _crow_dscl_shell
+fi
 
 case "$SHELL" in
   *zsh)
@@ -35,16 +67,32 @@ case "$SHELL" in
     # at a temp dir whose .zshrc sources the user's real config, then appends
     # our hook via add-zsh-hook (which composes with any existing precmd).
     ZTMP="$(mktemp -d -t crowzdotdir)"
+    if [ -z "$ZTMP" ] || [ ! -d "$ZTMP" ]; then
+      crow_log "mktemp_failed branch=zsh status=$?"
+      echo "crow-shell-wrapper: mktemp -d failed for zsh ZDOTDIR" >&2
+      exit 73
+    fi
+    crow_log "zdotdir_temp_created path=$ZTMP"
     cat > "$ZTMP/.zshrc" <<'ZRC'
+# Helper redefined inside the embedded rc — it runs in the new shell, so it
+# needs its own crow_log. Same file the wrapper appends to (issue #256).
+crow_log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "${CROW_WRAPPER_LOG:-/dev/null}" 2>/dev/null || true; }
+
 # Source the user's real config from their original ZDOTDIR (or $HOME).
 if [ -n "${CROW_USER_ZDOTDIR:-}" ]; then
   ZDOTDIR="$CROW_USER_ZDOTDIR"
 else
   ZDOTDIR="$HOME"
 fi
-[ -f "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
+if [ -f "$ZDOTDIR/.zshrc" ]; then
+  source "$ZDOTDIR/.zshrc"
+  crow_log "user_rc_sourced rc=$ZDOTDIR/.zshrc"
+else
+  crow_log "user_rc_skipped reason=missing rc=$ZDOTDIR/.zshrc"
+fi
 
 _crow_precmd() {
+  crow_log "precmd_fired"
   if [ -n "${TMUX:-}" ]; then
     printf '\033Ptmux;\033\033]133;A\007\033\\'
     printf '\033Ptmux;\033\033]9;crow-ready\007\033\\'
@@ -52,17 +100,51 @@ _crow_precmd() {
     printf '\033]133;A\007'
     printf '\033]9;crow-ready\007'
   fi
-  : > "$CROW_SENTINEL" 2>/dev/null || true
+  if : > "$CROW_SENTINEL" 2>>"${CROW_WRAPPER_LOG:-/dev/null}"; then
+    crow_log "sentinel_written"
+  else
+    crow_log "sentinel_write_failed status=$?"
+  fi
+  # Self-disarm logging after first prompt so we don't bloat the log on every
+  # subsequent prompt (issue #256).
+  crow_log() { :; }
 }
-autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook precmd _crow_precmd
+
+if autoload -Uz add-zsh-hook 2>/dev/null; then
+  add-zsh-hook precmd _crow_precmd
+  crow_log "hook_installed mechanism=add-zsh-hook"
+else
+  crow_log "add_zsh_hook_unavailable"
+fi
+# Belt-and-braces (issue #256 §4): covers the case where a deferred plugin
+# reassigns precmd_functions=(...) after our install. add-zsh-hook already
+# dedupes, so this is safe even when the hook is already registered.
+if (( ${precmd_functions[(I)_crow_precmd]:-0} == 0 )); then
+  precmd_functions+=(_crow_precmd)
+  crow_log "hook_installed mechanism=precmd_functions_append"
+fi
 ZRC
+    crow_log "pre_exec shell=$SHELL"
     CROW_USER_ZDOTDIR="${ZDOTDIR:-$HOME}" ZDOTDIR="$ZTMP" exec "$SHELL" -i
     ;;
   *bash)
     BTMP="$(mktemp -t crowbashrc.XXXXXX)"
+    if [ -z "$BTMP" ] || [ ! -f "$BTMP" ]; then
+      crow_log "mktemp_failed branch=bash status=$?"
+      echo "crow-shell-wrapper: mktemp failed for bash rcfile" >&2
+      exit 73
+    fi
+    crow_log "zdotdir_temp_created path=$BTMP"
     cat > "$BTMP" <<'BRC'
-[ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"
+crow_log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "${CROW_WRAPPER_LOG:-/dev/null}" 2>/dev/null || true; }
+if [ -f "$HOME/.bashrc" ]; then
+  source "$HOME/.bashrc"
+  crow_log "user_rc_sourced rc=$HOME/.bashrc"
+else
+  crow_log "user_rc_skipped reason=missing rc=$HOME/.bashrc"
+fi
 _crow_precmd() {
+  crow_log "precmd_fired"
   if [ -n "${TMUX:-}" ]; then
     printf '\033Ptmux;\033\033]133;A\007\033\\'
     printf '\033Ptmux;\033\033]9;crow-ready\007\033\\'
@@ -70,7 +152,12 @@ _crow_precmd() {
     printf '\033]133;A\007'
     printf '\033]9;crow-ready\007'
   fi
-  : > "$CROW_SENTINEL" 2>/dev/null || true
+  if : > "$CROW_SENTINEL" 2>>"${CROW_WRAPPER_LOG:-/dev/null}"; then
+    crow_log "sentinel_written"
+  else
+    crow_log "sentinel_write_failed status=$?"
+  fi
+  crow_log() { :; }
 }
 # Preserve any existing PROMPT_COMMAND.
 if [ -n "${PROMPT_COMMAND:-}" ]; then
@@ -78,18 +165,26 @@ if [ -n "${PROMPT_COMMAND:-}" ]; then
 else
   PROMPT_COMMAND="_crow_precmd"
 fi
+crow_log "hook_installed mechanism=PROMPT_COMMAND"
 BRC
+    crow_log "pre_exec shell=$SHELL"
     exec "$SHELL" --rcfile "$BTMP" -i
     ;;
   *)
     # fish / unknown: best-effort. Emit markers once at startup; no per-prompt
     # hook. Production work would extend this with shell-specific paths.
+    crow_log "hook_skipped reason=unsupported_shell shell=$SHELL"
     if [ -n "${TMUX:-}" ]; then
       printf '\033Ptmux;\033\033]133;A\007\033\\\033Ptmux;\033\033]9;crow-ready\007\033\\'
     else
       printf '\033]133;A\007\033]9;crow-ready\007'
     fi
-    : > "$CROW_SENTINEL" 2>/dev/null || true
+    if : > "$CROW_SENTINEL" 2>>"${CROW_WRAPPER_LOG:-/dev/null}"; then
+      crow_log "sentinel_written"
+    else
+      crow_log "sentinel_write_failed status=$?"
+    fi
+    crow_log "pre_exec shell=$SHELL"
     exec "$SHELL" -i
     ;;
 esac

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -53,6 +53,11 @@ public final class TmuxBackend {
     /// UUID → per-terminal sentinel path. Cleared on destroy.
     private var sentinels: [UUID: String] = [:]
 
+    /// UUID → per-terminal wrapper-log path. Populated alongside `sentinels`
+    /// so `captureDiagnostics(id:)` can read it back on `.timedOut`. Cleared
+    /// on destroy. Issue #256.
+    private var wrapperLogs: [UUID: String] = [:]
+
     /// Offscreen window the shared surface lives in until SwiftUI re-parents
     /// it into the visible UI. Same trick the Ghostty path uses for
     /// background surface creation.
@@ -106,6 +111,10 @@ public final class TmuxBackend {
             try? FileManager.default.removeItem(atPath: path)
         }
         sentinels.removeAll()
+        for path in wrapperLogs.values {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+        wrapperLogs.removeAll()
     }
 
     // MARK: - Per-terminal API (mirrors TerminalManager surface)
@@ -136,6 +145,13 @@ public final class TmuxBackend {
         try? FileManager.default.removeItem(atPath: sentinelPath)
         sentinels[id] = sentinelPath
 
+        // Per-terminal wrapper log. The bundled shell wrapper writes stage
+        // breadcrumbs here so `captureDiagnostics(id:)` can include them in
+        // the .timedOut bundle (issue #256).
+        let wrapperLog = wrapperLogPath(for: id)
+        try? FileManager.default.removeItem(atPath: wrapperLog)
+        wrapperLogs[id] = wrapperLog
+
         // Shell wrapper does the readiness markers + sources user's shell
         // config. Each tmux window's child process *is* the wrapper.
         guard let wrapperURL = BundledResources.shellWrapperScriptURL else {
@@ -143,7 +159,10 @@ public final class TmuxBackend {
         }
         let wrapperPath = wrapperURL.path
 
-        var env = ["CROW_SENTINEL": sentinelPath]
+        var env = [
+            "CROW_SENTINEL": sentinelPath,
+            "CROW_WRAPPER_LOG": wrapperLog,
+        ]
         if !cwd.isEmpty { env["PWD"] = cwd }
 
         let windowIndex = try ctrl.newWindow(
@@ -191,6 +210,7 @@ public final class TmuxBackend {
         // touched the file when the original window was created.
         let sentinelPath = sentinelPath(for: id)
         sentinels[id] = sentinelPath
+        wrapperLogs[id] = wrapperLogPath(for: id)
         if trackReadiness, FileManager.default.fileExists(atPath: sentinelPath) {
             onReadinessChanged?(id, .shellReady)
         } else if trackReadiness {
@@ -245,6 +265,9 @@ public final class TmuxBackend {
         bindings.removeValue(forKey: id)
         if let sentinelPath = sentinels.removeValue(forKey: id) {
             try? FileManager.default.removeItem(atPath: sentinelPath)
+        }
+        if let logPath = wrapperLogs.removeValue(forKey: id) {
+            try? FileManager.default.removeItem(atPath: logPath)
         }
     }
 
@@ -334,12 +357,35 @@ public final class TmuxBackend {
             .appendingPathComponent("crow-ready-\(id.uuidString).sentinel")
     }
 
+    /// Per-terminal log path for `crow-shell-wrapper.sh` stage breadcrumbs
+    /// (issue #256). Stable across `registerTerminal` / `adoptTerminal` /
+    /// `retryReadinessWatch` for a given terminal UUID.
+    private func wrapperLogPath(for id: UUID) -> String {
+        let dir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp/"
+        return (dir as NSString)
+            .appendingPathComponent("crow-wrapper-\(id.uuidString).log")
+    }
+
     private func startReadinessWatch(id: UUID, sentinelPath: String) {
         startReadinessWatch(id: id, sentinelPath: sentinelPath, timeoutBudget: 30.0)
     }
 
     private func startReadinessWatch(id: UUID, sentinelPath: String, timeoutBudget: TimeInterval) {
         let waiter = SentinelWaiter()
+        // Periodic progress beacon every 10s so operators tailing the log can
+        // see the watch is alive and whether the sentinel has appeared yet
+        // (issue #256). Cancelled when the waiter resolves.
+        let progressTask = Task { [weak self] in
+            let startedAt = Date()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                if Task.isCancelled { break }
+                let elapsed = Int(Date().timeIntervalSince(startedAt) * 1000)
+                let exists = FileManager.default.fileExists(atPath: sentinelPath)
+                _ = self  // keep the capture; method-level NSLog is fine
+                NSLog("[CrowTelemetry tmux:first_prompt_progress terminal=\(id) elapsed_ms=\(elapsed) sentinel_exists=\(exists)]")
+            }
+        }
         Task { [weak self] in
             // 30s default budget (was 5s). On app restart with many managed
             // terminals hydrating concurrently, shell startup is CPU-contended
@@ -349,6 +395,7 @@ public final class TmuxBackend {
                 sentinelPath: sentinelPath,
                 timeout: timeoutBudget
             )
+            progressTask.cancel()
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 if let elapsed {
@@ -372,6 +419,11 @@ public final class TmuxBackend {
                     // when the app returns to the foreground.
                     let ms = Int(timeoutBudget * 1000)
                     NSLog("[CrowTelemetry tmux:first_prompt_timeout terminal=\(id) budget_ms=\(ms)]")
+                    // Capture stage-by-stage diagnostics and dump them to the
+                    // system log alongside the timeout marker. The UI surfaces
+                    // the same bundle via "Copy diagnostics" (issue #256).
+                    let bundle = self.captureDiagnostics(id: id)
+                    NSLog("[CrowTelemetry tmux:first_prompt_diagnostics terminal=\(id)]\n\(bundle)")
                     self.onReadinessChanged?(id, .timedOut)
                 }
             }
@@ -386,6 +438,185 @@ public final class TmuxBackend {
         guard let sentinelPath = sentinels[id] else { return }
         try? FileManager.default.removeItem(atPath: sentinelPath)
         startReadinessWatch(id: id, sentinelPath: sentinelPath, timeoutBudget: timeoutBudget)
+    }
+
+    /// Build a stage-by-stage diagnostic bundle for terminal `id`. Captures
+    /// pane contents, pane PID + process tree, sentinel state, and the
+    /// wrapper's breadcrumb log. Each section is wrapped so a single missing
+    /// piece doesn't lose the rest; per-section output is capped to keep the
+    /// clipboard payload sane. Called from the readiness-watch timeout path
+    /// (logged via NSLog) and from the UI "Copy diagnostics" button
+    /// (issue #256).
+    public func captureDiagnostics(id: UUID) -> String {
+        let sectionCap = 8_192
+        var lines: [String] = []
+        lines.append("=== Crow tmux readiness diagnostics ===")
+        lines.append("terminal=\(id)")
+        lines.append("captured_at=\(ISO8601DateFormatter().string(from: Date()))")
+        lines.append("")
+
+        // Section 1: environment & host
+        lines.append("--- environment ---")
+        let env = ProcessInfo.processInfo.environment
+        lines.append("SHELL=\(env["SHELL"] ?? "")")
+        lines.append("PATH=\(env["PATH"] ?? "")")
+        lines.append("TERM=\(env["TERM"] ?? "")")
+        lines.append("USER=\(env["USER"] ?? "")")
+        if !tmuxBinary.isEmpty,
+           let ver = TmuxController.versionString(tmuxBinary: tmuxBinary) {
+            lines.append("tmux=\(ver)")
+        } else {
+            lines.append("tmux=<unknown>")
+        }
+        if let dscl = runShortCommand(
+            "/usr/bin/dscl",
+            ["." , "-read", "/Users/\(env["USER"] ?? "")", "UserShell"]
+        ) {
+            lines.append("dscl=\(dscl.trimmingCharacters(in: .whitespacesAndNewlines))")
+        }
+        lines.append("")
+
+        // Section 2: tmux state for this terminal's window
+        lines.append("--- tmux state ---")
+        guard let windowIndex = bindings[id] else {
+            lines.append("no binding for terminal \(id) — window never created")
+            lines.append("")
+            return appendSentinelAndLog(id: id, sectionCap: sectionCap, lines: lines)
+        }
+        let ctrl = controller
+        if let ctrl {
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            lines.append("target=\(target)")
+
+            // pane_pid + pane_current_command — what's actually running in
+            // the pane right now.
+            var panePID: Int32?
+            if let info = try? ctrl.displayMessage(
+                target: target,
+                format: "#{pane_pid} #{pane_current_command}"
+            ) {
+                let trimmed = info.trimmingCharacters(in: .whitespacesAndNewlines)
+                lines.append("display_message=\(trimmed)")
+                if let firstField = trimmed.split(separator: " ").first,
+                   let pid = Int32(firstField) {
+                    panePID = pid
+                }
+            } else {
+                lines.append("display_message=<failed>")
+            }
+            lines.append("")
+
+            // ps on the pane PID + immediate descendants. Reveals whether the
+            // wrapper is still alive or has exec'd into the shell.
+            lines.append("--- process tree ---")
+            if let pid = panePID {
+                if let ps = runShortCommand(
+                    "/bin/ps",
+                    ["-o", "pid,ppid,stat,etime,command", "-p", "\(pid)"]
+                ) {
+                    lines.append(ps.trimmingCharacters(in: .whitespacesAndNewlines))
+                }
+                if let children = runShortCommand("/usr/bin/pgrep", ["-P", "\(pid)"]) {
+                    let childPIDs = children.split(separator: "\n").map(String.init).filter { !$0.isEmpty }
+                    for child in childPIDs {
+                        if let ps = runShortCommand(
+                            "/bin/ps",
+                            ["-o", "pid,ppid,stat,etime,command", "-p", child]
+                        ) {
+                            lines.append(ps.trimmingCharacters(in: .whitespacesAndNewlines))
+                        }
+                    }
+                }
+            } else {
+                lines.append("<no pane pid available>")
+            }
+            lines.append("")
+
+            // Pane capture — usually the single most useful signal: shows
+            // whether we're stuck at the shell prompt, mid-.zshrc, or showing
+            // a python traceback from oh-my-zsh.
+            lines.append("--- pane capture (last 200 lines) ---")
+            if let pane = try? ctrl.capturePane(target: target, linesBack: 200) {
+                lines.append(truncated(pane, max: sectionCap))
+            } else {
+                lines.append("<capture-pane failed>")
+            }
+            lines.append("")
+        } else {
+            lines.append("controller not initialized")
+            lines.append("")
+        }
+
+        return appendSentinelAndLog(id: id, sectionCap: sectionCap, lines: lines)
+    }
+
+    private func appendSentinelAndLog(id: UUID, sectionCap: Int, lines: [String]) -> String {
+        var out = lines
+
+        // Sentinel state — exists? size? parent writable?
+        out.append("--- sentinel ---")
+        if let path = sentinels[id] {
+            out.append("path=\(path)")
+            let fm = FileManager.default
+            let exists = fm.fileExists(atPath: path)
+            out.append("exists=\(exists)")
+            if exists, let attrs = try? fm.attributesOfItem(atPath: path) {
+                if let size = attrs[.size] as? Int { out.append("size=\(size)") }
+                if let mtime = attrs[.modificationDate] as? Date {
+                    out.append("mtime=\(ISO8601DateFormatter().string(from: mtime))")
+                }
+            }
+            let parent = (path as NSString).deletingLastPathComponent
+            out.append("parent=\(parent) parent_writable=\(fm.isWritableFile(atPath: parent))")
+        } else {
+            out.append("no sentinel path recorded for terminal \(id)")
+        }
+        out.append("")
+
+        // Wrapper log — the breadcrumb trail.
+        out.append("--- wrapper log ---")
+        if let path = wrapperLogs[id] {
+            out.append("path=\(path)")
+            if let data = try? String(contentsOfFile: path, encoding: .utf8) {
+                out.append(truncated(data, max: sectionCap))
+            } else {
+                out.append("<log not readable or absent>")
+            }
+        } else {
+            out.append("no wrapper log path recorded for terminal \(id)")
+        }
+        out.append("")
+        out.append("=== end diagnostics ===")
+        return out.joined(separator: "\n")
+    }
+
+    /// Run a short command and return its stdout (≤2s timeout). Used by
+    /// `captureDiagnostics` so any single subprocess hanging can't wedge the
+    /// main actor. Returns `nil` on any failure (missing binary, non-zero
+    /// exit, timeout) so the caller can fall back gracefully.
+    private func runShortCommand(_ launchPath: String, _ args: [String]) -> String? {
+        guard FileManager.default.isExecutableFile(atPath: launchPath) else { return nil }
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: launchPath)
+        p.arguments = args
+        let outPipe = Pipe()
+        p.standardOutput = outPipe
+        p.standardError = Pipe()
+        do { try p.run() } catch { return nil }
+        let queue = DispatchQueue.global(qos: .utility)
+        let killer = DispatchWorkItem { if p.isRunning { p.terminate() } }
+        queue.asyncAfter(deadline: .now() + 2.0, execute: killer)
+        p.waitUntilExit()
+        killer.cancel()
+        guard p.terminationStatus == 0 else { return nil }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func truncated(_ s: String, max: Int) -> String {
+        if s.count <= max { return s }
+        let head = s.prefix(max)
+        return head + "\n…(truncated; \(s.count - max) chars omitted)"
     }
 
     private func shellQuote(_ s: String) -> String {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -212,6 +212,21 @@ public struct TmuxController: Sendable {
 
     // MARK: - Diagnostic
 
+    /// `tmux capture-pane -p -t <target> -S -<linesBack>`. Returns the
+    /// visible pane contents (last `linesBack` lines). Used by the readiness
+    /// timeout diagnostics to show what state the shell got stuck in
+    /// (issue #256).
+    public func capturePane(target: String, linesBack: Int = 200) throws -> String {
+        try run(["capture-pane", "-p", "-t", target, "-S", "-\(linesBack)"])
+    }
+
+    /// `tmux display-message -p -t <target> <format>`. Used by the readiness
+    /// timeout diagnostics to read `#{pane_pid}` and `#{pane_current_command}`
+    /// for the wedged window (issue #256).
+    public func displayMessage(target: String, format: String) throws -> String {
+        try run(["display-message", "-p", "-t", target, format])
+    }
+
     public static func versionString(tmuxBinary: String) -> String? {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: tmuxBinary)

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/CrowShellWrapperTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/CrowShellWrapperTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Testing
+@testable import CrowTerminal
+
+/// Tests for the bundled `crow-shell-wrapper.sh` stage breadcrumbs (#256).
+///
+/// We invoke the wrapper as a subprocess with a controlled environment so
+/// the assertions don't depend on the developer's actual `~/.zshrc`. Two
+/// flavors:
+///   1. Setup-phase test: uses a fake `*-zsh` shell that exits immediately,
+///      proving the wrapper writes the breadcrumbs it controls directly
+///      (`start`, `zdotdir_temp_created`, `pre_exec`).
+///   2. Runtime test (zsh-only, skipped if /bin/zsh is absent): drives a
+///      real zsh through a controlled `.zshrc` so we observe the runtime
+///      breadcrumbs (`user_rc_sourced`, `hook_installed`, `precmd_fired`,
+///      `sentinel_written`).
+///   3. Sentinel-failure test: points `CROW_SENTINEL` at an un-writable
+///      path and confirms the wrapper logs `sentinel_write_failed`.
+@Suite("crow-shell-wrapper breadcrumbs")
+struct CrowShellWrapperTests {
+
+    /// Spawn the wrapper, wait for it to exit, return the breadcrumb log.
+    /// All temp files live under the returned `workDir` for inspection on
+    /// failure.
+    private struct Fixture {
+        let workDir: URL
+        let sentinel: String
+        let log: String
+        let logContents: String
+    }
+
+    private func runWrapper(
+        shell: String,
+        userZdotdir: String? = nil,
+        sentinelOverride: String? = nil,
+        timeoutSeconds: TimeInterval = 8.0
+    ) throws -> Fixture {
+        guard let wrapperURL = BundledResources.shellWrapperScriptURL else {
+            throw WrapperTestError.missingWrapperScript
+        }
+
+        let workDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-wrapper-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+
+        let sentinel = sentinelOverride
+            ?? workDir.appendingPathComponent("sentinel").path
+        let log = workDir.appendingPathComponent("wrapper.log").path
+
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/bash")
+        p.arguments = [wrapperURL.path]
+        var env: [String: String] = [
+            "SHELL": shell,
+            "CROW_SENTINEL": sentinel,
+            "CROW_WRAPPER_LOG": log,
+            "HOME": workDir.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "USER": ProcessInfo.processInfo.environment["USER"] ?? "test",
+        ]
+        if let userZdotdir { env["ZDOTDIR"] = userZdotdir }
+        p.environment = env
+        p.standardInput = FileHandle(forReadingAtPath: "/dev/null")
+        p.standardOutput = Pipe()
+        p.standardError = Pipe()
+        try p.run()
+
+        // Kill the process after `timeoutSeconds` regardless of state — for
+        // the runtime test the shell is interactive and won't exit on its
+        // own. The setup-phase test exits much sooner.
+        let deadline = DispatchWorkItem { if p.isRunning { p.terminate() } }
+        DispatchQueue.global(qos: .utility)
+            .asyncAfter(deadline: .now() + timeoutSeconds, execute: deadline)
+        p.waitUntilExit()
+        deadline.cancel()
+
+        let logContents = (try? String(contentsOfFile: log, encoding: .utf8)) ?? ""
+        return Fixture(
+            workDir: workDir,
+            sentinel: sentinel,
+            log: log,
+            logContents: logContents
+        )
+    }
+
+    /// Drop a `*-zsh`-named fake shell that exits immediately. Lets us trip
+    /// the wrapper's zsh code path without invoking a real shell.
+    private func makeFakeZshShell(in dir: URL) throws -> String {
+        let path = dir.appendingPathComponent("myshell-zsh").path
+        let script = "#!/bin/sh\nexit 0\n"
+        try script.write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        return path
+    }
+
+    private enum WrapperTestError: Error {
+        case missingWrapperScript
+    }
+
+    // MARK: - Tests
+
+    @Test func setupPhaseBreadcrumbsAreEmitted() throws {
+        // Setup-phase tests are deterministic — no real shell needed.
+        let scratch = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-fake-shell-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        let fakeShell = try makeFakeZshShell(in: scratch)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let fx = try runWrapper(shell: fakeShell)
+        defer { try? FileManager.default.removeItem(at: fx.workDir) }
+
+        #expect(fx.logContents.contains(" start "))
+        #expect(fx.logContents.contains(" zdotdir_temp_created "))
+        #expect(fx.logContents.contains(" pre_exec "))
+    }
+
+    @Test(.enabled(if: FileManager.default.isExecutableFile(atPath: "/bin/zsh")))
+    func runtimeBreadcrumbsWithRealZsh() throws {
+        // Point CROW_USER_ZDOTDIR at a controlled dir whose .zshrc exits the
+        // shell as soon as the first prompt has fired — so the test resolves
+        // quickly.
+        let userZdotdir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-userz-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: userZdotdir, withIntermediateDirectories: true)
+        // Minimal user .zshrc: a comment is enough — we just need the file
+        // to exist so the wrapper logs `user_rc_sourced`.
+        try "# crow wrapper test rc\n".write(
+            to: userZdotdir.appendingPathComponent(".zshrc"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: userZdotdir) }
+
+        // Override CROW_USER_ZDOTDIR via env, then run wrapper. The wrapper
+        // re-exports ZDOTDIR=$ZTMP and the embedded rc reads CROW_USER_ZDOTDIR
+        // from env. Inject via runWrapper's `userZdotdir` parameter — but
+        // that parameter sets ZDOTDIR (the user's), which the wrapper then
+        // moves into CROW_USER_ZDOTDIR. Same effect.
+        let fx = try runWrapper(
+            shell: "/bin/zsh",
+            userZdotdir: userZdotdir.path,
+            timeoutSeconds: 6.0
+        )
+        defer { try? FileManager.default.removeItem(at: fx.workDir) }
+
+        // We can't guarantee the shell prints a prompt without a PTY, so
+        // we tolerate either of two outcomes:
+        //   (a) the shell *did* fire precmd → full chain present
+        //   (b) the shell didn't reach a prompt → at minimum the user_rc
+        //       sourcing + hook install lines must be there
+        let setupLine = fx.logContents.contains("hook_installed mechanism=add-zsh-hook")
+            || fx.logContents.contains("hook_installed mechanism=precmd_functions_append")
+        let sourcedLine = fx.logContents.contains("user_rc_sourced")
+            || fx.logContents.contains("user_rc_skipped")
+        #expect(setupLine, "expected hook_installed line in:\n\(fx.logContents)")
+        #expect(sourcedLine, "expected user_rc line in:\n\(fx.logContents)")
+        // pre_exec must appear regardless — it's a wrapper-side breadcrumb
+        // emitted before the shell starts.
+        #expect(fx.logContents.contains(" pre_exec "))
+    }
+
+    @Test(.enabled(if: FileManager.default.isExecutableFile(atPath: "/bin/zsh")))
+    func sentinelWriteFailureIsLogged() throws {
+        // Point CROW_SENTINEL at a path under a non-existent directory so the
+        // wrapper's redirect can't possibly succeed. Then check the wrapper
+        // log for the `sentinel_write_failed` breadcrumb. Requires the shell
+        // to actually fire its precmd hook — best-effort here; if the shell
+        // never prompts under the test harness, we don't fail loudly.
+        let userZdotdir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-userz-fail-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: userZdotdir, withIntermediateDirectories: true)
+        try "# crow wrapper test rc\n".write(
+            to: userZdotdir.appendingPathComponent(".zshrc"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: userZdotdir) }
+
+        let badSentinel = "/this/path/cannot/exist/crow-sentinel"
+        let fx = try runWrapper(
+            shell: "/bin/zsh",
+            userZdotdir: userZdotdir.path,
+            sentinelOverride: badSentinel,
+            timeoutSeconds: 6.0
+        )
+        defer { try? FileManager.default.removeItem(at: fx.workDir) }
+
+        // The strong assertion — wrapper-side setup must still complete.
+        #expect(fx.logContents.contains(" pre_exec "))
+        // Best-effort: if precmd ever fires, we expect a failure line. We
+        // don't make this an unconditional #expect because non-tty zsh may
+        // not reach a prompt before we kill it. The log path itself remains
+        // a useful diagnostic if this turns out flaky.
+        if fx.logContents.contains("precmd_fired") {
+            #expect(fx.logContents.contains("sentinel_write_failed"))
+        }
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -516,6 +516,8 @@ struct ReadinessAwareTerminal: View {
     let terminal: SessionTerminal
     @Bindable var appState: AppState
 
+    @State private var diagnosticsCopied = false
+
     private var readiness: TerminalReadiness {
         appState.terminalReadiness[terminal.id] ?? .claudeLaunched  // Default for non-tracked terminals
     }
@@ -568,11 +570,27 @@ struct ReadinessAwareTerminal: View {
                         .foregroundStyle(CorveilTheme.textMuted)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
-                    Button("Retry") {
-                        appState.onRetryReadiness?(terminal.id)
+                    HStack(spacing: 10) {
+                        Button("Retry") {
+                            appState.onRetryReadiness?(terminal.id)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+
+                        // Bundles wrapper-stage log + pane capture + ps tree +
+                        // sentinel state onto the clipboard so reporters can
+                        // paste a one-shot diagnostic into a comment instead
+                        // of describing the symptom (issue #256).
+                        Button(diagnosticsCopied ? "Copied!" : "Copy diagnostics") {
+                            appState.onCopyDiagnostics?(terminal.id)
+                            diagnosticsCopied = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                diagnosticsCopied = false
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.regular)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
                 }
                 .padding(24)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -321,6 +321,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             service?.retryReadiness(terminalID: terminalID)
         }
 
+        appState.onCopyDiagnostics = { [weak service] terminalID in
+            service?.copyDiagnostics(terminalID: terminalID)
+        }
+
         // Wire terminal tab management
         appState.onAddTerminal = { [weak service] sessionID in
             service?.addTerminal(sessionID: sessionID)

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -312,6 +312,17 @@ final class SessionService {
         TmuxBackend.shared.retryReadinessWatch(id: terminalID)
     }
 
+    /// Capture a stage-by-stage diagnostic bundle for `terminalID` (wrapper
+    /// log, pane capture, ps tree, sentinel state) and copy it to the
+    /// clipboard so a teammate hitting the .timedOut state can paste it
+    /// into a comment without screenshot-archaeology (issue #256).
+    func copyDiagnostics(terminalID: UUID) {
+        let bundle = TmuxBackend.shared.captureDiagnostics(id: terminalID)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(bundle, forType: .string)
+        NSLog("[SessionService] copied tmux diagnostics for terminal=\(terminalID) bytes=\(bundle.utf8.count)")
+    }
+
     /// Re-arm any tmux readiness watches that have stalled while the app
     /// was backgrounded. Called from `NSApplication.didBecomeActiveNotification`
     /// so a user who returns to a long-idle app doesn't have to click


### PR DESCRIPTION
Closes #256.

## Summary
- **Wrapper-side stage breadcrumbs** in `crow-shell-wrapper.sh`: new `CROW_WRAPPER_LOG` env var; one timestamped line per stage (`start`, `zdotdir_temp_created`, `user_rc_sourced`/`_skipped`, `hook_installed mechanism=…`, `pre_exec`, `precmd_fired`, `sentinel_written`/`sentinel_write_failed status=$?`). Stops swallowing the sentinel-write failure. Hard `exit 73` on `mktemp` failure instead of `exec`-ing into a broken env. Opt-in `CROW_WRAPPER_DEBUG=1` enables `set -x` to the same log.
- **Swift-side diagnostics on `.timedOut`**: `TmuxBackend.captureDiagnostics(id:)` builds a multi-section bundle — `tmux -V`/`PATH`/`SHELL`/`dscl . -read /Users/$USER UserShell` header, `display-message` for pane PID + current command, `capture-pane -p -S -200`, `ps` tree (pane PID + descendants via `pgrep -P`), sentinel state + writability, full wrapper log. Each section size-capped to keep the clipboard payload sane. NSLogged on timeout under `[CrowTelemetry tmux:first_prompt_diagnostics …]`.
- **Periodic progress logging**: a sibling task fires `tmux:first_prompt_progress terminal=… elapsed_ms=… sentinel_exists=…` every 10s so operators tailing logs can see whether the watch is healthy.
- **UI "Copy diagnostics" button** in the `.timedOut` overlay added by #253 — bundles the same diagnostics onto the clipboard with a 1.5s "Copied!" confirmation.
- **Speculative hardening** (one-line comments cite #256): `precmd_functions+=(_crow_precmd)` belt-and-braces after `add-zsh-hook` for the deferred-plugin-reassignment edge case; `$SHELL` vs `dscl` cross-check logged at the `start` stage when they disagree.
- **Tests**: new `CrowShellWrapperTests.swift` — setup-phase breadcrumbs assertion (always runs, uses a fake `*-zsh` shell), runtime breadcrumbs (gated on `/bin/zsh`), sentinel-write-failure logging.

## Test plan
- [x] `swift build` at root — green
- [x] `swift test --package-path Packages/CrowTerminal` — 24/24 (incl. 3 new wrapper tests)
- [x] `swift test --package-path Packages/CrowCore` — 150/150
- [x] `swift test --package-path Packages/CrowUI` — 22/22
- [x] `swift test` at root — 68/68
- [x] Inspect captured bundle inline (visible in `retryReadinessEmitsTimedOutWhenSentinelMissing` test stderr) — wrapper log + pane capture + ps tree + sentinel state all rendered.
- [ ] Manual: heavy `.zshrc` (`sleep 5`) + cold app + immediate `cmd-h` → `.timedOut` overlay → click "Copy diagnostics" → verify pasted bundle contains breadcrumbs pinpointing the failing stage.
- [ ] Manual happy-path regression: normal session reaches `.shellReady`; wrapper log shows full `start → … → sentinel_written` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)