### PR TITLE
fix(reviews): serialize review session creation + broaden crash logging

### DIFF
--- a/Sources/Crow/App/AboutView.swift
+++ b/Sources/Crow/App/AboutView.swift
@@ -1,8 +1,10 @@
+import AppKit
 import CrowUI
 import SwiftUI
 
 struct AboutView: View {
     @State private var copied = false
+    @State private var revealedCrashLogs = false
 
     var body: some View {
         VStack(spacing: 12) {
@@ -45,6 +47,19 @@ struct AboutView: View {
                 .padding(.horizontal, 24)
                 .padding(.vertical, 4)
 
+            // Diagnostics: where signal-level crashes and stderr are logged.
+            Button(action: revealCrashLogs) {
+                HStack(spacing: 4) {
+                    Text("Crash logs")
+                        .font(.caption)
+                    Image(systemName: revealedCrashLogs ? "checkmark" : "folder")
+                        .font(.caption)
+                }
+                .foregroundStyle(revealedCrashLogs ? .green : CorveilTheme.textMuted)
+            }
+            .buttonStyle(.plain)
+            .help(CrashReporter.logDirectory.path)
+
             Text("© \(Calendar.current.component(.year, from: Date())) Radius Method")
                 .font(.caption)
                 .foregroundStyle(CorveilTheme.textMuted)
@@ -75,6 +90,16 @@ struct AboutView: View {
         copied = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             copied = false
+        }
+    }
+
+    private func revealCrashLogs() {
+        let dir = CrashReporter.logDirectory
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        NSWorkspace.shared.activateFileViewerSelecting([dir])
+        revealedCrashLogs = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            revealedCrashLogs = false
         }
     }
 }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -33,7 +33,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var reviewKickoffTail: Task<Void, Never>?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        installUncaughtExceptionHandler()
+        // Must be the very first call so the next exit (graceful or not)
+        // lands somewhere readable. Also redirects stderr so Swift runtime
+        // traps (`fatalError`, `precondition`) and `print` to stderr show up
+        // in the crash log instead of being silently dropped when the app is
+        // launched from Finder.
+        CrashReporter.install()
+
+        // Surface the prior launch's crash (if any) once the app is up.
+        // Deferred via async so it doesn't block first-paint.
+        if let priorCrashLog = CrashReporter.unseenPriorCrashLog() {
+            DispatchQueue.main.async { [weak self] in
+                self?.presentPriorCrashAlert(logURL: priorCrashLog)
+            }
+        }
 
         // Check for devRoot pointer
         if let root = ConfigStore.loadDevRoot() {
@@ -44,21 +57,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Capture ObjC exceptions that would otherwise tear the app down
-    /// silently. The macOS crash reporter handles Mach exceptions / pure
-    /// SIGSEGV on its own, but ObjC exceptions thrown out of AppKit or
-    /// libghostty wrappers can `abort()` without producing a useful .ips
-    /// file. Logging name + reason + symbolicated stack to NSLog routes
-    /// them into Console.app and the unified log so the next reproduction
-    /// of issue #240 (and similar) is debuggable.
-    private func installUncaughtExceptionHandler() {
-        NSSetUncaughtExceptionHandler { exception in
-            let symbols = exception.callStackSymbols.joined(separator: "\n")
-            NSLog(
-                "[CrowCrash] uncaught NSException name=\(exception.name.rawValue) " +
-                "reason=\(exception.reason ?? "<nil>")\n\(symbols)"
-            )
+    /// Show an alert pointing the user at the prior launch's crash log.
+    /// Dismissing acknowledges the prompt; "Reveal in Finder" opens the
+    /// containing directory.
+    private func presentPriorCrashAlert(logURL: URL) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Crow exited unexpectedly last time"
+        alert.informativeText = """
+            A crash log was written to:
+            \(logURL.path)
+            """
+        alert.addButton(withTitle: "Reveal in Finder")
+        alert.addButton(withTitle: "Dismiss")
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            NSWorkspace.shared.activateFileViewerSelecting([logURL])
         }
+        CrashReporter.acknowledgePriorCrash()
     }
 
     // MARK: - Review kickoff queue

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -25,6 +25,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var devRoot: String?
     private var appConfig: AppConfig?
 
+    /// Tail of the serial review-kickoff queue. Each call to
+    /// `enqueueReviewKickoff` awaits the previous tail before doing any work,
+    /// so all `createReviewSession` runs are strictly sequential across both
+    /// manual batches and auto-review refreshes. See #266 for the race this
+    /// replaced.
+    private var reviewKickoffTail: Task<Void, Never>?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         installUncaughtExceptionHandler()
 
@@ -51,6 +58,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 "[CrowCrash] uncaught NSException name=\(exception.name.rawValue) " +
                 "reason=\(exception.reason ?? "<nil>")\n\(symbols)"
             )
+        }
+    }
+
+    // MARK: - Review kickoff queue
+
+    /// Enqueue one or more PR URLs for review-session creation, processed
+    /// strictly in order on the main actor. Each batch awaits the prior tail
+    /// before starting, so a user clicking "Start Review" mid-batch (or an
+    /// auto-review refresh landing while a manual batch is in flight) does not
+    /// race the previous batch's `appState` writes.
+    ///
+    /// `selectAfterCreate` is hard-coded false: a kickoff should never yank
+    /// the user's detail-pane focus. New review sessions appear in the sidebar
+    /// and the user clicks in when they're ready. This is the selection policy
+    /// chosen for #266.
+    @MainActor
+    private func enqueueReviewKickoff(_ urls: [String]) {
+        guard !urls.isEmpty, let service = sessionService else { return }
+        let previous = reviewKickoffTail
+        reviewKickoffTail = Task { @MainActor in
+            await previous?.value
+            for url in urls {
+                _ = await service.createReviewSession(prURL: url, selectAfterCreate: false)
+            }
         }
     }
 
