### PR TITLE
feat: use crow emoji in GitHub/GitLab posts

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -4,5 +4,5 @@ public enum CrowAttribution {
     public static let repoURL = "https://github.com/radiusmethod/crow"
 
     public static let reviewMarkdownLink =
-        "[🤖 Reviewed by Crow via Claude Code](\(repoURL))"
+        "[🐦‍⬛ Reviewed by Crow via Claude Code](\(repoURL))"
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @Test func crowAttributionReviewLinkIsCanonical() {
     #expect(CrowAttribution.reviewMarkdownLink ==
-            "[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)")
+            "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)")
 }
 
 @Test func crowAttributionReviewLinkEmbedsRepoURL() {

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -129,7 +129,7 @@ Use this format for the review:
 
 ---
 
-[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -137,7 +137,7 @@ Use this format for the review:
 The review body passed to `gh pr review --body` MUST end with a blank line followed by exactly this line:
 
 ```
-[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
 ```
 
 - Do not modify the link text.

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -14,7 +14,7 @@ struct AttributionSkillTests {
 
     private static let canonicalRepoURL = "https://github.com/radiusmethod/crow"
     private static let canonicalReviewLink =
-        "[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)"
+        "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)"
 
     /// Walk up from this test source file until we find Package.swift.
     /// Returns the repo root URL.

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -129,7 +129,7 @@ Use this format for the review:
 
 ---
 
-[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -137,7 +137,7 @@ Use this format for the review:
 The review body passed to `gh pr review --body` MUST end with a blank line followed by exactly this line:
 
 ```
-[🤖 Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
 ```
 
 - Do not modify the link text.

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -349,7 +349,7 @@ write_settings_local() {
   cat > "$settings_path" <<EOF
 {
   "attribution": {
-    "commit": "🤖 Generated with Claude Code, orchestrated by Crow\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>\\nCrow-Session: $SESSION_ID"
+    "commit": "🐦‍⬛ Generated with Claude Code, orchestrated by Crow\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>\\nCrow-Session: $SESSION_ID"
   }
 }
 EOF


### PR DESCRIPTION
## Summary
- Replace 🤖 with 🐦‍⬛ in the PR review attribution constant (`CrowAttribution.reviewMarkdownLink`) so Crow-posted reviews on GitHub render with the crow emoji.
- Mirror the change in the `crow-review-pr` skill (live + bundled template) and update both snapshot tests.
- Update the commit attribution heredoc in `skills/crow-workspace/setup.sh` so new worktrees' `.claude/settings.local.json` writes Crow-originated commits with 🐦‍⬛ — those commit messages are visible on GitHub/GitLab once pushed.

Closes #279

## Test plan
- [x] `make build`
- [x] `swift test --filter Attribution` (5/5 pass)
- [x] `cd Packages/CrowCore && swift test --filter crowAttribution` (4/4 pass)
- [x] `grep -rn '🤖' Sources/ Packages/ skills/ Resources/ Tests/` returns 0 hits
- [x] `grep -rn '🐦‍⬛' …` returns the 7 expected hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)