### PR TITLE
fix: run gh pr merge from $TMPDIR to dodge worktree lock

### DIFF
--- a/Sources/Crow/App/AutoRespondCoordinator.swift
+++ b/Sources/Crow/App/AutoRespondCoordinator.swift
@@ -193,7 +193,7 @@ enum QuickActionPrompts {
             if provider == .gitlab {
                 mergeHint = "Run `glab mr view \(prURL)` to verify the MR is in the expected state, then `glab mr merge \(prURL)` to merge. If the project uses a different merge strategy or extra steps, adjust accordingly."
             } else {
-                mergeHint = "Run `\(cli) pr view \(prURL)` to verify the PR is in the expected state, then `\(cli) pr merge \(prURL) --squash --delete-branch` to merge. If the repo uses a different merge strategy, adjust accordingly."
+                mergeHint = "Run `\(cli) pr view \(prURL)` to verify the PR is in the expected state, then `cd \"$TMPDIR\" && \(cli) pr merge \(prURL) --squash --delete-branch` to merge. The `cd` keeps `gh`'s post-merge git cleanup (which runs in the CWD) from tripping when `main` is checked out in another worktree. If the repo uses a different merge strategy, adjust accordingly."
             }
             return "Merge \(prRef) (\(prURL)). \(mergeHint)\n"
         }

--- a/Tests/CrowTests/QuickActionPromptsTests.swift
+++ b/Tests/CrowTests/QuickActionPromptsTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+@Suite("QuickActionPrompts.mergePR")
+struct QuickActionPromptsTests {
+
+    @Test func githubMergeHintRunsFromTmpdirToAvoidWorktreeConflict() {
+        let prompt = QuickActionPrompts.build(
+            action: .mergePR,
+            provider: .github,
+            prURL: "https://github.com/radiusmethod/crow/pull/123",
+            prNumber: 123
+        )
+        #expect(prompt.contains("cd \"$TMPDIR\" && gh pr merge https://github.com/radiusmethod/crow/pull/123 --squash --delete-branch"))
+        #expect(prompt.contains("worktree"))
+        #expect(prompt.hasSuffix("\n"))
+    }
+
+    @Test func gitlabMergeHintIsUnaffected() {
+        let prompt = QuickActionPrompts.build(
+            action: .mergePR,
+            provider: .gitlab,
+            prURL: "https://gitlab.example.com/org/repo/-/merge_requests/45",
+            prNumber: 45
+        )
+        #expect(prompt.contains("glab mr merge https://gitlab.example.com/org/repo/-/merge_requests/45"))
+        #expect(!prompt.contains("$TMPDIR"))
+        #expect(prompt.hasSuffix("\n"))
+    }
+}


### PR DESCRIPTION
## Summary

- The **Merge PR** quick action injects a single-line prompt into the session's managed Claude Code terminal telling Claude what command to run. The hint previously suggested running `gh pr merge <url> --squash --delete-branch` from the worktree CWD.
- `gh pr merge` does the merge server-side but then shells out to local `git` to update/delete refs. With `--delete-branch` (and the `--admin` retry path), git refuses with `fatal: 'main' is already used by worktree at ...` whenever the main repo clone holds `main` checked out at a sibling worktree.
- This patch prefixes the suggested command with `cd "$TMPDIR" &&` so the local git steps run outside any worktree. GitLab branch is unaffected (no analogous failure mode).

Closes #296

## Files

- `Sources/Crow/App/AutoRespondCoordinator.swift` — updated GitHub branch of `QuickActionPrompts.build` → `.mergePR`.
- `Tests/CrowTests/QuickActionPromptsTests.swift` — new tests pinning both providers' merge-hint shapes.

## Test plan

- [ ] CI: `swift build` + `swift test --filter QuickActionPromptsTests` pass (local build was blocked because this worktree doesn't carry the `Frameworks/GhosttyKit.xcframework` binary needed by `CrowTerminal`; syntax-parsed both changed files with `swiftc -parse`).
- [ ] Manual: in a setup where `main` is checked out in the main repo clone and Crow is running against a feature worktree, click **Merge PR** on a ready PR — the injected prompt should now include `cd "$TMPDIR" &&` before `gh pr merge`, and Claude's run should complete without the worktree error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)