### PR TITLE
fix(tmux): submit quick action prompts via Enter keycode after paste

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -241,16 +241,33 @@ public final class TmuxBackend {
     /// Send text to `id`'s window via the buffer-paste path. Works for
     /// arbitrary-size payloads (Phase 3 §3 finding: send-keys -l fails
     /// on >10KB; load-buffer + paste-buffer scales to 50KB+ in 133ms).
+    ///
+    /// Quirk: Claude Code's TUI enables bracketed-paste mode, which wraps
+    /// `paste-buffer` output in `\e[200~…\e[201~`. A trailing `\n` inside the
+    /// bracket is treated as literal text, not as Enter — so prompts that
+    /// rely on `\n` to submit (quick actions: Merge PR, Fix Conflicts, …) get
+    /// pasted but never submitted (#264). Strip the trailing newline before
+    /// pasting and deliver a separate `Enter` via `send-keys` afterwards,
+    /// mirroring what `GhosttySurfaceView.writeText` does with keycode 36.
     public func sendText(id: UUID, text: String) throws {
         guard let windowIndex = bindings[id] else {
             throw TmuxBackendError.unknownTerminal(id)
         }
         do {
             let ctrl = try ensureRunningServer()
-            let bufferName = "crow-\(id.uuidString)"
-            try ctrl.loadBufferFromStdin(name: bufferName, data: Data(text.utf8))
-            defer { ctrl.deleteBuffer(name: bufferName) }
-            try ctrl.pasteBuffer(name: bufferName, target: "\(ctrl.sessionName):\(windowIndex)")
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            let endsWithNewline = text.hasSuffix("\n")
+            let payload = endsWithNewline ? String(text.dropLast()) : text
+
+            if !payload.isEmpty {
+                let bufferName = "crow-\(id.uuidString)"
+                try ctrl.loadBufferFromStdin(name: bufferName, data: Data(payload.utf8))
+                defer { ctrl.deleteBuffer(name: bufferName) }
+                try ctrl.pasteBuffer(name: bufferName, target: target)
+            }
+            if endsWithNewline {
+                try ctrl.sendKeys(target: target, keys: ["Enter"])
+            }
         } catch {
             reportIfTimeout(error)
             throw error

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift
@@ -206,6 +206,14 @@ public struct TmuxController: Sendable {
         try run(["paste-buffer", "-b", name, "-t", target])
     }
 
+    /// `tmux send-keys -t <target> <keys...>`. Each entry in `keys` is passed
+    /// as a separate argument (e.g. "Enter", "C-c"). Used by
+    /// `TmuxBackend.sendText` to deliver an Enter *outside* the bracketed-paste
+    /// bracket so prompts that end with `\n` are actually submitted (#264).
+    public func sendKeys(target: String, keys: [String]) throws {
+        try run(["send-keys", "-t", target] + keys)
+    }
+
     public func deleteBuffer(name: String) {
         _ = try? run(["delete-buffer", "-b", name])
     }


### PR DESCRIPTION
## Summary

Quick action prompts (Merge PR, Address Changes, Fix Checks, Fix Conflicts) end with a trailing \`\n\` so they auto-submit in Claude Code's input. The Ghostty backend honored that contract by splitting on \`\n\` and emitting a synthetic Return keycode (36) — those events fire outside any bracketed-paste bracket, so the TUI saw them as real Enter keys.

The tmux backend shipped the entire string through \`tmux load-buffer\` + \`tmux paste-buffer\`. Claude Code's TUI enables bracketed-paste mode, so tmux wrapped the buffer in \`\e[200~ … \e[201~\` and the trailing \`\n\` was delivered as literal text — typed as a newline character in the input field, never as Enter. Prompt visible, never submitted.

## Changes

- \`TmuxController.sendKeys(target:keys:)\` — thin wrapper over \`tmux send-keys -t <target> <keys...>\` reusing the existing \`run\` watchdog/timeout path.
- \`TmuxBackend.sendText\` — strip the single trailing \`\n\` from the paste payload, then send a separate \`Enter\` via \`sendKeys\` *after* \`paste-buffer\` completes (outside the bracket). Internal newlines are preserved as-is; an empty-after-strip payload skips the paste entirely (some tmux builds reject empty \`load-buffer\` input).

Ghostty path is untouched.

## Test plan

- [x] \`make build\` — green
- [x] \`swift test\` for the CrowTerminal package — all 24 tests pass, including \`TmuxBackendTests.sendTextRoundTripsThroughBuffer\`
- [ ] Manual: with \`experimentalTmuxBackend: true\`, click **Fix Conflicts** / **Merge PR** on a PR session and confirm the prompt is submitted automatically
- [ ] Manual regression: same flow with \`experimentalTmuxBackend: false\` (Ghostty) — behavior unchanged

Closes #264