### PR TITLE
feat: manual Refresh button and ⌘R shortcut

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -115,6 +115,11 @@ public final class AppState {
     /// AppDelegate wires this to its `showSettings()` method.
     public var onShowSettings: (() -> Void)?
 
+    /// Called when the user requests a manual refresh (toolbar button or ⌘R).
+    /// AppDelegate wires this to `IssueTracker.refresh()`, which re-fetches
+    /// issues, review requests, PR status, and runs auto-create/auto-complete.
+    public var onManualRefresh: (() -> Void)?
+
     // MARK: - PR & Tool Status
 
     /// PR status per session (pipeline, review, merge readiness).

--- a/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
@@ -32,5 +32,18 @@ public struct MainContentView: View {
                 )
             }
         }
+        .background(refreshShortcut)
+    }
+
+    /// Zero-sized button that registers a window-wide ⌘R shortcut so the user
+    /// can force-refresh polled data without waiting for the next auto-poll.
+    private var refreshShortcut: some View {
+        Button("Refresh") {
+            appState.onManualRefresh?()
+        }
+        .keyboardShortcut("r", modifiers: .command)
+        .frame(width: 0, height: 0)
+        .opacity(0)
+        .accessibilityHidden(true)
     }
 }

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -54,11 +54,37 @@ public struct ReviewBoardView: View {
                 .font(.caption)
                 .foregroundStyle(CorveilTheme.textSecondary)
 
+            refreshButton
+
             selectToggleButton
         }
         .padding(.horizontal)
         .padding(.vertical, 10)
         .background(CorveilTheme.bgSurface)
+    }
+
+    private var refreshButton: some View {
+        Button {
+            appState.onManualRefresh?()
+        } label: {
+            Image(systemName: "arrow.clockwise")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(CorveilTheme.textSecondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(CorveilTheme.bgCard)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(CorveilTheme.borderSubtle, lineWidth: 1)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(appState.isLoadingReviews)
+        .help("Refresh")
+        .accessibilityLabel("Refresh reviews")
     }
 
     private var selectToggleButton: some View {

--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -52,6 +52,8 @@ public struct TicketBoardView: View {
                     .font(.caption)
                     .foregroundStyle(CorveilTheme.textSecondary)
 
+                refreshButton
+
                 selectToggleButton
 
                 SortMenu(sortOrder: $appState.ticketSortOrder)
@@ -63,6 +65,30 @@ public struct TicketBoardView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(CorveilTheme.bgSurface)
+    }
+
+    private var refreshButton: some View {
+        Button {
+            appState.onManualRefresh?()
+        } label: {
+            Image(systemName: "arrow.clockwise")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(CorveilTheme.textSecondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(CorveilTheme.bgCard)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(CorveilTheme.borderSubtle, lineWidth: 1)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(appState.isLoadingIssues)
+        .help("Refresh")
+        .accessibilityLabel("Refresh tickets")
     }
 
     private var selectToggleButton: some View {

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -500,6 +500,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Task { await tracker?.markInReview(sessionID: id) }
         }
 
+        appState.onManualRefresh = { [weak tracker] in
+            Task { await tracker?.refresh() }
+        }
+
         // Initialize notification manager
         let notifManager = NotificationManager(appState: appState, settings: config.notifications)
         self.notificationManager = notifManager


### PR DESCRIPTION
## Summary
- Adds a manual refresh affordance so users can force a re-fetch of polled data without waiting for the 60-second `IssueTracker` cycle.
- Refresh buttons appear in the Ticket Board and Review Board headers, disabled while a fetch is in flight.
- A window-wide ⌘R keyboard shortcut is registered via a hidden button in `MainContentView`.
- All paths funnel into `IssueTracker.refresh()`; the existing `isRefreshing` guard and rate-limit short-circuit make repeat triggers safe.

Closes #281

## Test plan
- [ ] Open the Ticket Board, click the new refresh icon — issues re-fetch and the spinner appears briefly.
- [ ] Open the Review Board, click refresh — reviews re-fetch.
- [ ] Press ⌘R from either board (or anywhere in the main window) — same behavior.
- [ ] Spam ⌘R during a fetch — no crash, no duplicate work (guarded by `isRefreshing`).
- [ ] With a rate-limit warning active, click refresh — call is a no-op (guarded by `shouldPoll()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)