### PR TITLE
fix(tmux): enable extended-keys so Shift+Enter inserts newline in Claude Code

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -39,3 +39,16 @@ set -gs history-limit 5000
 # No escape-key delay — interactive editors (vi-mode shells, etc.) feel
 # sluggish with tmux's default 500ms.
 set -gs escape-time 0
+
+# Emit CSI-u / modifyOtherKeys sequences so the inner app can distinguish
+# Shift+Enter from Enter (and other modified keys). Required by Claude
+# Code to insert a newline on Shift+Enter instead of submitting.
+set -gs extended-keys on
+
+# Advertise the `extkeys` capability for the terminal types we actually
+# run under. `default-terminal` above is `screen-256color`, so the docs'
+# literal `xterm*:extkeys` glob does NOT match on its own — `screen*` is
+# the load-bearing entry here. `-gas` appends to the server-level list so
+# tmux's built-in terminal-features merges are preserved; the leading
+# comma keeps the append safe when the existing value is empty.
+set -gas terminal-features ',screen*:extkeys,xterm*:extkeys'


### PR DESCRIPTION
## Summary

- Adds `set -gs extended-keys on` to Crow's bundled tmux conf so the inner app sees CSI-u / modifyOtherKeys sequences and can distinguish **Shift+Enter** from plain **Enter**.
- Appends `set -gas terminal-features ',screen*:extkeys,xterm*:extkeys'`. Crow's `default-terminal` is `screen-256color`, so the Claude Code docs' literal `xterm*:extkeys` glob does **not** match on its own — `screen*` is the load-bearing entry; `xterm*` is kept for future-proofing.
- `-gas` appends to the server-scope list so tmux's built-in `terminal-features` merges are preserved; the leading comma keeps the append safe when the existing value is empty.
- Purely additive — no existing settings change, OSC passthrough / sentinel readiness from #258 are untouched.

Config is read via `tmux -f` at server start, so a Crow restart is required to pick up the change. Live-reload onto an already-running tmux server, a user-level `~/.config/crow/tmux.conf` escape hatch, and changing `default-terminal` away from `screen-256color` are explicitly out of scope.

## Test plan

- [ ] Quit any running Crow + `tmux kill-server` (or just relaunch Crow) so a fresh tmux server picks up the new conf.
- [ ] New Crow session → launch Claude Code → **Shift+Enter** inserts a newline (does not submit).
- [ ] Plain **Enter** still submits.
- [ ] **Ctrl+J** and **`\` + Enter** newline fallbacks still work (regression check).
- [ ] Sentinel-based shell readiness from #258 still fires; OSC passthrough unaffected.
- [ ] Verify on both a **resumed** session and a **server cold-start** session.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)