### PR TITLE
feat: per-workspace custom instructions appended to initial prompt

### DIFF
--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
@@ -10,7 +10,8 @@ public actor ClaudeLauncher {
         session: Session,
         worktrees: [SessionWorktree],
         ticketURL: String?,
-        provider: Provider?
+        provider: Provider?,
+        customInstructions: String? = nil
     ) -> String {
         var lines: [String] = []
         lines.append("/plan")
@@ -64,6 +65,14 @@ public actor ClaudeLauncher {
                 ticketNumber: session.ticketNumber,
                 hasTicket: ticketURL != nil
             )
+        }
+
+        if let instructions = customInstructions,
+           !instructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append("")
+            lines.append("## Custom Instructions")
+            lines.append("")
+            lines.append(instructions)
         }
 
         return lines.joined(separator: "\n")

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeLauncherTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeLauncherTests.swift
@@ -192,6 +192,54 @@ import Testing
     #expect(command.contains("'\\''"))
 }
 
+// MARK: - Custom instructions
+
+@Test func generatePromptWithCustomInstructions() async {
+    let launcher = ClaudeLauncher()
+    let session = Session(name: "test-session")
+
+    let prompt = await launcher.generatePrompt(
+        session: session,
+        worktrees: [],
+        ticketURL: nil,
+        provider: nil,
+        customInstructions: "Always run npm test before committing"
+    )
+
+    #expect(prompt.contains("## Custom Instructions"))
+    #expect(prompt.contains("Always run npm test before committing"))
+}
+
+@Test func generatePromptWithoutCustomInstructions() async {
+    let launcher = ClaudeLauncher()
+    let session = Session(name: "test-session")
+
+    let prompt = await launcher.generatePrompt(
+        session: session,
+        worktrees: [],
+        ticketURL: nil,
+        provider: nil,
+        customInstructions: nil
+    )
+
+    #expect(!prompt.contains("## Custom Instructions"))
+}
+
+@Test func generatePromptWithEmptyCustomInstructions() async {
+    let launcher = ClaudeLauncher()
+    let session = Session(name: "test-session")
+
+    let prompt = await launcher.generatePrompt(
+        session: session,
+        worktrees: [],
+        ticketURL: nil,
+        provider: nil,
+        customInstructions: "   \n  "
+    )
+
+    #expect(!prompt.contains("## Custom Instructions"))
+}
+
 // MARK: - Prompt structure
 
 @Test func generatePromptMultipleWorktrees() async {

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -115,6 +115,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
     public var host: String?          // GitLab host (e.g., "gitlab.example.com")
     public var alwaysInclude: [String] // repos to always list in prompt table
     public var autoReviewRepos: [String] // repos where review requests auto-create a review session
+    public var customInstructions: String? // free-text instructions appended to session prompts
 
     /// The CLI tool name derived from the current `provider` value.
     /// Unlike `cli` (which may be stale from an old config file), this is always correct.
@@ -129,7 +130,8 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         cli: String = "gh",
         host: String? = nil,
         alwaysInclude: [String] = [],
-        autoReviewRepos: [String] = []
+        autoReviewRepos: [String] = [],
+        customInstructions: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -138,6 +140,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         self.host = host
         self.alwaysInclude = alwaysInclude
         self.autoReviewRepos = autoReviewRepos
+        self.customInstructions = customInstructions
     }
 
     public init(from decoder: Decoder) throws {
@@ -149,10 +152,11 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         host = try container.decodeIfPresent(String.self, forKey: .host)
         alwaysInclude = try container.decodeIfPresent([String].self, forKey: .alwaysInclude) ?? []
         autoReviewRepos = try container.decodeIfPresent([String].self, forKey: .autoReviewRepos) ?? []
+        customInstructions = try container.decodeIfPresent(String.self, forKey: .customInstructions)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, provider, cli, host, alwaysInclude, autoReviewRepos
+        case id, name, provider, cli, host, alwaysInclude, autoReviewRepos, customInstructions
     }
 
     /// Characters that are unsafe in directory names (workspace names become directory names).

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -174,6 +174,24 @@ import Testing
     #expect(config.workspaces[0].alwaysInclude.isEmpty)
 }
 
