### PR TITLE
Fix re-review not triggering reviewer Crow after /refine

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/ReviewRequest.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/ReviewRequest.swift
@@ -15,6 +15,8 @@ public struct ReviewRequest: Identifiable, Codable, Sendable {
     public var labels: [LabelInfo]
     public var provider: Provider
     public var reviewSessionID: UUID?  // set if a review session already exists
+    public var headRefOid: String?     // PR head commit SHA — used to detect new pushes
+    public var viewerLastReviewedAt: Date?  // viewer's most recent APPROVED/CHANGES_REQUESTED/DISMISSED review timestamp
 
     public init(
         id: String,
@@ -29,7 +31,9 @@ public struct ReviewRequest: Identifiable, Codable, Sendable {
         requestedAt: Date? = nil,
         labels: [LabelInfo] = [],
         provider: Provider = .github,
-        reviewSessionID: UUID? = nil
+        reviewSessionID: UUID? = nil,
+        headRefOid: String? = nil,
+        viewerLastReviewedAt: Date? = nil
     ) {
         self.id = id
         self.prNumber = prNumber
@@ -44,5 +48,7 @@ public struct ReviewRequest: Identifiable, Codable, Sendable {
         self.labels = labels
         self.provider = provider
         self.reviewSessionID = reviewSessionID
+        self.headRefOid = headRefOid
+        self.viewerLastReviewedAt = viewerLastReviewedAt
     }
 }

--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -16,6 +16,13 @@ public struct Session: Identifiable, Codable, Sendable {
     // prompt dispatched. Gates the launchClaude prompt-vs-`--continue`
     // branch so completed reviews don't restart on app relaunch.
     public var reviewPromptDispatched: Bool
+    // Head SHA of the PR at the time the review session was created or
+    // last re-launched. Used by the kickoff guard as a fallback re-kick
+    // signal when a PR's head advances without an explicit re-request
+    // (e.g. force-push) or before the viewer-submitted-review signal is
+    // observed. Nil for non-review sessions and for legacy persisted
+    // sessions predating this field (CROW-290).
+    public var lastReviewedHeadSha: String?
 
     public init(
         id: UUID = UUID(),
@@ -28,7 +35,8 @@ public struct Session: Identifiable, Codable, Sendable {
         provider: Provider? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
-        reviewPromptDispatched: Bool = false
+        reviewPromptDispatched: Bool = false,
+        lastReviewedHeadSha: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -41,6 +49,7 @@ public struct Session: Identifiable, Codable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.reviewPromptDispatched = reviewPromptDispatched
+        self.lastReviewedHeadSha = lastReviewedHeadSha
     }
 
     // Backward-compatible decoding: default `kind` to `.work` when missing
@@ -60,5 +69,6 @@ public struct Session: Identifiable, Codable, Sendable {
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         reviewPromptDispatched = try container.decodeIfPresent(Bool.self, forKey: .reviewPromptDispatched) ?? true
+        lastReviewedHeadSha = try container.decodeIfPresent(String.self, forKey: .lastReviewedHeadSha)
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
@@ -48,6 +48,41 @@ import Testing
     #expect(decoded.provider == nil)
 }
 
+@Test func sessionBackwardCompatDecodingLastReviewedHeadSha() throws {
+    // Persisted state.json predating CROW-290 has no `lastReviewedHeadSha`.
+    // Decode must succeed and default the field to nil.
+    let id = UUID()
+    let date = Date()
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let dateStr = formatter.string(from: date)
+    let json: [String: Any] = [
+        "id": id.uuidString,
+        "name": "legacy",
+        "status": "active",
+        "kind": "review",
+        "createdAt": dateStr,
+        "updatedAt": dateStr,
+    ]
+    let data = try JSONSerialization.data(withJSONObject: json)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let session = try decoder.decode(Session.self, from: data)
+    #expect(session.lastReviewedHeadSha == nil)
+    #expect(session.kind == .review)
+}
+
+@Test func sessionRoundTripsLastReviewedHeadSha() throws {
+    let session = Session(
+        name: "review",
+        kind: .review,
+        lastReviewedHeadSha: "deadbeef"
+    )
+    let data = try JSONEncoder().encode(session)
+    let decoded = try JSONDecoder().decode(Session.self, from: data)
+    #expect(decoded.lastReviewedHeadSha == "deadbeef")
+}
+
 // MARK: - Enum Raw Values
 
 @Test func sessionStatusRawValues() {

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -451,8 +451,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Auto-review: fire on every refresh (including the first) so review
         // requests already pending at app launch are picked up. Idempotent
-        // via an in-flight Set + the persistent `reviewSessionID` cross-ref.
-        var autoReviewedIDs: Set<String> = []
+        // via a (request.id, headRefOid) fingerprint cache + the persistent
+        // `reviewSessionID` cross-ref. The fingerprint keys SHA so that a
+        // PR's next push after a completed review is treated as a fresh
+        // round (CROW-290) instead of being blocked by a stale entry.
+        var autoReviewedFingerprints: Set<String> = []
         tracker.onReviewRequestsRefreshed = { [weak self] requests in
             guard let self else { return }
             let enabledRepos = Set((self.appConfig?.workspaces ?? [])
@@ -462,10 +465,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             var pendingURLs: [String] = []
             for request in requests {
-                guard request.reviewSessionID == nil,
-                      !autoReviewedIDs.contains(request.id),
-                      enabledRepos.contains(request.repo.lowercased()) else { continue }
-                autoReviewedIDs.insert(request.id)
+                guard enabledRepos.contains(request.repo.lowercased()) else { continue }
+                let fingerprint = "\(request.id)@\(request.headRefOid ?? "")"
+                guard !autoReviewedFingerprints.contains(fingerprint) else { continue }
+
+                // Two kickoff conditions:
+                //   1. No linked session — fresh request, or A's
+                //      viewer-submitted-review path just completed the prior
+                //      session so the cross-ref dropped to nil.
+                //   2. Linked session is still active but its
+                //      `lastReviewedHeadSha` is stale relative to the PR's
+                //      current head — fallback re-kick (force-push, or
+                //      round-2 commits landed before signal A was observed).
+                let linkedSession = request.reviewSessionID.flatMap { id in
+                    self.appState.sessions.first(where: { $0.id == id })
+                }
+                let shaAdvanced = linkedSession != nil
+                    && request.headRefOid != nil
+                    && linkedSession?.lastReviewedHeadSha != request.headRefOid
+                guard request.reviewSessionID == nil || shaAdvanced else { continue }
+
+                // B-fallback: tear down the stale round-1 session so the new
+                // session doesn't double up in `reviewSessions` for the same
+                // PR. The A path doesn't need this — `decideReviewCompletions`
+                // already completed the prior session before this point.
+                if shaAdvanced, let staleID = request.reviewSessionID {
+                    self.appState.onCompleteSession?(staleID)
+                }
+
+                autoReviewedFingerprints.insert(fingerprint)
                 pendingURLs.append(request.url)
             }
             if !pendingURLs.isEmpty {

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -338,6 +338,7 @@ final class IssueTracker {
             autoCompleteFinishedReviews(
                 openReviewPRURLs: Set(reviews.map(\.url)),
                 prsByURL: Dictionary(allKnownPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords),
+                reviewRequestsByPRURL: Dictionary(reviews.map { ($0.url, $0) }, uniquingKeysWith: { lhs, _ in lhs }),
                 prDataComplete: prDataComplete
             )
 
@@ -576,13 +577,15 @@ final class IssueTracker {
       reviewPRs: search(type: ISSUE, query: $reviewQuery, first: 50) {
         nodes {
           ... on PullRequest {
-            number title url isDraft updatedAt headRefName baseRefName state
+            number title url isDraft updatedAt headRefName headRefOid baseRefName state
             author { login }
             repository { nameWithOwner }
             labels(first: 20) { nodes { name color } }
+            reviews(last: 20) { nodes { author { login } submittedAt state } }
           }
         }
       }
+      viewer { login }
       rateLimit { remaining limit resetAt cost }
     }
     """
@@ -970,9 +973,11 @@ final class IssueTracker {
             projectStatusOverride: .done
         )
         let viewerPRs = parseViewerPRs(dataObj["viewerPRs"] as? [String: Any])
+        let viewerLogin = (dataObj["viewer"] as? [String: Any])?["login"] as? String
         let reviewRequests = parseReviewRequests(
             dataObj["reviewPRs"] as? [String: Any],
-            dateFormatter: dateFormatter
+            dateFormatter: dateFormatter,
+            viewerLogin: viewerLogin
         )
         let rateLimit = parseRateLimit(dataObj["rateLimit"] as? [String: Any])
 
@@ -1101,9 +1106,15 @@ final class IssueTracker {
 
     private func parseReviewRequests(
         _ searchObj: [String: Any]?,
-        dateFormatter: ISO8601DateFormatter
+        dateFormatter: ISO8601DateFormatter,
+        viewerLogin: String?
     ) -> [ReviewRequest] {
         guard let nodes = searchObj?["nodes"] as? [[String: Any]] else { return [] }
+
+        // Only formal verdicts satisfy a review request. COMMENTED/PENDING
+        // do not — gating on those would mis-complete a session before the
+        // viewer has actually approved or requested changes.
+        let satisfyingStates: Set<String> = ["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]
 
         var requests: [ReviewRequest] = []
         for node in nodes {
@@ -1115,6 +1126,7 @@ final class IssueTracker {
             let authorLogin = (node["author"] as? [String: Any])?["login"] as? String ?? ""
             let isDraft = node["isDraft"] as? Bool ?? false
             let headBranch = node["headRefName"] as? String ?? ""
+            let headRefOid = node["headRefOid"] as? String
             let baseBranch = node["baseRefName"] as? String ?? ""
             let updatedAt = (node["updatedAt"] as? String).flatMap { dateFormatter.date(from: $0) }
             let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
@@ -1123,6 +1135,26 @@ final class IssueTracker {
                     let color = labelNode["color"] as? String
                     return LabelInfo(name: name, color: color)
                 } ?? []
+
+            // Latest viewer-authored review timestamp (APPROVED / CHANGES_REQUESTED
+            // / DISMISSED only). Used by `decideReviewCompletions` to detect when
+            // the reviewer has actually submitted a verdict so the session can be
+            // auto-completed before the PR is merged.
+            var viewerLastReviewedAt: Date?
+            if let viewerLogin,
+               let reviewNodes = ((node["reviews"] as? [String: Any])?["nodes"]) as? [[String: Any]] {
+                for review in reviewNodes {
+                    guard let author = (review["author"] as? [String: Any])?["login"] as? String,
+                          author == viewerLogin,
+                          let state = review["state"] as? String,
+                          satisfyingStates.contains(state),
+                          let submittedAtStr = review["submittedAt"] as? String,
+                          let submittedAt = dateFormatter.date(from: submittedAtStr) else { continue }
+                    if viewerLastReviewedAt == nil || submittedAt > viewerLastReviewedAt! {
+                        viewerLastReviewedAt = submittedAt
+                    }
+                }
+            }
 
             requests.append(ReviewRequest(
                 id: "github:\(repoName)#\(number)",
@@ -1136,7 +1168,9 @@ final class IssueTracker {
                 isDraft: isDraft,
                 requestedAt: updatedAt,
                 labels: labels,
-                provider: .github
+                provider: .github,
+                headRefOid: headRefOid,
+                viewerLastReviewedAt: viewerLastReviewedAt
             ))
         }
         // Newest first so stale review requests sink to the bottom
@@ -1809,23 +1843,42 @@ final class IssueTracker {
         return CompletionResult(completions: decisions, floorGuardTriggered: false)
     }
 
-    /// Decide which review sessions should be auto-completed. Requires the
-    /// PR to be present in `prsByURL` with state `MERGED` or `CLOSED` — the
-    /// old "missing from open review queue == done" rule was unsafe under
-    /// partial fetches.
+    /// Decide which review sessions should be auto-completed. Three rules:
+    ///   1. Viewer has submitted a formal review (APPROVED / CHANGES_REQUESTED
+    ///      / DISMISSED) at a time strictly after `session.createdAt`. This
+    ///      closes the round so that an author's subsequent `/refine` +
+    ///      re-request lands as a fresh review request with no linked
+    ///      session, letting the kickoff guard re-fire (CROW-290).
+    ///   2. PR is MERGED — terminal state, always complete.
+    ///   3. PR is CLOSED — terminal state, always complete.
+    /// Rules 2 + 3 require the PR to be present in `prsByURL` with the
+    /// matching state and `prDataComplete == true` so the old "missing
+    /// from open review queue == done" rule isn't reintroduced under
+    /// partial fetches. Rule 1 only needs the `ReviewRequest` payload (the
+    /// PR is still open at this point so it's always present in `reviewRequestsByPRURL`).
     nonisolated static func decideReviewCompletions(
         reviewSessions: [Session],
         linksBySessionID: [UUID: [SessionLink]],
         openReviewPRURLs: Set<String>,
         prsByURL: [String: ViewerPR],
+        reviewRequestsByPRURL: [String: ReviewRequest],
         prDataComplete: Bool
     ) -> [CompletionDecision] {
-        guard prDataComplete else { return [] }
-
         var decisions: [CompletionDecision] = []
         for session in reviewSessions {
             let sessionLinks = linksBySessionID[session.id] ?? []
             guard let prLink = sessionLinks.first(where: { $0.linkType == .pr }) else { continue }
+
+            // Rule 1: viewer-submitted review after the session was created.
+            if let request = reviewRequestsByPRURL[prLink.url],
+               let reviewedAt = request.viewerLastReviewedAt,
+               reviewedAt > session.createdAt {
+                decisions.append(CompletionDecision(sessionID: session.id, reason: "viewer submitted review"))
+                continue
+            }
+
+            // Rules 2 + 3 — terminal PR states. Require complete data.
+            guard prDataComplete else { continue }
             if openReviewPRURLs.contains(prLink.url) { continue }
             guard let pr = prsByURL[prLink.url] else { continue }
             switch pr.state {
@@ -1889,6 +1942,7 @@ final class IssueTracker {
     private func autoCompleteFinishedReviews(
         openReviewPRURLs: Set<String>,
         prsByURL: [String: ViewerPR],
+        reviewRequestsByPRURL: [String: ReviewRequest],
         prDataComplete: Bool
     ) {
         let activeReviews = appState.sessions.filter { $0.kind == .review && $0.status == .active }
@@ -1902,6 +1956,7 @@ final class IssueTracker {
             linksBySessionID: linksBySessionID,
             openReviewPRURLs: openReviewPRURLs,
             prsByURL: prsByURL,
+            reviewRequestsByPRURL: reviewRequestsByPRURL,
             prDataComplete: prDataComplete
         )
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1106,7 +1106,7 @@ final class SessionService {
         // Fetch PR metadata
         guard let prOutput = try? await shell(
             "gh", "pr", "view", prURL,
-            "--json", "title,headRefName,baseRefName,number"
+            "--json", "title,headRefName,headRefOid,baseRefName,number"
         ) else {
             NSLog("[SessionService] Failed to fetch PR metadata for \(prURL)")
             return nil
@@ -1119,6 +1119,10 @@ final class SessionService {
             NSLog("[SessionService] Failed to parse PR metadata for \(prURL)")
             return nil
         }
+        // `headRefOid` is the SHA the review session is anchored to. Used by
+        // the kickoff guard (AppDelegate) as a fallback re-kick signal when
+        // the PR head advances without an explicit re-request (CROW-290).
+        let headRefOid = prJSON["headRefOid"] as? String
 
         // Determine clone path
         guard let devRoot = ConfigStore.loadDevRoot() else {
@@ -1172,7 +1176,8 @@ final class SessionService {
             name: "review-\(repoName)-\(prNumber)",
             kind: .review,
             ticketTitle: prTitle,
-            provider: .github
+            provider: .github,
+            lastReviewedHeadSha: headRefOid
         )
 
         let worktree = SessionWorktree(

--- a/Tests/CrowTests/IssueTrackerCompletionTests.swift
+++ b/Tests/CrowTests/IssueTrackerCompletionTests.swift
@@ -15,6 +15,7 @@ struct IssueTrackerCompletionTests {
         kind: SessionKind = .work,
         ticketURL: String? = nil,
         provider: Provider? = .github,
+        createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) -> Session {
         Session(
@@ -24,7 +25,27 @@ struct IssueTrackerCompletionTests {
             kind: kind,
             ticketURL: ticketURL,
             provider: provider,
+            createdAt: createdAt,
             updatedAt: updatedAt
+        )
+    }
+
+    private func makeReviewRequest(
+        url: String,
+        viewerLastReviewedAt: Date? = nil,
+        headRefOid: String? = nil
+    ) -> ReviewRequest {
+        ReviewRequest(
+            id: "github:foo/bar#9",
+            prNumber: 9,
+            title: "title",
+            url: url,
+            repo: "foo/bar",
+            author: "alice",
+            headBranch: "feature",
+            baseBranch: "main",
+            headRefOid: headRefOid,
+            viewerLastReviewedAt: viewerLastReviewedAt
         )
     }
 
@@ -258,6 +279,7 @@ struct IssueTrackerCompletionTests {
             linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
             openReviewPRURLs: [],
             prsByURL: [prURL: makeViewerPR(url: prURL, state: "MERGED")],
+            reviewRequestsByPRURL: [:],
             prDataComplete: true
         )
         #expect(decisions == [
@@ -274,6 +296,7 @@ struct IssueTrackerCompletionTests {
             linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
             openReviewPRURLs: [prURL],
             prsByURL: [prURL: makeViewerPR(url: prURL, state: "MERGED")],
+            reviewRequestsByPRURL: [:],
             prDataComplete: true
         )
         #expect(decisions.isEmpty)
@@ -288,6 +311,7 @@ struct IssueTrackerCompletionTests {
             linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
             openReviewPRURLs: [],
             prsByURL: [prURL: makeViewerPR(url: prURL, state: "MERGED")],
+            reviewRequestsByPRURL: [:],
             prDataComplete: false
         )
         #expect(decisions.isEmpty)
@@ -304,9 +328,93 @@ struct IssueTrackerCompletionTests {
             linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
             openReviewPRURLs: [],
             prsByURL: [:],
+            reviewRequestsByPRURL: [:],
             prDataComplete: true
         )
         #expect(decisions.isEmpty)
+    }
+
+    // MARK: - Viewer-submitted review completes session (CROW-290)
+
+    @Test
+    func reviewSubmittedAfterSessionStartCompletes() {
+        // Reviewer has submitted a verdict (APPROVED) after the session was
+        // created — close the session so a re-request lands as a fresh one.
+        let createdAt = Date().addingTimeInterval(-3600)
+        let reviewSession = makeSession(kind: .review, createdAt: createdAt)
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let request = makeReviewRequest(url: prURL, viewerLastReviewedAt: Date())
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [prURL],
+            prsByURL: [:],
+            reviewRequestsByPRURL: [prURL: request],
+            prDataComplete: true
+        )
+        #expect(decisions == [
+            IssueTracker.CompletionDecision(sessionID: reviewSession.id, reason: "viewer submitted review")
+        ])
+    }
+
+    @Test
+    func reviewSubmittedBeforeSessionStartIgnored() {
+        // Reviewer's last verdict predates this session — that was round 1,
+        // round 2's session is what's active now. Don't complete it.
+        let reviewedAt = Date().addingTimeInterval(-3600)
+        let reviewSession = makeSession(kind: .review, createdAt: Date())
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let request = makeReviewRequest(url: prURL, viewerLastReviewedAt: reviewedAt)
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [prURL],
+            prsByURL: [:],
+            reviewRequestsByPRURL: [prURL: request],
+            prDataComplete: true
+        )
+        #expect(decisions.isEmpty)
+    }
+
+    @Test
+    func reviewWithNoViewerVerdictIgnored() {
+        // PR has reviews from other users, or only viewer COMMENTED reviews.
+        // `viewerLastReviewedAt` is nil because the parser already filters
+        // these out. Decision function should treat that as "not yet reviewed".
+        let reviewSession = makeSession(kind: .review, createdAt: Date().addingTimeInterval(-3600))
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let request = makeReviewRequest(url: prURL, viewerLastReviewedAt: nil)
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [prURL],
+            prsByURL: [:],
+            reviewRequestsByPRURL: [prURL: request],
+            prDataComplete: true
+        )
+        #expect(decisions.isEmpty)
+    }
+
+    @Test
+    func viewerReviewCompletesEvenUnderPartialFetch() {
+        // The viewer-submitted signal only needs the ReviewRequest payload,
+        // which is always live data. It must not be gated on prDataComplete
+        // (that gate exists for the MERGED/CLOSED rule, which has to guard
+        // against missing-PR-as-closed under partial fetches).
+        let reviewSession = makeSession(kind: .review, createdAt: Date().addingTimeInterval(-3600))
+        let prURL = "https://github.com/foo/bar/pull/9"
+        let request = makeReviewRequest(url: prURL, viewerLastReviewedAt: Date())
+        let decisions = IssueTracker.decideReviewCompletions(
+            reviewSessions: [reviewSession],
+            linksBySessionID: [reviewSession.id: [prLink(sessionID: reviewSession.id, url: prURL)]],
+            openReviewPRURLs: [prURL],
+            prsByURL: [:],
+            reviewRequestsByPRURL: [prURL: request],
+            prDataComplete: false
+        )
+        #expect(decisions == [
+            IssueTracker.CompletionDecision(sessionID: reviewSession.id, reason: "viewer submitted review")
+        ])
     }
 
     // MARK: - Auto-Cleanup


### PR DESCRIPTION
## Summary

Closes #290.

After `/refine` + re-request, the reviewer's Crow did **not** auto-launch a new review session. Two compounding gates both keyed on terminal PR state:

- `AppDelegate.enqueueReviewKickoff` skipped any request whose `reviewSessionID != nil`, and
- `decideReviewCompletions` only completed sessions on `MERGED` / `CLOSED`.

Result: the round-1 session lingered `.active` forever while the PR was still open, holding the kickoff gate closed.

Two signals now unblock the kickoff (both implemented — A is primary, B is a fallback that also handles force-push):

### A. Viewer-submitted review completes the session

- GraphQL `reviewPRs` block now selects `reviews(last:20) { author { login } submittedAt state }` + top-level `viewer { login }`.
- `parseReviewRequests` surfaces `viewerLastReviewedAt` (latest `APPROVED` / `CHANGES_REQUESTED` / `DISMISSED` timestamp authored by the viewer) on `ReviewRequest`.
- `decideReviewCompletions` completes any active review session whose viewer-verdict timestamp is later than `session.createdAt`.
- Next refresh sees `reviewSessionID == nil`, and the existing kickoff fires for round 2 naturally.

### B. Head-SHA advance — fallback re-kick

- `Session` persists `lastReviewedHeadSha` (set from `gh pr view --json …headRefOid` at session creation, decoded with a nil default for back-compat with existing `state.json`).
- The kickoff guard also fires when `request.headRefOid != session.lastReviewedHeadSha`. Catches force-push without an explicit re-request, and the race window where round-2 commits land before signal A is observed.
- For the B path, the stale session is auto-completed inline before the new kickoff so `reviewSessions` doesn't double up on the same PR.

### Idempotency

The in-flight auto-review dedupe set is now keyed on `(request.id, headRefOid)` so a stale entry from a completed-and-re-requested PR doesn't block a fresh kickoff. Previously it was keyed on `request.id` alone, which would have re-blocked round 2 even with the gate fix.

## Test plan

- [x] Four new `decideReviewCompletions` cases:
  - Viewer-submitted review after session start → completes.
  - Viewer-submitted review before session start → ignored (round-1 leftover).
  - No viewer verdict (only other-user or COMMENTED) → ignored.
  - Viewer-submitted review under partial fetch → still completes (rule 1 doesn't gate on `prDataComplete`).
- [x] `Session` back-compat decode test: legacy `state.json` without `lastReviewedHeadSha` decodes to nil.
- [x] All existing CrowCore + root tests pass (`swift test` + per-package).
- [ ] Manual E2E happy path: open PR → review session auto-launches → submit review → session flips to `.completed` on next 60s tick → author runs `/refine` + re-requests → new session auto-launches.
- [ ] Manual E2E force-push path: with an active review session, force-push without re-request → next refresh detects `headRefOid` mismatch and re-kicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)