### PR TITLE
fix(tmux): add delay between paste and Enter for auto-respond prompts

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -245,10 +245,16 @@ public final class TmuxBackend {
     /// Quirk: Claude Code's TUI enables bracketed-paste mode, which wraps
     /// `paste-buffer` output in `\e[200~…\e[201~`. A trailing `\n` inside the
     /// bracket is treated as literal text, not as Enter — so prompts that
-    /// rely on `\n` to submit (quick actions: Merge PR, Fix Conflicts, …) get
-    /// pasted but never submitted (#264). Strip the trailing newline before
-    /// pasting and deliver a separate `Enter` via `send-keys` afterwards,
-    /// mirroring what `GhosttySurfaceView.writeText` does with keycode 36.
+    /// rely on `\n` to submit (quick actions, auto-respond) get pasted but
+    /// never submitted (#264). Strip the trailing newline before pasting and
+    /// deliver a separate `Enter` via `send-keys` afterwards, mirroring what
+    /// `GhosttySurfaceView.writeText` does with keycode 36.
+    ///
+    /// A 50ms delay between the paste and the Enter keystroke gives the TUI
+    /// time to process the bracket-end sequence (`\e[201~`). Without this,
+    /// auto-respond prompts (which fire when the terminal has been idle) can
+    /// race: the Enter arrives before the TUI finishes handling the paste,
+    /// causing it to be silently dropped (#272).
     public func sendText(id: UUID, text: String) throws {
         guard let windowIndex = bindings[id] else {
             throw TmuxBackendError.unknownTerminal(id)
@@ -259,13 +265,21 @@ public final class TmuxBackend {
             let endsWithNewline = text.hasSuffix("\n")
             let payload = endsWithNewline ? String(text.dropLast()) : text
 
+            var didPaste = false
             if !payload.isEmpty {
                 let bufferName = "crow-\(id.uuidString)"
                 try ctrl.loadBufferFromStdin(name: bufferName, data: Data(payload.utf8))
                 defer { ctrl.deleteBuffer(name: bufferName) }
                 try ctrl.pasteBuffer(name: bufferName, target: target)
+                didPaste = true
             }
             if endsWithNewline {
+                // Give the TUI time to process the paste bracket-end before
+                // the Enter key arrives. Only needed when we actually pasted
+                // content — a bare "\n" (Enter-only) needs no delay.
+                if didPaste {
+                    Thread.sleep(forTimeInterval: 0.05)
+                }
                 try ctrl.sendKeys(target: target, keys: ["Enter"])
             }
         } catch {

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -125,6 +125,42 @@ struct TmuxBackendTests {
         #expect(binding.windowIndex >= 0)
     }
 
+    @Test func sendTextWithTrailingNewlineDoesNotThrow() throws {
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+
+        let id = UUID()
+        _ = try backend.registerTerminal(
+            id: id,
+            name: "newline-test",
+            cwd: NSHomeDirectory(),
+            command: nil,
+            trackReadiness: false
+        )
+
+        // Trailing \n triggers the paste + separate Enter path (#264/#272).
+        // Verify the full code path executes without throwing.
+        let payload = "AUTO-RESPOND-TEST-\(UUID().uuidString)\n"
+        try backend.sendText(id: id, text: payload)
+    }
+
+    @Test func sendTextEmptyWithNewlineDoesNotThrow() throws {
+        let backend = makeBackend()
+        defer { backend.shutdown() }
+
+        let id = UUID()
+        _ = try backend.registerTerminal(
+            id: id,
+            name: "bare-enter",
+            cwd: NSHomeDirectory(),
+            command: nil,
+            trackReadiness: false
+        )
+
+        // Edge case: bare "\n" should only send Enter (no paste).
+        try backend.sendText(id: id, text: "\n")
+    }
+
     @Test func retryReadinessEmitsTimedOutWhenSentinelMissing() async throws {
         let backend = makeBackend()
         defer { backend.shutdown() }


### PR DESCRIPTION
Closes #272

## Summary

- Adds a 50ms delay between `paste-buffer` and `send-keys Enter` in `TmuxBackend.sendText()` to prevent a timing race where the Enter keystroke arrives before the TUI has finished processing the bracketed-paste bracket-end sequence
- Only applies the delay when content was actually pasted (bare Enter-only sends skip the delay)
- Adds two integration tests covering the trailing-newline paste+Enter path and the bare-Enter edge case

## Context

PR #267 fixed quick-action prompts not submitting by splitting the trailing `\n` into a separate `send-keys Enter` after the paste. The same fix covers auto-respond prompts (same code path), but a timing race between the two tmux CLI invocations can cause the Enter to be silently dropped when the terminal has been idle — which is the typical state when auto-respond fires.

## Test plan

- [ ] `swift build` compiles without errors
- [ ] `swift test` passes (existing + new `TmuxBackendTests`)
- [ ] Manual: create a tmux-backed session with a PR that has failing CI, verify the auto-respond prompt is submitted automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)