### PR TITLE
Re-request reviews after addressing changes

### DIFF
--- a/Sources/Crow/App/AutoRespondCoordinator.swift
+++ b/Sources/Crow/App/AutoRespondCoordinator.swift
@@ -116,13 +116,16 @@ enum AutoRespondPrompts {
         switch transition.kind {
         case .changesRequested:
             let fetchHint: String
+            let reRequestHint: String
             if provider == .gitlab {
                 fetchHint = "Run `glab mr view \(transition.prURL) --comments` to read the review feedback."
+                reRequestHint = "After pushing, re-request review from each reviewer who requested changes by running `glab mr update \(transition.prURL) --reviewer <login>` for each one (the reviewer logins are in the review data you already fetched)."
             } else {
                 let prNumStr = transition.prNumber.map(String.init) ?? "<number>"
                 fetchHint = "Run `gh pr view \(transition.prURL) --json reviews,comments` (and `gh api repos/{owner}/{repo}/pulls/\(prNumStr)/comments` for inline comments) to read the full review feedback."
+                reRequestHint = "After pushing, re-request review from each reviewer who requested changes by running `gh pr edit \(transition.prURL) --add-reviewer <login>` for each one (the reviewer logins are in the review data you already fetched)."
             }
-            return "Crow detected a 'changes requested' review on \(prRef) (\(transition.prURL)). \(fetchHint) Address every reviewer comment in code, commit the fix, and push so the PR updates. If a comment is unclear or you disagree, leave a reply explaining your reasoning instead of changing the code.\n"
+            return "Crow detected a 'changes requested' review on \(prRef) (\(transition.prURL)). \(fetchHint) Address every reviewer comment in code, commit the fix, and push so the PR updates. If a comment is unclear or you disagree, leave a reply explaining your reasoning instead of changing the code. \(reRequestHint)\n"
 
         case .checksFailing:
             let failedSummary: String


### PR DESCRIPTION
## Summary

- Adds a re-request review instruction to the `changesRequested` auto-respond prompt in `AutoRespondCoordinator`
- After Claude Code addresses review comments and pushes, it now also runs `gh pr edit --add-reviewer <login>` (GitHub) or `glab mr update --reviewer <login>` (GitLab) to re-request review from each reviewer who requested changes
- Both the auto-respond and manual "Address Changes" quick action paths pick up the change since they share `AutoRespondPrompts.build()`

Closes #275

## Test plan

- [ ] Trigger a "changes requested" review on a PR managed by Crow
- [ ] Verify the injected prompt includes the re-request instruction
- [ ] Verify Claude Code fetches reviews, addresses comments, pushes, then runs `gh pr edit --add-reviewer`
- [ ] Verify the reviewer receives a GitHub notification that their review was re-requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)