@@ -378,18 +409,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.appState.selectedSessionID = AppState.managerSessionID
         }
 
-        // Wire "Start Review" action — creates review session for a PR
+        // Wire "Start Review" action — creates review session for a PR.
+        // Single-PR kickoffs route through the same serial queue as batches so
+        // a rapid double-click can never race two `createReviewSession` calls.
         appState.onStartReview = { [weak self] prURL in
-            guard let self else { return }
-            Task { await self.sessionService?.createReviewSession(prURL: prURL) }
+            self?.enqueueReviewKickoff([prURL])
         }
 
-        // Wire batch "Start Review" action — creates review sessions for multiple PRs in parallel
+        // Wire batch "Start Review" action — N PRs at once.
+        // Previously this spawned one Task per PR (no serialization), which
+        // produced the SwiftUI "reentrant layout" / silent-exit crash in #266
+        // when N concurrent `createReviewSession` calls all reached the final
+        // `appState.selectedSessionID =` write within the same render frame.
         appState.onBatchStartReview = { [weak self] prURLs in
-            guard let self else { return }
-            for url in prURLs {
-                Task { await self.sessionService?.createReviewSession(prURL: url) }
-            }
+            self?.enqueueReviewKickoff(prURLs)
         }
 
         // Start issue tracker
@@ -411,12 +444,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .map { $0.lowercased() })
             guard !enabledRepos.isEmpty else { return }
 
