### PR TITLE
review: require approve or request-changes verdict (no comment reviews)

### DIFF
--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -81,23 +81,21 @@ ruff check . 2>&1 | head -50
 
 ### Step 5: Post Review
 
-Based on your findings, determine the appropriate review action:
+Every Crow review must end with a verdict — **exactly one** of the two actions below. Comment-only reviews (`--comment` / `event: COMMENT`) are **not permitted**: they are ambiguous, don't move the PR forward, and effectively no-op the review.
 
 - **Approve**: No critical or blocking issues found → use `--approve`
-- **Request Changes**: Critical or blocking issues found → use `--request-changes`
-- **Comment**: Informational only, no strong opinion either way → use `--comment`
+- **Request Changes**: Anything the author should address before merging → use `--request-changes`
 
-Post the review using the appropriate flag:
+If you have feedback but cannot confidently approve, you **must** use `--request-changes`. Never fall back to `--comment`.
+
+Post the review using exactly one of these two flags:
 
 ```bash
 # If approving:
 gh pr review $ARGUMENTS --approve --body "YOUR_REVIEW_HERE"
 
-# If requesting changes:
+# If requesting changes (also the default when uncertain):
 gh pr review $ARGUMENTS --request-changes --body "YOUR_REVIEW_HERE"
-
-# If commenting only:
-gh pr review $ARGUMENTS --comment --body "YOUR_REVIEW_HERE"
 ```
 
 Use this format for the review:
@@ -125,7 +123,7 @@ Use this format for the review:
 | Yellow | Should fix items |
 | Green | Consider items |
 
-**Recommendation:** [Approve / Request Changes / Comment — with reasoning]
+**Recommendation:** [Approve / Request Changes — with reasoning]
 
 ---
 
@@ -143,7 +141,7 @@ The review body passed to `gh pr review --body` MUST end with a blank line follo
 - Do not modify the link text.
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
-- This line MUST appear in every review body, regardless of whether you used `--approve`, `--request-changes`, or `--comment`.
+- This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.
 
 ### Important Notes
 
@@ -154,5 +152,5 @@ The review body passed to `gh pr review --body` MUST end with a blank line follo
 - If tests fail, note which ones and why
 - Use `--approve` when the PR looks good (no red/blocking items)
 - Use `--request-changes` when there are critical issues that must be fixed before merge
-- Use `--comment` only when you have no strong recommendation either way
+- **Never** use `--comment` — a Crow review must always be a verdict. If you would have commented, request changes instead.
 - All `gh` and `git` commands require `dangerouslyDisableSandbox: true`

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -81,23 +81,21 @@ ruff check . 2>&1 | head -50
 
 ### Step 5: Post Review
 
-Based on your findings, determine the appropriate review action:
+Every Crow review must end with a verdict — **exactly one** of the two actions below. Comment-only reviews (`--comment` / `event: COMMENT`) are **not permitted**: they are ambiguous, don't move the PR forward, and effectively no-op the review.
 
 - **Approve**: No critical or blocking issues found → use `--approve`
-- **Request Changes**: Critical or blocking issues found → use `--request-changes`
-- **Comment**: Informational only, no strong opinion either way → use `--comment`
+- **Request Changes**: Anything the author should address before merging → use `--request-changes`
 
-Post the review using the appropriate flag:
+If you have feedback but cannot confidently approve, you **must** use `--request-changes`. Never fall back to `--comment`.
+
+Post the review using exactly one of these two flags:
 
 ```bash
 # If approving:
 gh pr review $ARGUMENTS --approve --body "YOUR_REVIEW_HERE"
 
-# If requesting changes:
+# If requesting changes (also the default when uncertain):
 gh pr review $ARGUMENTS --request-changes --body "YOUR_REVIEW_HERE"
-
-# If commenting only:
-gh pr review $ARGUMENTS --comment --body "YOUR_REVIEW_HERE"
 ```
 
 Use this format for the review:
@@ -125,7 +123,7 @@ Use this format for the review:
 | Yellow | Should fix items |
 | Green | Consider items |
 
-**Recommendation:** [Approve / Request Changes / Comment — with reasoning]
+**Recommendation:** [Approve / Request Changes — with reasoning]
 
 ---
 
@@ -143,7 +141,7 @@ The review body passed to `gh pr review --body` MUST end with a blank line follo
 - Do not modify the link text.
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
-- This line MUST appear in every review body, regardless of whether you used `--approve`, `--request-changes`, or `--comment`.
+- This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.
 
 ### Important Notes
 
@@ -154,5 +152,5 @@ The review body passed to `gh pr review --body` MUST end with a blank line follo
 - If tests fail, note which ones and why
 - Use `--approve` when the PR looks good (no red/blocking items)
 - Use `--request-changes` when there are critical issues that must be fixed before merge
-- Use `--comment` only when you have no strong recommendation either way
+- **Never** use `--comment` — a Crow review must always be a verdict. If you would have commented, request changes instead.
 - All `gh` and `git` commands require `dangerouslyDisableSandbox: true`


### PR DESCRIPTION
## Summary

- Removes `--comment` / `event: COMMENT` from the `crow-review-pr` skill's allowed review actions, in both the source skill (`skills/crow-review-pr/SKILL.md`) and the bundled fallback (`Resources/crow-review-pr-SKILL.md.template`).
- Forces every Crow code review to resolve to **Approve** or **Request Changes**, with `--request-changes` as the explicit default when the model has feedback but cannot confidently approve.
- Updates the in-prompt "Recommendation" template, attribution rules, and "Important Notes" so no path to a comment-only review remains.

## Test plan

- [ ] Open a fresh review session in Crow against a test PR; confirm the model only invokes `gh pr review --approve` or `gh pr review --request-changes`.
- [ ] `grep -n -- '--comment' skills/crow-review-pr/SKILL.md Resources/crow-review-pr-SKILL.md.template` → only matches the new "not permitted" / "never use" guard rails.
- [ ] `diff` of the two skill files is empty (bundled template stays in sync with source).

Closes #287

🐦‍⬛ Generated with [Claude Code](https://claude.com/claude-code), orchestrated by [Crow](https://github.com/radiusmethod/crow)