### PR TITLE
fix: harden terminal teardown races on tab close (#282)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/SentinelWaiter.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/SentinelWaiter.swift
@@ -38,10 +38,18 @@ public struct SentinelWaiter: Sendable {
         let nanosPerInterval = UInt64(pollInterval * 1_000_000_000)
         let fm = FileManager.default
         while Date() < deadline {
+            // Cancellation: TmuxBackend.destroyTerminal cancels the waiter
+            // Task when the user closes a tab. Without this check, `try?`
+            // below would swallow `CancellationError` and the loop would
+            // tighten into a `fileExists` spin until the deadline (#282
+            // review). Re-check before the sleep too in case cancellation
+            // arrives mid-iteration.
+            if Task.isCancelled { return nil }
             if fm.fileExists(atPath: sentinelPath) {
                 return Date().timeIntervalSince(start)
             }
             try? await Task.sleep(nanoseconds: nanosPerInterval)
+            if Task.isCancelled { return nil }
         }
         return nil
     }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -112,6 +112,11 @@ public final class TmuxBackend {
         sharedSurface = nil
         controller = nil
         bindings.removeAll()
+        // Cancel any in-flight readiness watches so they don't keep polling
+        // (sentinel files are about to be unlinked) after server teardown.
+        // Mirrors the `destroyTerminal` cleanup (#282).
+        for tasks in readinessTasks.values { tasks.forEach { $0.cancel() } }
+        readinessTasks.removeAll()
         for path in sentinels.values {
             try? FileManager.default.removeItem(atPath: path)
         }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -58,6 +58,11 @@ public final class TmuxBackend {
     /// on destroy. Issue #256.
     private var wrapperLogs: [UUID: String] = [:]
 
+    /// UUID → in-flight readiness watch Tasks (the 10s progress beacon and
+    /// the waiter). `destroyTerminal` cancels these so they don't fire
+    /// `onReadinessChanged` for a tab the user just closed. Issue #282.
+    private var readinessTasks: [UUID: [Task<Void, Never>]] = [:]
+
     /// Offscreen window the shared surface lives in until SwiftUI re-parents
     /// it into the visible UI. Same trick the Ghostty path uses for
     /// background surface creation.
@@ -294,6 +299,10 @@ public final class TmuxBackend {
             controller?.killWindow(index: windowIndex)
         }
         bindings.removeValue(forKey: id)
+        // Cancel in-flight readiness watch Tasks so a 30s waiter doesn't
+        // fire `onReadinessChanged` against a stale id long after the tab
+        // is gone (issue #282).
+        readinessTasks.removeValue(forKey: id)?.forEach { $0.cancel() }
         if let sentinelPath = sentinels.removeValue(forKey: id) {
             try? FileManager.default.removeItem(atPath: sentinelPath)
         }
@@ -417,7 +426,7 @@ public final class TmuxBackend {
                 NSLog("[CrowTelemetry tmux:first_prompt_progress terminal=\(id) elapsed_ms=\(elapsed) sentinel_exists=\(exists)]")
             }
         }
-        Task { [weak self] in
+        let waiterTask = Task { [weak self] in
             // 30s default budget (was 5s). On app restart with many managed
             // terminals hydrating concurrently, shell startup is CPU-contended
             // and the wrapper's first precmd may not fire within 5s. Callers
@@ -428,7 +437,11 @@ public final class TmuxBackend {
             )
             progressTask.cancel()
             await MainActor.run { [weak self] in
-                guard let self else { return }
+                // Bail if the terminal was destroyed (or the backend went
+                // away) while we were waiting. Without this guard a 30s
+                // waiter could fire readiness for a tab the user closed
+                // 29s ago — issue #282.
+                guard let self, self.bindings[id] != nil else { return }
                 if let elapsed {
                     let ms = Int(elapsed * 1000)
                     NSLog("[CrowTelemetry tmux:first_prompt_ms=\(ms) terminal=\(id)]")
@@ -459,6 +472,11 @@ public final class TmuxBackend {
                 }
             }
         }
+        // Track both Tasks so `destroyTerminal` can cancel them (#282).
+        // `retryReadinessWatch` may call us again for the same id; the
+        // previous Tasks are already resolved (or about to be), so appending
+        // here rather than replacing keeps the contract simple.
+        readinessTasks[id, default: []].append(contentsOf: [progressTask, waiterTask])
     }
 
     /// Re-arm the readiness watch for a terminal whose first attempt timed

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1011,6 +1011,12 @@ final class SessionService {
         // underlying `ghostty_surface_t` (or kill the tmux window). Freeing
         // it while AppKit still holds the view risks a Metal/input callback
         // landing on a dangling pointer (issue #282).
+        //
+        // Note: single-tick defer is a conservative first attempt. Neither
+        // Combine nor DispatchQueue strictly guarantee ordering against the
+        // SwiftUI CATransaction commit; if #282 recurs the next step is a
+        // two-tick defer (nested `DispatchQueue.main.async`) or moving the
+        // destroy to a runloop-quiesce sweep.
         DispatchQueue.main.async {
             TerminalRouter.destroy(terminal)
         }

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -996,7 +996,6 @@ final class SessionService {
               let terminal = terminals.first(where: { $0.id == terminalID }),
               !terminal.isManaged else { return }
 
-        TerminalRouter.destroy(terminal)
         appState.terminals[sessionID]?.removeAll { $0.id == terminalID }
         appState.terminalReadiness.removeValue(forKey: terminalID)
         appState.autoLaunchTerminals.remove(terminalID)
@@ -1006,6 +1005,15 @@ final class SessionService {
         }
 
         store.mutate { data in data.terminals.removeAll { $0.id == terminalID } }
+
+        // Defer the backing destroy so SwiftUI's render pass detaches the
+        // GhosttySurfaceView from the view hierarchy before we free its
+        // underlying `ghostty_surface_t` (or kill the tmux window). Freeing
+        // it while AppKit still holds the view risks a Metal/input callback
+        // landing on a dangling pointer (issue #282).
+        DispatchQueue.main.async {
+            TerminalRouter.destroy(terminal)
+        }
     }
 
     /// Rename a terminal tab. Returns `false` if the terminal was not found or the name is invalid.
@@ -1046,11 +1054,6 @@ final class SessionService {
     func closeGlobalTerminal(terminalID: UUID) {
         let sessionID = AppState.globalTerminalSessionID
         let terminal = appState.terminals[sessionID]?.first(where: { $0.id == terminalID })
-        if let terminal {
-            TerminalRouter.destroy(terminal)
-        } else {
-            TerminalManager.shared.destroy(id: terminalID)
-        }
         appState.terminals[sessionID]?.removeAll { $0.id == terminalID }
 
         if appState.activeTerminalID[sessionID] == terminalID {
@@ -1058,6 +1061,16 @@ final class SessionService {
         }
 
         store.mutate { data in data.terminals.removeAll { $0.id == terminalID } }
+
+        // Defer the backing destroy so SwiftUI detaches the view before the
+        // underlying surface is freed (issue #282). Mirrors `closeTerminal`.
+        DispatchQueue.main.async {
+            if let terminal {
+                TerminalRouter.destroy(terminal)
+            } else {
+                TerminalManager.shared.destroy(id: terminalID)
+            }
+        }
     }
 
     // MARK: - Review Session


### PR DESCRIPTION
Closes #282

## Summary

Closes two teardown races that match the bug report's "unbalanced retain/release on terminal/tab teardown" hypothesis.

- **`SessionService.closeTerminal` / `closeGlobalTerminal`** previously called `TerminalRouter.destroy(terminal)` *before* mutating `appState.terminals`. Result: `ghostty_surface_free` (or `tmux kill-window`) ran while the `GhosttySurfaceView` was still in the SwiftUI view hierarchy. Any Metal redraw, mouse-tracking, or input callback in that window operated on a freed surface pointer. Fix: mutate `appState` first so SwiftUI's render pass detaches the view; dispatch the backing destroy to the next main-actor tick.
- **`TmuxBackend.startReadinessWatch`** spawns a 10s progress beacon and a 30s sentinel waiter as `Task { … }` blocks. `destroyTerminal(id:)` removed the binding but never cancelled the Tasks. After the user closed a tab, the waiter could still fire `onReadinessChanged` ~29s later for a stale id. Fix: track the Task handles in `readinessTasks: [UUID: [Task<Void, Never>]]`, cancel them in `destroyTerminal`, and gate the post-wait callback on `bindings[id] != nil` so a Task that wins the cancel race bails.

The existing `CrashReporter` (`Sources/Crow/App/CrashReporter.swift`) already installs POSIX signal handlers and redirects stderr to `~/.local/share/crow/crash-logs/`, so if the bug still reproduces after this change, the next iteration has a stack trace to work from.

## Test plan

- [ ] `swift build --arch arm64` succeeds (verified locally)
- [ ] Add 10+ shell tabs to a session via the "+" button, switch between them rapidly, then close them in arbitrary order — no crash
- [ ] Same flow on the Global Terminals row
- [ ] Close a tmux-backed tab within 30s of opening it; confirm no late `onReadinessChanged` fires (look for stale `[CrowTelemetry tmux:first_prompt_ms=…]` lines in the log)
- [ ] If a crash still reproduces, confirm a stack trace lands in `~/.local/share/crow/crash-logs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)