### PR TITLE
Auto-cleanup completed sessions after configurable retention

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -21,6 +21,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// that overrides Claude Code's `attribution.commit` to include the crow
     /// session UUID alongside the standard `Co-Authored-By: Claude` trailer.
     public var attributionTrailers: Bool
+    public var cleanup: CleanupConfig
 
     public init(
         workspaces: [WorkspaceInfo] = [],
@@ -32,7 +33,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
         telemetry: TelemetryConfig = TelemetryConfig(),
         autoRespond: AutoRespondSettings = AutoRespondSettings(),
         experimentalTmuxBackend: Bool = false,
-        attributionTrailers: Bool = true
+        attributionTrailers: Bool = true,
+        cleanup: CleanupConfig = CleanupConfig()
     ) {
         self.workspaces = workspaces
         self.defaults = defaults
@@ -44,6 +46,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.autoRespond = autoRespond
         self.experimentalTmuxBackend = experimentalTmuxBackend
         self.attributionTrailers = attributionTrailers
+        self.cleanup = cleanup
     }
 
     public init(from decoder: Decoder) throws {
@@ -58,10 +61,11 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoRespond = try container.decodeIfPresent(AutoRespondSettings.self, forKey: .autoRespond) ?? AutoRespondSettings()
         experimentalTmuxBackend = try container.decodeIfPresent(Bool.self, forKey: .experimentalTmuxBackend) ?? false
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
+        cleanup = try container.decodeIfPresent(CleanupConfig.self, forKey: .cleanup) ?? CleanupConfig()
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, experimentalTmuxBackend, attributionTrailers
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, experimentalTmuxBackend, attributionTrailers, cleanup
     }
 }
 