+            var pendingURLs: [String] = []
             for request in requests {
                 guard request.reviewSessionID == nil,
                       !autoReviewedIDs.contains(request.id),
                       enabledRepos.contains(request.repo.lowercased()) else { continue }
                 autoReviewedIDs.insert(request.id)
-                Task { await self.sessionService?.createReviewSession(prURL: request.url) }
+                pendingURLs.append(request.url)
+            }
+            if !pendingURLs.isEmpty {
+                self.enqueueReviewKickoff(pendingURLs)
             }
         }
         tracker.onAutoCreateRequest = { [weak self] issue in

--- a/Sources/Crow/App/CrashReporter.swift
+++ b/Sources/Crow/App/CrashReporter.swift
@@ -1,0 +1,284 @@
+import Darwin
+import Foundation
+
+/// Captures crashes that the macOS crash reporter misses or buries.
+///
+/// Three classes of crash motivated this (#266):
+///   1. POSIX signals (SIGABRT/SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP) raised
+///      out of SwiftUI's AttributeGraph or libghostty wrappers, which can
+///      vanish the process without producing a `.ips` file.
+///   2. Swift runtime traps (`fatalError`, `precondition`) which print to
+///      stderr and then `abort()` — stderr is otherwise discarded for
+///      .app bundles double-clicked from Finder.
+///   3. Uncaught `NSException`s (already handled in #240, folded in here
+///      so all paths land in the same on-disk artifact).
+///
+/// On each launch a new log file is opened at
+/// `~/.local/share/crow/crash-logs/crow-<ISO8601>.log` and `stderr` is
+/// redirected to it. Signal handlers write a short header plus the raw
+/// stack via `backtrace_symbols_fd(3)` and then re-raise the signal so the
+/// OS still has a chance to write `.ips`. A marker file alongside the log
+/// records that the prior launch crashed, surfaced on next launch via
+/// `unseenPriorCrashLog()`.
+///
+/// Symbolication: the on-disk frames are raw addresses + mangled symbol
+/// names. Pair with the build's `.dSYM` and `atos` to demangle.
+enum CrashReporter {
+    static let logDirectory: URL = FileManager.default
+        .homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/share/crow/crash-logs", isDirectory: true)
+
+    private static let markerFilename = ".unseen-crash"
+    private static let maxRetainedLogs = 20
+    private static let signals: [Int32] = [
+        SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGTRAP,
+    ]
+
+    // Mutable state is touched once on the main thread at install time and
+    // then read-only from C signal handlers. `nonisolated(unsafe)` follows
+    // the convention established in FeatureFlags.swift.
+    nonisolated(unsafe) private static var currentLogURL: URL?
+    nonisolated(unsafe) private static var priorCrashLogURL: URL?
+    nonisolated(unsafe) private static var logFD: Int32 = -1
+    nonisolated(unsafe) private static var markerPathCString: UnsafeMutablePointer<CChar>?
+    nonisolated(unsafe) private static var backtraceBuffer: UnsafeMutablePointer<UnsafeMutableRawPointer?>?
+    private static let backtraceCapacity: Int32 = 128
+    nonisolated(unsafe) private static var installed = false
+
+    // MARK: - Public API
+
+    /// Idempotent. Safe to call multiple times; subsequent calls are no-ops.
+    /// Must be invoked on the main thread at app launch before any other
+    /// AppDelegate work so the next exit (graceful or not) lands in the log.
+    static func install() {
+        guard !installed else { return }
+        installed = true
+
+        ensureDirectory()
+        priorCrashLogURL = detectPriorCrash()
+        rotateOldLogs()
+        openCurrentLog()
+        prepareSignalHandlerBuffers()
+        redirectStderr()
+        installSignalHandlers()
+        installExceptionHandler()
+    }
+
+    /// The crash log written by the previous launch, if it crashed.
+    /// Returns nil after `acknowledgePriorCrash()` is called.
+    static func unseenPriorCrashLog() -> URL? { priorCrashLogURL }
+
+    /// Clears the cached "prior crash" pointer and removes the marker file.
+    static func acknowledgePriorCrash() {
+        priorCrashLogURL = nil
+        let markerURL = logDirectory.appendingPathComponent(markerFilename)
+        try? FileManager.default.removeItem(at: markerURL)
+    }
+
+    /// Path of the log this launch is writing to. nil before install.
+    static var currentLogURLForDisplay: URL? { currentLogURL }
+
+    // MARK: - Install steps
+
+    private static func ensureDirectory() {
+        try? FileManager.default.createDirectory(
+            at: logDirectory, withIntermediateDirectories: true
+        )
+    }
+
+    /// Look for the previous-launch marker BEFORE this launch opens a fresh
+    /// log. If found, identify the prior log by mtime (newest .log present
+    /// at this moment, which is necessarily from a prior launch).
+    private static func detectPriorCrash() -> URL? {
+        let markerURL = logDirectory.appendingPathComponent(markerFilename)
+        guard FileManager.default.fileExists(atPath: markerURL.path) else {
+            return nil
+        }
+        let logs = (try? FileManager.default.contentsOfDirectory(
+            at: logDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        let newest = logs
+            .filter { $0.pathExtension == "log" }
+            .sorted { lhs, rhs in
+                let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                return l > r
+            }
+            .first
+        return newest
+    }
+
+    /// Keep at most `maxRetainedLogs` historical logs. Skipped silently on
+    /// any I/O failure — never block app launch on housekeeping.
+    private static func rotateOldLogs() {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: logDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+        let logs = entries
+            .filter { $0.pathExtension == "log" }
+            .sorted { lhs, rhs in
+                let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                return l > r
+            }
+        guard logs.count >= maxRetainedLogs else { return }
+        for stale in logs.dropFirst(maxRetainedLogs - 1) {
+            try? fm.removeItem(at: stale)
+        }
+    }
+
+    private static func openCurrentLog() {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withYear, .withMonth, .withDay, .withTime]
+        let stamp = formatter.string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let url = logDirectory.appendingPathComponent("crow-\(stamp).log")
+        currentLogURL = url
+
+        let fd = url.path.withCString { path in
+            open(path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        }
+        guard fd >= 0 else { return }
+        logFD = fd
+
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let header = """
+        --- crow launch \(Date()) pid=\(ProcessInfo.processInfo.processIdentifier) version=\(version) ---
+
+        """
+        _ = header.withCString { ptr in
+            write(fd, ptr, strlen(ptr))
+        }
+    }
+
+    /// Pre-allocate everything the signal handler will need so the handler
+    /// itself only touches async-signal-safe primitives.
+    private static func prepareSignalHandlerBuffers() {
+        backtraceBuffer = UnsafeMutablePointer<UnsafeMutableRawPointer?>
+            .allocate(capacity: Int(backtraceCapacity))
+
+        let markerPath = logDirectory.appendingPathComponent(markerFilename).path
+        let bytes = Array(markerPath.utf8CString)
+        let ptr = UnsafeMutablePointer<CChar>.allocate(capacity: bytes.count)
+        for (i, b) in bytes.enumerated() { ptr[i] = b }
+        markerPathCString = ptr
+    }
+
+    private static func redirectStderr() {
+        guard logFD >= 0 else { return }
+        // dup2 returns the new fd or -1; we don't close logFD because we
+        // still need it for direct writes from the signal handler.
+        _ = dup2(logFD, STDERR_FILENO)
+    }
+
+    private static func installSignalHandlers() {
+        var action = sigaction()
+        action.__sigaction_u.__sa_handler = CrashReporter.signalHandler
+        sigemptyset(&action.sa_mask)
+        action.sa_flags = 0
+        for sig in signals {
+            sigaction(sig, &action, nil)
+        }
+    }
+
+    private static func installExceptionHandler() {
+        NSSetUncaughtExceptionHandler { exception in
+            let symbols = exception.callStackSymbols.joined(separator: "\n")
+            let message = "[CrowCrash] uncaught NSException name=\(exception.name.rawValue) " +
+                "reason=\(exception.reason ?? "<nil>")\n\(symbols)\n"
+            NSLog("%@", message)
+            // Also write to the on-disk log + drop the marker so next launch
+            // surfaces the crash artifact. stderr is already redirected to
+            // logFD, so a plain fputs reaches the file.
+            fputs(message, stderr)
+            CrashReporter.writeMarkerFromHandlerSafeContext()
+        }
+    }
+
+    // MARK: - Signal handler
+
+    /// Async-signal-safe path. NO Swift allocations, NO ObjC, NO String
+    /// formatting. Only `write(2)`, `open(2)`, `backtrace(3)`,
+    /// `backtrace_symbols_fd(3)`, `sigaction(2)`, `raise(3)` per POSIX.
+    private static let signalHandler: @convention(c) (Int32) -> Void = { signum in
+        if logFD >= 0 {
+            writeCString("\n--- crow crash signal=", to: logFD)
+            writeInt32(signum, to: logFD)
+            writeCString(" ---\n", to: logFD)
+            if let buf = backtraceBuffer {
+                let frames = backtrace(buf, backtraceCapacity)
+                backtrace_symbols_fd(buf, frames, logFD)
+            }
+            writeCString("\n", to: logFD)
+            fsync(logFD)
+        }
+        writeMarkerFromHandlerSafeContext()
+
+        // Restore the default disposition and re-raise so the OS crash
+        // reporter still gets a chance to write `.ips`. The re-raise
+        // terminates the process.
+        var action = sigaction()
+        action.__sigaction_u.__sa_handler = SIG_DFL
+        sigemptyset(&action.sa_mask)
+        action.sa_flags = 0
+        sigaction(signum, &action, nil)
+        raise(signum)
+    }
+
+    /// Touch the "crashed last launch" marker. Signal-safe: only `open` and
+    /// `write` (one byte). Called from both the signal handler and the
+    /// NSException handler.
+    private static func writeMarkerFromHandlerSafeContext() {
+        guard let path = markerPathCString else { return }
+        let fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
+        guard fd >= 0 else { return }
+        var byte: UInt8 = 0x31 // '1'
+        _ = withUnsafePointer(to: &byte) { write(fd, $0, 1) }
+        close(fd)
+    }
+
+    // MARK: - Signal-safe write helpers
+
+    private static func writeCString(_ literal: StaticString, to fd: Int32) {
+        // StaticString.utf8Start is a compile-time pointer — no allocation.
+        _ = write(fd, literal.utf8Start, literal.utf8CodeUnitCount)
+    }
+
+    /// Write a signed Int32 in base 10 to fd. Stack-only buffer.
+    private static func writeInt32(_ value: Int32, to fd: Int32) {
+        var buffer = (Int8(0), Int8(0), Int8(0), Int8(0), Int8(0),
+                      Int8(0), Int8(0), Int8(0), Int8(0), Int8(0), Int8(0), Int8(0))
+        withUnsafeMutableBytes(of: &buffer) { raw in
+            let chars = raw.bindMemory(to: Int8.self)
+            var n = value
+            var negative = false
+            if n < 0 { negative = true; n = -n }
+            var idx = chars.count - 1
+            if n == 0 {
+                chars[idx] = 0x30 // '0'
+                idx -= 1
+            } else {
+                while n > 0 && idx >= 0 {
+                    chars[idx] = Int8(0x30 + (n % 10))
+                    n /= 10
+                    idx -= 1
+                }
+            }
+            if negative && idx >= 0 {
+                chars[idx] = 0x2D // '-'
+                idx -= 1
+            }
+            let start = idx + 1
+            _ = write(fd, chars.baseAddress!.advanced(by: start), chars.count - start)
+        }
+    }
+}

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1063,13 +1063,22 @@ final class SessionService {
     // MARK: - Review Session
 
     /// Create a review session for an incoming PR review request.
-    func createReviewSession(prURL: String) async {
+    ///
+    /// Returns the new session's ID on success, or `nil` if the PR URL could not
+    /// be resolved or session creation failed. `selectAfterCreate` defaults to
+    /// false: review kickoff is normally driven by `AppDelegate.enqueueReviewKickoff`
+    /// which intentionally leaves the user's current detail-pane focus alone, so
+    /// new review sessions appear in the sidebar without yanking the view.
+    /// Concurrent writes to `appState.selectedSessionID` from racing kickoffs are
+    /// what produced the SwiftUI reentrant-layout crash in #266.
+    @discardableResult
+    func createReviewSession(prURL: String, selectAfterCreate: Bool = false) async -> UUID? {
         // Parse org/repo and PR number from URL like "https://github.com/org/repo/pull/123"
         let components = prURL.split(separator: "/")
         guard components.count >= 5,
               let prNumber = Int(components.last ?? "") else {
             NSLog("[SessionService] Could not parse PR URL: \(prURL)")
-            return
+            return nil
         }
         let owner = String(components[components.count - 4])
         let repoName = String(components[components.count - 3])
@@ -1081,7 +1090,7 @@ final class SessionService {
             "--json", "title,headRefName,baseRefName,number"
         ) else {
             NSLog("[SessionService] Failed to fetch PR metadata for \(prURL)")
-            return
+            return nil
         }
 
         guard let prData = prOutput.data(using: .utf8),
@@ -1089,13 +1098,13 @@ final class SessionService {
               let prTitle = prJSON["title"] as? String,
               let headBranch = prJSON["headRefName"] as? String else {
             NSLog("[SessionService] Failed to parse PR metadata for \(prURL)")
-            return
+            return nil
         }
 
         // Determine clone path
         guard let devRoot = ConfigStore.loadDevRoot() else {
             NSLog("[SessionService] No devRoot configured")
-            return
+            return nil
         }
         let reviewsDir = (devRoot as NSString).appendingPathComponent("crow-reviews")
         let cloneDirName = "\(repoName)-pr-\(prNumber)"
@@ -1191,9 +1200,12 @@ final class SessionService {
         }
 
         // Select the new session
-        appState.selectedSessionID = session.id
+        if selectAfterCreate {
+            appState.selectedSessionID = session.id
+        }
 
         NSLog("[SessionService] Created review session '\(session.name)' for \(prURL)")
+        return session.id
     }
 
     // MARK: - Review Prompt


### PR DESCRIPTION
Closes #266

## Summary
- Replace N fire-and-forget `Task { createReviewSession }` calls with a serial kickoff queue in `AppDelegate.enqueueReviewKickoff` — the SwiftUI reentrant-layout fault and silent exits in #266 were caused by concurrent kickoffs racing on `appState.selectedSessionID`.
- `createReviewSession` now takes `selectAfterCreate: Bool = false` and returns `UUID?`. Kickoffs never auto-select; new review sessions appear in the sidebar without yanking the user's detail-pane focus.
- New `CrashReporter` installs sigaction handlers for SIGABRT/SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP, redirects stderr to a rotated log under `~/.local/share/crow/crash-logs/`, folds in the existing NSException handler from #240, and surfaces a "Crow exited unexpectedly" alert on next launch.
- About panel gains a "Crash logs" entry that reveals the log directory.

## Stages (two commits)
1. `fix(reviews): serialize review session creation` — Stage 1 of #266 acceptance.
2. `feat(crash): capture signals, stderr, and last-crash alert` — Stage 2.

Each is independently revertable if needed.

## Test plan
- [ ] Verify clean build (\`make build\`).
- [ ] Repro: open a workspace with ≥ 3 PRs awaiting your review; click **Batch Start Review**; confirm `log stream --predicate 'process == "CrowApp"' --level info | grep -E 'Invalid Configuration|reentrantly'` is silent and the app does not vanish.
- [ ] Sessions appear in the sidebar in submission order; the detail pane remains on whatever the user was viewing.
- [ ] Boot once normally; confirm `~/.local/share/crow/crash-logs/crow-<ts>.log` is created with a header line.
- [ ] (Optional smoke test of the crash path) temporarily wire a debug menu item to `abort()`, trigger it, relaunch; confirm the prior-launch log has a stack dump and the "Crow exited unexpectedly" alert appears.
- [ ] Open About → "Crash logs" reveals the directory in Finder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)