### PR TITLE
fix: async per-terminal rehydration + review-kickoff yielding (#293)

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -95,7 +95,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let previous = reviewKickoffTail
         reviewKickoffTail = Task { @MainActor in
             await previous?.value
-            for url in urls {
+            // Yield between kickoffs so a burst of pending PRs spreads
+            // across run-loop turns and SwiftUI/AppKit can render between
+            // each `createReviewSession` (#293). The first iteration runs
+            // immediately so the single-PR case has no added latency.
+            for (i, url) in urls.enumerated() {
+                if i > 0 { await Task.yield() }
                 _ = await service.createReviewSession(prURL: url, selectAfterCreate: false)
             }
         }

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -124,41 +124,52 @@ final class SessionService {
         // launches; spec §12). If a .tmux row's re-registration fails (e.g.
         // tmux uninstalled), silently fall back to .ghostty so the user
         // can still use the app.
-        var rehydrationOverwrites: [SessionTerminal] = []
+        //
+        // Each per-terminal rehydration is dispatched as its own @MainActor
+        // task so the run loop can service AppKit/SwiftUI between them.
+        // Previously this loop ran synchronously and pinned the main actor
+        // for seconds on profiles with many persisted .tmux rows (each
+        // call to TmuxBackend.registerTerminal spawns a subprocess) — #293.
         for session in appState.sessions {
-            guard var terminals = appState.terminals[session.id] else { continue }
+            guard let terminals = appState.terminals[session.id] else { continue }
             let isManagerSession = session.id == AppState.managerSessionID
-            for i in terminals.indices {
-                let trackReadiness = !isManagerSession && terminals[i].isManaged
-                let updated = rehydrateTerminalSurface(terminals[i], trackReadiness: trackReadiness)
-                if updated.backend != terminals[i].backend || updated.tmuxBinding != terminals[i].tmuxBinding {
-                    rehydrationOverwrites.append(updated)
+            let sid = session.id
+            for original in terminals {
+                let trackReadiness = !isManagerSession && original.isManaged
+                Task { @MainActor in
+                    let updated = self.rehydrateTerminalSurface(original, trackReadiness: trackReadiness)
+                    self.applyRehydrationResult(sessionID: sid, original: original, updated: updated)
                 }
-                terminals[i] = updated
             }
-            appState.terminals[session.id] = terminals
         }
 
-        if var globals = appState.terminals[AppState.globalTerminalSessionID] {
-            for i in globals.indices {
-                let updated = rehydrateTerminalSurface(globals[i], trackReadiness: false)
-                if updated.backend != globals[i].backend || updated.tmuxBinding != globals[i].tmuxBinding {
-                    rehydrationOverwrites.append(updated)
+        if let globals = appState.terminals[AppState.globalTerminalSessionID] {
+            let sid = AppState.globalTerminalSessionID
+            for original in globals {
+                Task { @MainActor in
+                    let updated = self.rehydrateTerminalSurface(original, trackReadiness: false)
+                    self.applyRehydrationResult(sessionID: sid, original: original, updated: updated)
                 }
-                globals[i] = updated
             }
-            appState.terminals[AppState.globalTerminalSessionID] = globals
         }
+    }
 
-        // Persist any backend / windowIndex changes from re-hydration back
-        // to the store so a subsequent crash doesn't try to re-register
-        // terminals that are already on the fallback backend.
-        if !rehydrationOverwrites.isEmpty {
+    /// Commit the result of a per-terminal rehydration task back to
+    /// `appState.terminals`, locating the row by ID since the array may
+    /// have shifted while the task awaited. If the backend or tmuxBinding
+    /// changed (e.g. .tmux → .ghostty fallback), persist the updated row
+    /// so a subsequent crash doesn't re-attempt the failed backend.
+    @MainActor
+    private func applyRehydrationResult(sessionID: UUID, original: SessionTerminal, updated: SessionTerminal) {
+        if var terminals = appState.terminals[sessionID],
+           let idx = terminals.firstIndex(where: { $0.id == updated.id }) {
+            terminals[idx] = updated
+            appState.terminals[sessionID] = terminals
+        }
+        if updated.backend != original.backend || updated.tmuxBinding != original.tmuxBinding {
             store.mutate { data in
-                for updated in rehydrationOverwrites {
-                    if let i = data.terminals.firstIndex(where: { $0.id == updated.id }) {
-                        data.terminals[i] = updated
-                    }
+                if let i = data.terminals.firstIndex(where: { $0.id == updated.id }) {
+                    data.terminals[i] = updated
                 }
             }
         }


### PR DESCRIPTION
Closes #293

## Summary
- Dispatch each per-terminal rehydration in `SessionService.hydrateState` as its own `Task { @MainActor in }` so the main actor gets to service AppKit/SwiftUI between calls. Previously a profile with many persisted `.tmux` rows pinned the run loop for seconds at launch (each `TmuxBackend.registerTerminal` spawns a subprocess).
- Replace the batched `rehydrationOverwrites` accumulator with a per-terminal `applyRehydrationResult` helper that locates the row by ID and persists fallback backend changes individually through `store.mutate`.
- Keep `wireTerminalReadiness()` and the `terminalReadiness` / `autoLaunchTerminals` pre-seeding synchronous and before any task dispatch — readiness callbacks fired from inside `preInitialize` still need their slots ready.
- Add `await Task.yield()` between kickoffs in `AppDelegate.enqueueReviewKickoff` so a burst of pending PRs spreads across run-loop turns. The first iteration runs immediately so single-PR kickoffs have no added latency; the serial-tail discipline that fixed #266 stays intact.

## Test plan
- [ ] Launch the app on a profile with many persisted sessions/terminals — UI should respond within the first run-loop turn (no multi-second hang); restored terminals still come up and auto-launch `claude --continue`.
- [ ] With `CROW_TMUX_BACKEND` unset on a profile that has persisted `.tmux` rows, confirm fallback to `.ghostty` rendering and the persisted row is left alone (existing semantics preserved).
- [ ] Trigger an auto-review refresh with ≥3 pending PRs (or batch Start Review on ≥3 PRs) — sidebar populates one row at a time and the rest of the UI stays responsive while the queue drains.
- [ ] Single-PR "Start Review" click still creates the session promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)