@@ -259,5 +263,18 @@ public struct TelemetryConfig: Codable, Sendable, Equatable {
         self.enabled = enabled
         self.port = port
         self.retentionDays = retentionDays
+    }
+}
+
+/// Auto-cleanup settings for completed and archived sessions.
+public struct CleanupConfig: Codable, Sendable, Equatable {
+    /// Whether auto-cleanup is enabled. Disabled by default.
+    public var enabled: Bool
+    /// Hours to retain completed/archived sessions before deletion.
+    public var retentionHours: Int
+
+    public init(enabled: Bool = false, retentionHours: Int = 24) {
+        self.enabled = enabled
+        self.retentionHours = retentionHours
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -46,6 +46,26 @@ import Testing
     #expect(config.managerAutoPermissionMode == true)
     #expect(config.experimentalTmuxBackend == false)
     #expect(config.attributionTrailers == true)
+    #expect(config.cleanup.enabled == false)
+    #expect(config.cleanup.retentionHours == 24)
+}
+
+@Test func appConfigCleanupRoundTrip() throws {
+    var config = AppConfig()
+    config.cleanup.enabled = true
+    config.cleanup.retentionHours = 72
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.cleanup.enabled == true)
+    #expect(decoded.cleanup.retentionHours == 72)
+}
+
+@Test func appConfigCleanupDefaultsWhenKeyMissing() throws {
+    let json = #"{"workspaces":[]}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.cleanup.enabled == false)
+    #expect(config.cleanup.retentionHours == 24)
 }
 
 @Test func appConfigRemoteControlRoundTrip() throws {

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -182,6 +182,24 @@ public struct SettingsView: View {
                 .onChange(of: config.telemetry.retentionDays) { _, _ in save() }
                 .disabled(!config.telemetry.enabled)
             }
+
+            Section("Session Cleanup") {
+                Toggle("Auto-delete completed sessions", isOn: $config.cleanup.enabled)
+                    .onChange(of: config.cleanup.enabled) { _, _ in save() }
+                Text("Automatically deletes completed and archived sessions after the retention period. Includes worktree and branch cleanup. Manager and virtual tab sessions are never deleted.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Picker("Retention", selection: $config.cleanup.retentionHours) {
+                    Text("1 hour").tag(1)
+                    Text("1 day").tag(24)
+                    Text("3 days").tag(72)
+                    Text("7 days").tag(168)
+                    Text("30 days").tag(720)
+                }
+                .onChange(of: config.cleanup.retentionHours) { _, _ in save() }
+                .disabled(!config.cleanup.enabled)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -433,6 +433,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             self.autoRespondCoordinator?.handle(transitions)
         }
+        tracker.onDeleteSession = { [weak self] id in
+            do {
+                try await self?.appState.onDeleteSession?(id)
+            } catch {
+                print("[IssueTracker] auto-cleanup delete failed for \(id): \(error)")
+            }
+        }
         tracker.start()
         self.issueTracker = tracker
 

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -36,6 +36,10 @@ final class IssueTracker {
     /// and the auto-respond coordinator.
     var onPRStatusTransitions: (([PRStatusTransition]) -> Void)?
 
+    /// Callback fired to delete a session during auto-cleanup.
+    /// Wired in AppDelegate to call `appState.onDeleteSession`.
+    var onDeleteSession: ((UUID) async -> Void)?
+
     /// Previously seen review request IDs for delta detection.
     private var previousReviewRequestIDs: Set<String> = []
     private var isFirstFetch = true
@@ -347,6 +351,12 @@ final class IssueTracker {
         // sessions that actually need it. Safe for GitLab-only or no-GitHub
         // workspaces — the GitHub branch is gated by candidate count.
         await reconcileMissingPRLinks()
+
+        // Auto-cleanup expired completed/archived sessions. Runs outside
+        // the ghResult block so it fires even without GitHub data. Placed
+        // after auto-complete so freshly completed sessions respect the
+        // full retention window.
+        await autoCleanupExpiredSessions(config: config)
 
         logRefreshSummary(elapsed: Date().timeIntervalSince(startedAt))
     }
@@ -1892,6 +1902,56 @@ final class IssueTracker {
             let name = sessionsByID[decision.sessionID]?.name ?? decision.sessionID.uuidString
             print("[IssueTracker] Review session '\(name)' — \(decision.reason), marking completed")
             appState.onCompleteSession?(decision.sessionID)
+        }
+    }
+
+    // MARK: - Auto-Cleanup
+
+    /// Protected session IDs that must never be deleted by auto-cleanup.
+    /// Includes the manager session and all fixed-UUID virtual tab sessions.
+    nonisolated static let protectedSessionIDs: Set<UUID> = [
+        AppState.managerSessionID,
+        AppState.ticketBoardSessionID,
+        AppState.allowListSessionID,
+        AppState.reviewBoardSessionID,
+        AppState.globalTerminalSessionID,
+    ]
+
+    /// Pure decision function: returns session IDs eligible for auto-cleanup.
+    /// A session is eligible when its status is `.completed` or `.archived`,
+    /// its `updatedAt` is older than the retention cutoff, and its ID is not
+    /// in the protected set.
+    nonisolated static func sessionsEligibleForCleanup(
+        sessions: [Session],
+        retentionHours: Int,
+        now: Date = Date()
+    ) -> [UUID] {
+        let cutoff = now.addingTimeInterval(-Double(retentionHours) * 3600)
+        return sessions.compactMap { session in
+            guard !protectedSessionIDs.contains(session.id) else { return nil }
+            guard session.status == .completed || session.status == .archived else { return nil }
+            guard session.updatedAt < cutoff else { return nil }
+            return session.id
+        }
+    }
+
+    /// Delete completed/archived sessions that have exceeded their retention
+    /// window. Errors are logged per-session by the `onDeleteSession` callback
+    /// and do not abort subsequent deletions.
+    private func autoCleanupExpiredSessions(config: AppConfig) async {
+        guard config.cleanup.enabled else { return }
+
+        let eligible = Self.sessionsEligibleForCleanup(
+            sessions: appState.sessions,
+            retentionHours: config.cleanup.retentionHours
+        )
+        guard !eligible.isEmpty else { return }
+
+        let sessionsByID = Dictionary(uniqueKeysWithValues: appState.sessions.map { ($0.id, $0) })
+        for sessionID in eligible {
+            let name = sessionsByID[sessionID]?.name ?? sessionID.uuidString
+            print("[IssueTracker] Auto-cleanup: deleting session '\(name)' (retention: \(config.cleanup.retentionHours)h)")
+            await onDeleteSession?(sessionID)
         }
     }
 

--- a/Tests/CrowTests/IssueTrackerCompletionTests.swift
+++ b/Tests/CrowTests/IssueTrackerCompletionTests.swift
@@ -14,7 +14,8 @@ struct IssueTrackerCompletionTests {
         status: SessionStatus = .active,
         kind: SessionKind = .work,
         ticketURL: String? = nil,
-        provider: Provider? = .github
+        provider: Provider? = .github,
+        updatedAt: Date = Date()
     ) -> Session {
         Session(
             id: id,
@@ -22,7 +23,8 @@ struct IssueTrackerCompletionTests {
             status: status,
             kind: kind,
             ticketURL: ticketURL,
-            provider: provider
+            provider: provider,
+            updatedAt: updatedAt
         )
     }
 
@@ -305,5 +307,121 @@ struct IssueTrackerCompletionTests {
             prDataComplete: true
         )
         #expect(decisions.isEmpty)
+    }
+
+    // MARK: - Auto-Cleanup
+
+    private func hoursAgo(_ hours: Double) -> Date {
+        Date().addingTimeInterval(-hours * 3600)
+    }
+
+    @Test
+    func completedSessionPastRetentionIsEligible() {
+        let session = makeSession(status: .completed, updatedAt: hoursAgo(25))
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible == [session.id])
+    }
+
+    @Test
+    func archivedSessionPastRetentionIsEligible() {
+        let session = makeSession(status: .archived, updatedAt: hoursAgo(25))
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible == [session.id])
+    }
+
+    @Test
+    func completedSessionWithinRetentionIsNotEligible() {
+        let session = makeSession(status: .completed, updatedAt: hoursAgo(23))
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible.isEmpty)
+    }
+
+    @Test
+    func activeSessionIsNeverEligible() {
+        let session = makeSession(status: .active, updatedAt: hoursAgo(48))
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible.isEmpty)
+    }
+
+    @Test
+    func pausedSessionIsNeverEligible() {
+        let session = makeSession(status: .paused, updatedAt: hoursAgo(48))
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible.isEmpty)
+    }
+
+    @Test
+    func inReviewSessionIsNeverEligible() {
+        let session = makeSession(status: .inReview, updatedAt: hoursAgo(48))
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible.isEmpty)
+    }
+
+    @Test
+    func managerSessionIsProtected() {
+        let session = makeSession(
+            id: AppState.managerSessionID,
+            status: .completed,
+            updatedAt: hoursAgo(48)
+        )
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible.isEmpty)
+    }
+
+    @Test
+    func virtualTabSessionsAreProtected() {
+        let protectedIDs = [
+            AppState.ticketBoardSessionID,
+            AppState.allowListSessionID,
+            AppState.reviewBoardSessionID,
+            AppState.globalTerminalSessionID,
+        ]
+        let sessions = protectedIDs.map {
+            makeSession(id: $0, status: .completed, updatedAt: hoursAgo(48))
+        }
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: sessions,
+            retentionHours: 24
+        )
+        #expect(eligible.isEmpty)
+    }
+
+    @Test
+    func mixedSessionsReturnsOnlyEligible() {
+        let expired = makeSession(name: "expired", status: .completed, updatedAt: hoursAgo(25))
+        let fresh = makeSession(name: "fresh", status: .completed, updatedAt: hoursAgo(1))
+        let active = makeSession(name: "active", status: .active, updatedAt: hoursAgo(48))
+        let manager = makeSession(
+            id: AppState.managerSessionID,
+            name: "manager",
+            status: .completed,
+            updatedAt: hoursAgo(48)
+        )
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [expired, fresh, active, manager],
+            retentionHours: 24
+        )
+        #expect(eligible == [expired.id])
     }
 }