+@Test func workspaceCustomInstructionsRoundTrip() throws {
+    let config = AppConfig(workspaces: [
+        WorkspaceInfo(name: "Org", customInstructions: "Always run npm test before committing")
+    ])
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.workspaces[0].customInstructions == "Always run npm test before committing")
+}
+
+@Test func workspaceCustomInstructionsDefaultsNilWhenKeyMissing() throws {
+    // Legacy configs without the key should default to nil.
+    let json = """
+    {"workspaces": [{"id": "00000000-0000-0000-0000-000000000001", "name": "Org", "provider": "github", "cli": "gh"}]}
+    """.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.workspaces[0].customInstructions == nil)
+}
+
 @Test func workspaceNameValidation() {
     // Valid name
     #expect(WorkspaceInfo.validateName("MyOrg", existingNames: []) == nil)

--- a/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
@@ -13,6 +13,7 @@ public struct WorkspaceFormView: View {
     @State private var host: String
     @State private var alwaysIncludeText: String
     @State private var autoReviewReposText: String
+    @State private var customInstructionsText: String
 
     private let existingID: UUID?
     private let existingNames: [String]
@@ -33,6 +34,7 @@ public struct WorkspaceFormView: View {
         self._host = State(initialValue: workspace?.host ?? "")
         self._alwaysIncludeText = State(initialValue: workspace?.alwaysInclude.joined(separator: ", ") ?? "")
         self._autoReviewReposText = State(initialValue: workspace?.autoReviewRepos.joined(separator: ", ") ?? "")
+        self._customInstructionsText = State(initialValue: workspace?.customInstructions ?? "")
         self.existingNames = existingNames
         self.onSave = onSave
     }
@@ -79,6 +81,15 @@ public struct WorkspaceFormView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Section("Custom Instructions") {
+                TextEditor(text: $customInstructionsText)
+                    .font(.body)
+                    .frame(minHeight: 80)
+                Text("Instructions appended to the session prompt (e.g., \"Always run npm test before committing\").")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
         .safeAreaInset(edge: .bottom) {
@@ -96,6 +107,9 @@ public struct WorkspaceFormView: View {
                         .map { $0.trimmingCharacters(in: .whitespaces) }
                         .filter { !$0.isEmpty }
 
+                    let trimmedInstructions = customInstructionsText
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+
                     let ws = WorkspaceInfo(
                         id: existingID ?? UUID(),
                         name: trimmedName,
@@ -103,7 +117,8 @@ public struct WorkspaceFormView: View {
                         cli: provider == "github" ? "gh" : "glab",
                         host: provider == "gitlab" && !host.isEmpty ? host : nil,
                         alwaysInclude: alwaysInclude,
-                        autoReviewRepos: autoReviewRepos
+                        autoReviewRepos: autoReviewRepos,
+                        customInstructions: trimmedInstructions.isEmpty ? nil : trimmedInstructions
                     )
                     onSave(ws)
                     dismiss()
@@ -113,6 +128,6 @@ public struct WorkspaceFormView: View {
             }
             .padding()
         }
-        .frame(width: 440, height: 400)
+        .frame(width: 440, height: 520)
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,8 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
       "name": "RadiusMethod",
       "provider": "github",
       "cli": "gh",
-      "host": null
+      "host": null,
+      "customInstructions": "Always run npm test before committing"
     },
     {
       "id": "uuid",
@@ -61,6 +62,7 @@ All persistent state lives under `~/Library/Application Support/crow/` (see `Pac
 - **`excludeDirs`** — ignored when scanning repos for git worktrees.
 - **`excludeReviewRepos`** — repos to hide from the review board (e.g., `["zarf-dev/zarf"]`). Supports `*` wildcards (e.g., `"zarf-dev/*"`). Matching reviews are filtered out from the board, sidebar badge count, and notifications. Editable in Settings → Automation → Reviews.
 - **`excludeTicketRepos`** — repos to hide from the ticket board (e.g., `["zarf-dev/zarf"]`). Supports `*` wildcards (e.g., `"zarf-dev/*"`). Matching issues are filtered out from the board, pipeline counts, and auto-create candidates. Editable in Settings → Automation → Tickets.
+- **`customInstructions`** — optional free-text instructions appended to the session prompt as a `## Custom Instructions` section. Use this for workspace-specific conventions, e.g., "Always run `npm test` before committing" or "Use the auth middleware in `src/middleware/auth.ts` as a pattern."
 
 For the full set of automation toggles backed by this config, see [automation.md](automation.md).
 

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -24,13 +24,15 @@ Configuration is at `{devRoot}/.claude/config.json` (managed by the Crow app). T
   "workspaces": {
     "RadiusMethod": {
       "provider": "github",
-      "cli": "gh"
+      "cli": "gh",
+      "customInstructions": "Always run `npm test` before committing."
     },
     "MyGitLab": {
       "provider": "gitlab",
       "cli": "glab",
       "host": "gitlab.example.com",
-      "alwaysInclude": []
+      "alwaysInclude": [],
+      "customInstructions": null
     }
   },
   "defaults": {
@@ -337,7 +339,13 @@ gh issue view https://github.com/org/repo/issues/123 --comments
 ```bash
 gh pr create --title "<summary>" --body "Closes #123" --base main
 ```
+
+## Custom Instructions
+
+{workspace customInstructions text — include verbatim}
 ~~~
+
+If the workspace config contains a non-empty `customInstructions` field, append a `## Custom Instructions` section at the end of the prompt with its contents verbatim. Omit this section entirely if the field is absent, null, or empty.
 
 For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch main` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the body/description and fall back to `gh pr create --fill` / `glab mr create --fill`.
 


### PR DESCRIPTION
## Summary

- Adds `customInstructions: String?` field to `WorkspaceInfo` with backward-compatible decoding (defaults to `nil`)
- Adds `TextEditor` in workspace settings UI for editing multi-line custom instructions
- Appends `## Custom Instructions` section to generated prompts when the field is non-empty (both in `ClaudeLauncher.generatePrompt()` and the SKILL.md prompt template)

Closes #265

## Test plan

- [x] `swift test --package-path Packages/CrowCore` — 162 tests pass (including 2 new: round-trip + backward compat)
- [x] `swift test --package-path Packages/CrowClaude` — 13 tests pass (including 3 new: with/without/empty instructions)
- [ ] Manual: open Settings → edit workspace → verify TextEditor appears, saves, and persists
- [ ] Manual: `/crow-workspace` with custom instructions set → verify prompt file contains `## Custom Instructions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)