### PR DESCRIPTION
## Summary

- Add opt-in auto-cleanup that deletes expired completed/archived sessions (including worktrees and branches) after a configurable retention period
- Piggybacks on existing `IssueTracker.refresh()` cycle — no new timer
- Adds `CleanupConfig` to `AppConfig` with `enabled` (default: false) and `retentionHours` (default: 24)
- Adds "Session Cleanup" section to Settings → General tab with toggle and retention picker (1h, 1d, 3d, 7d, 30d)
- Protects manager and all fixed-UUID virtual tab sessions from cleanup

Closes #257

## Test plan

- [ ] CrowCore package builds and all 152 tests pass (`swift test --package-path Packages/CrowCore`)
- [ ] Full Xcode build succeeds
- [ ] New `appConfigCleanupRoundTrip` and `appConfigCleanupDefaultsWhenKeyMissing` tests pass
- [ ] New cleanup decision tests pass (9 cases: eligible completed/archived, within-retention, active/paused/inReview never eligible, manager/virtual tabs protected, mixed sessions)
- [ ] Settings → General shows "Session Cleanup" section after Telemetry
- [ ] Toggle enables/disables the retention picker
- [ ] Completed sessions older than retention period are deleted on next poll cycle
- [ ] Freshly auto-completed sessions are not immediately cleaned up (cleanup runs after auto-complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)