### PR TITLE
feat: crow:merge label auto-merges Crow-authored PRs (closes #299)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -21,6 +21,11 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// that overrides Claude Code's `attribution.commit` to include the crow
     /// session UUID alongside the standard `Co-Authored-By: Claude` trailer.
     public var attributionTrailers: Bool
+    /// When true, the IssueTracker watches for PRs labeled `crow:merge`
+    /// and enables GitHub native auto-merge (squash) — but only on PRs
+    /// authored by Crow (Crow-Session trailer matching a known session).
+    /// Opt-in: defaults to false (CROW-299).
+    public var autoMergeWatcherEnabled: Bool
     public var cleanup: CleanupConfig
 
     public init(
@@ -34,6 +39,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoRespond: AutoRespondSettings = AutoRespondSettings(),
         experimentalTmuxBackend: Bool = false,
         attributionTrailers: Bool = true,
+        autoMergeWatcherEnabled: Bool = false,
         cleanup: CleanupConfig = CleanupConfig()
     ) {
         self.workspaces = workspaces
@@ -46,6 +52,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.autoRespond = autoRespond
         self.experimentalTmuxBackend = experimentalTmuxBackend
         self.attributionTrailers = attributionTrailers
+        self.autoMergeWatcherEnabled = autoMergeWatcherEnabled
         self.cleanup = cleanup
     }
 
@@ -61,11 +68,12 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoRespond = try container.decodeIfPresent(AutoRespondSettings.self, forKey: .autoRespond) ?? AutoRespondSettings()
         experimentalTmuxBackend = try container.decodeIfPresent(Bool.self, forKey: .experimentalTmuxBackend) ?? false
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
+        autoMergeWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoMergeWatcherEnabled) ?? false
         cleanup = try container.decodeIfPresent(CleanupConfig.self, forKey: .cleanup) ?? CleanupConfig()
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, experimentalTmuxBackend, attributionTrailers, cleanup
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, experimentalTmuxBackend, attributionTrailers, autoMergeWatcherEnabled, cleanup
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -23,6 +23,10 @@ public struct Session: Identifiable, Codable, Sendable {
     // observed. Nil for non-review sessions and for legacy persisted
     // sessions predating this field (CROW-290).
     public var lastReviewedHeadSha: String?
+    // Timestamp at which Crow enabled GitHub native auto-merge on the
+    // linked PR (CROW-299). Non-nil means the one-shot enable has already
+    // run; the auto-merge watcher skips this session on subsequent polls.
+    public var autoMergeEnabledAt: Date?
 
     public init(
         id: UUID = UUID(),
@@ -36,7 +40,8 @@ public struct Session: Identifiable, Codable, Sendable {
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
         reviewPromptDispatched: Bool = false,
-        lastReviewedHeadSha: String? = nil
+        lastReviewedHeadSha: String? = nil,
+        autoMergeEnabledAt: Date? = nil
     ) {
         self.id = id
         self.name = name
@@ -50,6 +55,7 @@ public struct Session: Identifiable, Codable, Sendable {
         self.updatedAt = updatedAt
         self.reviewPromptDispatched = reviewPromptDispatched
         self.lastReviewedHeadSha = lastReviewedHeadSha
+        self.autoMergeEnabledAt = autoMergeEnabledAt
     }
 
     // Backward-compatible decoding: default `kind` to `.work` when missing
@@ -70,5 +76,6 @@ public struct Session: Identifiable, Codable, Sendable {
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         reviewPromptDispatched = try container.decodeIfPresent(Bool.self, forKey: .reviewPromptDispatched) ?? true
         lastReviewedHeadSha = try container.decodeIfPresent(String.self, forKey: .lastReviewedHeadSha)
+        autoMergeEnabledAt = try container.decodeIfPresent(Date.self, forKey: .autoMergeEnabledAt)
     }
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -46,8 +46,31 @@ import Testing
     #expect(config.managerAutoPermissionMode == true)
     #expect(config.experimentalTmuxBackend == false)
     #expect(config.attributionTrailers == true)
+    #expect(config.autoMergeWatcherEnabled == false)
     #expect(config.cleanup.enabled == false)
     #expect(config.cleanup.retentionHours == 24)
+}
+
+@Test func appConfigAutoMergeWatcherEnabledRoundTrip() throws {
+    var config = AppConfig()
+    config.autoMergeWatcherEnabled = true
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.autoMergeWatcherEnabled == true)
+
+    config.autoMergeWatcherEnabled = false
+    let data2 = try JSONEncoder().encode(config)
+    let decoded2 = try JSONDecoder().decode(AppConfig.self, from: data2)
+    #expect(decoded2.autoMergeWatcherEnabled == false)
+}
+
+@Test func appConfigAutoMergeWatcherDefaultsOffWhenKeyMissing() throws {
+    // Legacy configs without the key must default to off — the watcher is
+    // opt-in so users explicitly enable Crow to act on the crow:merge label.
+    let json = #"{"workspaces":[]}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.autoMergeWatcherEnabled == false)
 }
 
 @Test func appConfigCleanupRoundTrip() throws {

--- a/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
@@ -10,6 +10,7 @@ public struct AutomationSettingsView: View {
     @Binding var managerAutoPermissionMode: Bool
     @Binding var autoRespond: AutoRespondSettings
     @Binding var attributionTrailers: Bool
+    @Binding var autoMergeWatcherEnabled: Bool
     var onSave: (() -> Void)?
 
     @State private var excludeReviewReposText: String
@@ -22,6 +23,7 @@ public struct AutomationSettingsView: View {
         managerAutoPermissionMode: Binding<Bool>,
         autoRespond: Binding<AutoRespondSettings>,
         attributionTrailers: Binding<Bool>,
+        autoMergeWatcherEnabled: Binding<Bool>,
         onSave: (() -> Void)? = nil
     ) {
         self._defaults = defaults
@@ -29,6 +31,7 @@ public struct AutomationSettingsView: View {
         self._managerAutoPermissionMode = managerAutoPermissionMode
         self._autoRespond = autoRespond
         self._attributionTrailers = attributionTrailers
+        self._autoMergeWatcherEnabled = autoMergeWatcherEnabled
         self.onSave = onSave
         self._excludeReviewReposText = State(initialValue: defaults.wrappedValue.excludeReviewRepos.joined(separator: ", "))
         self._ignoreReviewLabelsText = State(initialValue: defaults.wrappedValue.ignoreReviewLabels.joined(separator: ", "))
@@ -103,6 +106,14 @@ public struct AutomationSettingsView: View {
                 Toggle("Add Crow-Session trailer to commits", isOn: $attributionTrailers)
                     .onChange(of: attributionTrailers) { _, _ in onSave?() }
                 Text("Writes a per-worktree .claude/settings.local.json that overrides Claude Code's commit attribution to include a Crow-Session: <uuid> trailer alongside Co-Authored-By: Claude. Applies to new worktrees only.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Auto-merge") {
+                Toggle("Enable crow:merge auto-merge for Crow-authored PRs", isOn: $autoMergeWatcherEnabled)
+                    .onChange(of: autoMergeWatcherEnabled) { _, _ in onSave?() }
+                Text("When a PR linked to a Crow session carries the crow:merge label, Crow enables GitHub native auto-merge with squash + delete branch. Only PRs whose commits include a Crow-Session trailer matching a known session are eligible. GitHub holds the merge until required reviews and checks pass. Off by default.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -44,6 +44,7 @@ public struct SettingsView: View {
                 managerAutoPermissionMode: $config.managerAutoPermissionMode,
                 autoRespond: $config.autoRespond,
                 attributionTrailers: $config.attributionTrailers,
+                autoMergeWatcherEnabled: $config.autoMergeWatcherEnabled,
                 onSave: { save() }
             )
                 .tabItem { Label("Automation", systemImage: "bolt.fill") }

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Crow can drive a ticket from assignment to merged with minimal manual steps. Tog
 - **Auto-suggest opening a PR** if a session completes with no PR linked
 - **Auto-start review sessions** for opted-in workspaces when a PR becomes reviewable
 - **Auto-respond** to changes-requested reviews and failed CI checks (off by default)
+- **Auto-merge** Crow-authored PRs labeled `crow:merge` via `gh pr merge --auto --squash` (off by default; only acts on PRs whose commits carry a `Crow-Session:` trailer matching a known session). Crow lazily creates the `crow:merge` label on first observation; to pre-seed it manually: `gh label create crow:merge --color 0E8A16 --description "Crow: enable auto-merge once mergeable"`
 
 ### Review Board
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -526,6 +526,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 print("[IssueTracker] auto-cleanup delete failed for \(id): \(error)")
             }
         }
+        tracker.autoMergeWatcherEnabledProvider = { [weak self] in
+            self?.appConfig?.autoMergeWatcherEnabled ?? false
+        }
+        tracker.onAutoMergeEnabled = { [weak self] sessionID, prURL, number in
+            self?.notificationManager?.notifyAutoMergeEnabled(prURL: prURL, number: number, sessionID: sessionID)
+        }
         tracker.start()
         self.issueTracker = tracker
 

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -71,8 +71,9 @@ final class IssueTracker {
     /// when the PR is Crow-authored (Crow-Session trailer matches a known
     /// session). One-shot per PR: persisted via `Session.autoMergeEnabledAt`,
     /// and gated in-process by `autoMergeInFlight` between dispatch and
-    /// persisted update (CROW-299).
-    static let autoMergeLabel = "crow:merge"
+    /// persisted update (CROW-299). `nonisolated` so the pure
+    /// `shouldAttemptAutoMerge` helper can read it without main-actor hops.
+    nonisolated static let autoMergeLabel = "crow:merge"
 
     /// PR URLs we've already started an auto-merge enable attempt for.
     /// Cleared on failure (so the next poll retries) and effectively frozen
@@ -1742,7 +1743,9 @@ final class IssueTracker {
     /// Pattern matching a Crow-Session commit trailer line. Anchored to
     /// line start (multiline) so trailing footers are required, not just
     /// anywhere in the body. The captured group is the UUID string.
-    private static let crowSessionTrailerPattern = #"^Crow-Session:\s*([0-9A-Fa-f-]{36})\s*$"#
+    /// `nonisolated` because it's consumed from the `nonisolated static`
+    /// extraction helper (which is in turn called by unit tests).
+    nonisolated private static let crowSessionTrailerPattern = #"^Crow-Session:\s*([0-9A-Fa-f-]{36})\s*$"#
 
     /// Extract every Crow-Session UUID from a commit message. Returns an
     /// empty array when no trailers match. Pure for testability. Compiles

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -40,6 +40,19 @@ final class IssueTracker {
     /// Wired in AppDelegate to call `appState.onDeleteSession`.
     var onDeleteSession: ((UUID) async -> Void)?
 
+    /// Reads the latest `AppConfig.autoMergeWatcherEnabled` snapshot on
+    /// every poll. Closure rather than direct AppConfig binding so toggling
+    /// the setting in Settings takes effect on the next refresh without
+    /// re-initializing the tracker. Defaults to a closure that returns
+    /// `false` so the watcher is inert until AppDelegate wires it (CROW-299).
+    var autoMergeWatcherEnabledProvider: () -> Bool = { false }
+
+    /// Fires after Crow has successfully enabled GitHub native auto-merge
+    /// on a PR. Wired in AppDelegate to post the user-facing notification.
+    /// (The durable audit-log line is `NSLog`'d at the call site so it
+    /// lands in Console regardless of notification settings.)
+    var onAutoMergeEnabled: ((UUID, String, Int) -> Void)?
+
     /// Previously seen review request IDs for delta detection.
     private var previousReviewRequestIDs: Set<String> = []
     private var isFirstFetch = true
@@ -53,6 +66,19 @@ final class IssueTracker {
     /// assigned issue. Removed after a successful dispatch (best-effort) so
     /// the trigger is one-shot and visible across machines.
     static let autoCreateLabel = "crow:auto"
+
+    /// Label that opts a PR into GitHub native auto-merge. Crow only acts
+    /// when the PR is Crow-authored (Crow-Session trailer matches a known
+    /// session). One-shot per PR: persisted via `Session.autoMergeEnabledAt`,
+    /// and gated in-process by `autoMergeInFlight` between dispatch and
+    /// persisted update (CROW-299).
+    static let autoMergeLabel = "crow:merge"
+
+    /// PR URLs we've already started an auto-merge enable attempt for.
+    /// Cleared on failure (so the next poll retries) and effectively frozen
+    /// on success once `Session.autoMergeEnabledAt` is persisted, which
+    /// the gating guard checks first.
+    private var autoMergeInFlight: Set<String> = []
 
     /// Last observed `PRStatus` per session, used to compute transitions.
     /// Populated lazily on first observation; that first poll never fires
@@ -460,6 +486,7 @@ final class IssueTracker {
         let headRefOid: String     // Head commit SHA (empty if unavailable)
         let baseRefName: String
         let repoNameWithOwner: String
+        let labels: [LabelInfo]
         let linkedIssueReferences: [LinkedIssue]
         let checksState: String    // SUCCESS / FAILURE / PENDING / EXPECTED / ERROR / ""
         let failedCheckNames: [String]
@@ -504,6 +531,7 @@ final class IssueTracker {
             headRefOid: winner.headRefOid.isEmpty ? loser.headRefOid : winner.headRefOid,
             baseRefName: winner.baseRefName.isEmpty ? loser.baseRefName : winner.baseRefName,
             repoNameWithOwner: winner.repoNameWithOwner.isEmpty ? loser.repoNameWithOwner : winner.repoNameWithOwner,
+            labels: winner.labels.isEmpty ? loser.labels : winner.labels,
             linkedIssueReferences: winner.linkedIssueReferences.isEmpty ? loser.linkedIssueReferences : winner.linkedIssueReferences,
             checksState: winner.checksState.isEmpty ? loser.checksState : winner.checksState,
             failedCheckNames: winner.failedCheckNames.isEmpty ? loser.failedCheckNames : winner.failedCheckNames,
@@ -550,6 +578,7 @@ final class IssueTracker {
           nodes {
             number url state mergeable reviewDecision isDraft headRefName headRefOid baseRefName
             repository { nameWithOwner }
+            labels(first: 20) { nodes { name color } }
             closingIssuesReferences(first: 5) { nodes { number repository { nameWithOwner } } }
             statusCheckRollup {
               state
@@ -862,6 +891,7 @@ final class IssueTracker {
             headRefOid: headRefOid,
             baseRefName: baseRefName,
             repoNameWithOwner: fallbackSlug,
+            labels: [],
             linkedIssueReferences: [],
             checksState: "",
             failedCheckNames: [],
@@ -941,6 +971,7 @@ final class IssueTracker {
                 headRefOid: headRefOid,
                 baseRefName: baseRefName,
                 repoNameWithOwner: repoName,
+                labels: [],
                 linkedIssueReferences: [],
                 checksState: "",
                 failedCheckNames: [],
@@ -1061,6 +1092,13 @@ final class IssueTracker {
             let baseRefName = node["baseRefName"] as? String ?? ""
             let repoName = (node["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
 
+            let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+                .compactMap { labelNode -> LabelInfo? in
+                    guard let name = labelNode["name"] as? String else { return nil }
+                    let color = labelNode["color"] as? String
+                    return LabelInfo(name: name, color: color)
+                } ?? []
+
             let linkedNodes = (node["closingIssuesReferences"] as? [String: Any])?["nodes"] as? [[String: Any]] ?? []
             let linkedRefs: [ViewerPR.LinkedIssue] = linkedNodes.compactMap { ref in
                 guard let n = ref["number"] as? Int else { return nil }
@@ -1096,6 +1134,7 @@ final class IssueTracker {
                 headRefOid: headRefOid,
                 baseRefName: baseRefName,
                 repoNameWithOwner: repoName,
+                labels: labels,
                 linkedIssueReferences: linkedRefs,
                 checksState: checksState,
                 failedCheckNames: failedCheckNames,
@@ -1694,6 +1733,163 @@ final class IssueTracker {
         if !transitions.isEmpty {
             onPRStatusTransitions?(transitions)
         }
+
+        applyAutoMerge(viewerPRs: viewerPRs)
+    }
+
+    // MARK: - Auto-Merge Watcher (CROW-299)
+
+    /// Pattern matching a Crow-Session commit trailer line. Anchored to
+    /// line start (multiline) so trailing footers are required, not just
+    /// anywhere in the body. The captured group is the UUID string.
+    private static let crowSessionTrailerPattern = #"^Crow-Session:\s*([0-9A-Fa-f-]{36})\s*$"#
+
+    /// Extract every Crow-Session UUID from a commit message. Returns an
+    /// empty array when no trailers match. Pure for testability. Compiles
+    /// the regex per call — NSRegularExpression isn't trivially Sendable
+    /// across `nonisolated` boundaries in Swift 6, and the cost is
+    /// negligible (only called on PRs entering the auto-merge flow).
+    nonisolated static func extractCrowSessionUUIDs(from message: String) -> [UUID] {
+        guard let regex = try? NSRegularExpression(
+            pattern: crowSessionTrailerPattern,
+            options: [.anchorsMatchLines]
+        ) else { return [] }
+        let range = NSRange(message.startIndex..., in: message)
+        var result: [UUID] = []
+        regex.enumerateMatches(in: message, range: range) { match, _, _ in
+            guard let m = match,
+                  let uuidRange = Range(m.range(at: 1), in: message),
+                  let uuid = UUID(uuidString: String(message[uuidRange])) else { return }
+            result.append(uuid)
+        }
+        return result
+    }
+
+    /// Decide whether `pr` (paired with `session`) is a candidate for
+    /// `gh pr merge --auto`. Pure so unit tests can exercise every guard
+    /// without spinning up an `IssueTracker`. Returns `false` when:
+    /// - the session has already had auto-merge enabled (one-shot guard)
+    /// - the PR is not OPEN, or is a draft
+    /// - the `crow:merge` label is absent
+    /// - the PR is in CONFLICTING or CHANGES_REQUESTED state
+    nonisolated static func shouldAttemptAutoMerge(pr: ViewerPR, session: Session) -> Bool {
+        guard session.autoMergeEnabledAt == nil else { return false }
+        guard pr.state == "OPEN" else { return false }
+        guard !pr.isDraft else { return false }
+        guard pr.labels.contains(where: { $0.name.caseInsensitiveCompare(autoMergeLabel) == .orderedSame }) else { return false }
+        guard pr.mergeable != "CONFLICTING" else { return false }
+        guard pr.reviewDecision != "CHANGES_REQUESTED" else { return false }
+        return true
+    }
+
+    /// Return true when at least one of the supplied commit messages
+    /// carries a `Crow-Session: <uuid>` trailer whose UUID matches a
+    /// session in `knownSessionIDs`. Trailer-with-unknown-session is
+    /// treated as NOT Crow-authored (acceptance criterion #4).
+    nonisolated static func crowAuthored(commitMessages: [String], knownSessionIDs: Set<UUID>) -> Bool {
+        for message in commitMessages {
+            for uuid in extractCrowSessionUUIDs(from: message) {
+                if knownSessionIDs.contains(uuid) { return true }
+            }
+        }
+        return false
+    }
+
+    /// Per-refresh entry point. Picks candidate (session, PR) pairs and
+    /// kicks off the async enable flow once each. No-op when the global
+    /// `autoMergeWatcherEnabled` setting is off.
+    private func applyAutoMerge(viewerPRs: [ViewerPR]) {
+        guard autoMergeWatcherEnabledProvider() else { return }
+        guard !viewerPRs.isEmpty else { return }
+        let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
+
+        for session in appState.sessions where session.id != AppState.managerSessionID {
+            guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
+            guard !autoMergeInFlight.contains(prLink.url) else { continue }
+            guard let pr = byURL[prLink.url] else { continue }
+            guard Self.shouldAttemptAutoMerge(pr: pr, session: session) else { continue }
+
+            autoMergeInFlight.insert(prLink.url)
+            let capturedSession = session
+            Task { await self.attemptEnableAutoMerge(session: capturedSession, pr: pr) }
+        }
+    }
+
+    /// Verify Crow authorship, lazily ensure the label exists, then enable
+    /// auto-merge with squash + delete branch. Idempotent: success persists
+    /// `Session.autoMergeEnabledAt`; failure clears the in-flight marker so
+    /// the next poll retries.
+    private func attemptEnableAutoMerge(session: Session, pr: ViewerPR) async {
+        guard await prHasCrowAuthoredCommit(pr: pr) else {
+            NSLog("[Crow] crow:merge ignored on %@ — no Crow-Session trailer matching a known session",
+                  pr.url as NSString)
+            // Leave the URL in autoMergeInFlight so we don't re-fetch
+            // commits every minute for a permanently-ineligible PR. The
+            // set is in-memory only — restart will re-check, which is
+            // fine for what's a fairly rare label-misuse case.
+            return
+        }
+
+        await ensureMergeLabel(repo: pr.repoNameWithOwner)
+
+        let cmd = #"cd "$TMPDIR" && gh pr merge \#(pr.url) --auto --squash --delete-branch"#
+        let result = await shellWithStatus(args: ["sh", "-c", cmd])
+        if result.exitCode == 0 {
+            let now = Date()
+            if let idx = appState.sessions.firstIndex(where: { $0.id == session.id }) {
+                appState.sessions[idx].autoMergeEnabledAt = now
+                appState.sessions[idx].updatedAt = now
+            }
+            JSONStore().mutate { data in
+                if let idx = data.sessions.firstIndex(where: { $0.id == session.id }) {
+                    data.sessions[idx].autoMergeEnabledAt = now
+                    data.sessions[idx].updatedAt = now
+                }
+            }
+            NSLog("[Crow] Auto-merge enabled on %@ (session %@, squash)",
+                  pr.url as NSString, session.id.uuidString as NSString)
+            onAutoMergeEnabled?(session.id, pr.url, pr.number)
+        } else {
+            autoMergeInFlight.remove(pr.url)
+            NSLog("[Crow] gh pr merge --auto failed for %@ (exit %d): %@",
+                  pr.url as NSString, result.exitCode, String(result.stderr.prefix(300)) as NSString)
+        }
+    }
+
+    /// Fetch the PR's commits and return true iff at least one carries a
+    /// `Crow-Session: <uuid>` trailer matching a known session. Uses the
+    /// REST `/repos/.../pulls/{N}/commits` endpoint (page-limited; the
+    /// default 30-commit window is plenty for any Crow PR).
+    private func prHasCrowAuthoredCommit(pr: ViewerPR) async -> Bool {
+        let endpoint = "/repos/\(pr.repoNameWithOwner)/pulls/\(pr.number)/commits"
+        let result = await shellWithStatus(args: ["gh", "api", endpoint])
+        guard result.exitCode == 0 else {
+            NSLog("[Crow] gh api %@ failed (exit %d): %@",
+                  endpoint as NSString, result.exitCode,
+                  String(result.stderr.prefix(300)) as NSString)
+            return false
+        }
+        guard let data = result.stdout.data(using: .utf8),
+              let nodes = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return false
+        }
+        let messages: [String] = nodes.compactMap { ($0["commit"] as? [String: Any])?["message"] as? String }
+        let knownIDs = Set(appState.sessions.map(\.id))
+        return Self.crowAuthored(commitMessages: messages, knownSessionIDs: knownIDs)
+    }
+
+    /// Best-effort: ensure the `crow:merge` label exists in the repo so
+    /// repo owners don't need to pre-create it. `gh label create` fails
+    /// loudly when the label already exists; the failure is harmless and
+    /// not surfaced.
+    private func ensureMergeLabel(repo: String) async {
+        guard !repo.isEmpty else { return }
+        _ = await shellWithStatus(args: [
+            "gh", "label", "create", Self.autoMergeLabel,
+            "--repo", repo,
+            "--color", "0E8A16",
+            "--description", "Crow: enable auto-merge once mergeable"
+        ])
     }
 
     private func buildPRStatus(from pr: ViewerPR) -> PRStatus {

--- a/Sources/Crow/App/NotificationManager.swift
+++ b/Sources/Crow/App/NotificationManager.swift
@@ -140,6 +140,25 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         )
     }
 
+    // MARK: - Auto-Merge Notifications
+
+    /// Notify the user that Crow has enabled GitHub native auto-merge on a
+    /// Crow-authored PR carrying the `crow:merge` label (CROW-299). One-shot
+    /// per PR — the audit-log line in `IssueTracker` is the durable record;
+    /// this is the human-facing banner.
+    func notifyAutoMergeEnabled(prURL: String, number: Int, sessionID: UUID) {
+        guard !settings.globalMute else { return }
+        guard settings.systemNotificationsEnabled else { return }
+
+        let sessionName = appState.sessions.first(where: { $0.id == sessionID })?.name ?? "session"
+        postSystemNotification(
+            title: "Auto-merge enabled \u{2014} \(sessionName)",
+            body: "PR #\(number) will merge once required reviews and checks pass.",
+            sessionID: sessionID,
+            eventName: "AutoMergeEnabled"
+        )
+    }
+
     // MARK: - PR Status Transition Notifications
 
     /// Notify the user about a detected PR status transition (changes

--- a/Tests/CrowTests/IssueTrackerAutoMergeTests.swift
+++ b/Tests/CrowTests/IssueTrackerAutoMergeTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+@Suite("IssueTracker auto-merge watcher (crow:merge label)")
+struct IssueTrackerAutoMergeTests {
+
+    // MARK: - Fixtures
+
+    private static let crowMergeLabel = LabelInfo(name: "crow:merge", color: "0E8A16")
+    private static let otherLabel = LabelInfo(name: "documentation", color: "ffffff")
+
+    private func makePR(
+        url: String = "https://github.com/radiusmethod/crow/pull/42",
+        number: Int = 42,
+        state: String = "OPEN",
+        mergeable: String = "MERGEABLE",
+        reviewDecision: String = "APPROVED",
+        isDraft: Bool = false,
+        labels: [LabelInfo] = [crowMergeLabel],
+        repo: String = "radiusmethod/crow"
+    ) -> IssueTracker.ViewerPR {
+        IssueTracker.ViewerPR(
+            number: number,
+            url: url,
+            state: state,
+            mergeable: mergeable,
+            reviewDecision: reviewDecision,
+            isDraft: isDraft,
+            headRefName: "feature/x",
+            headRefOid: "abc1234",
+            baseRefName: "main",
+            repoNameWithOwner: repo,
+            labels: labels,
+            linkedIssueReferences: [],
+            checksState: "SUCCESS",
+            failedCheckNames: [],
+            latestReviewStates: ["APPROVED"]
+        )
+    }
+
+    private func makeSession(autoMergeEnabledAt: Date? = nil) -> Session {
+        Session(
+            id: UUID(),
+            name: "session",
+            autoMergeEnabledAt: autoMergeEnabledAt
+        )
+    }
+
+    // MARK: - shouldAttemptAutoMerge guards
+
+    @Test func acceptsHealthyLabeledPR() {
+        let pr = makePR()
+        let session = makeSession()
+        #expect(IssueTracker.shouldAttemptAutoMerge(pr: pr, session: session))
+    }
+
+    @Test func ignoresPRWithoutCrowMergeLabel() {
+        let pr = makePR(labels: [Self.otherLabel])
+        let session = makeSession()
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: session))
+    }
+
+    @Test func ignoresAlreadyEnabledSession() {
+        let pr = makePR()
+        let session = makeSession(autoMergeEnabledAt: Date())
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: session))
+    }
+
+    @Test func ignoresConflictingPR() {
+        let pr = makePR(mergeable: "CONFLICTING")
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
+    @Test func ignoresDraftPR() {
+        let pr = makePR(isDraft: true)
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
+    @Test func ignoresChangesRequestedPR() {
+        let pr = makePR(reviewDecision: "CHANGES_REQUESTED")
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
+    @Test func ignoresClosedPR() {
+        let pr = makePR(state: "CLOSED")
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
+    @Test func ignoresMergedPR() {
+        let pr = makePR(state: "MERGED")
+        #expect(!IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
+    @Test func acceptsCaseInsensitiveLabelMatch() {
+        // GitHub treats labels as case-insensitive on lookup. Crow does too,
+        // so a stored label of "Crow:Merge" still triggers the watcher.
+        let pr = makePR(labels: [LabelInfo(name: "Crow:Merge", color: nil)])
+        #expect(IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
+    @Test func acceptsPRWithReviewDecisionNotYetSet() {
+        // Repos without required reviewers report `reviewDecision: ""` even
+        // when the PR is mergeable. GitHub will still honor --auto for them.
+        let pr = makePR(reviewDecision: "")
+        #expect(IssueTracker.shouldAttemptAutoMerge(pr: pr, session: makeSession()))
+    }
+
+    // MARK: - Trailer parsing
+
+    @Test func extractsSingleTrailer() {
+        let uuid = UUID()
+        let msg = """
+        feat: add the thing
+
+        Some body text.
+
+        Crow-Session: \(uuid.uuidString)
+        Co-Authored-By: Claude <noreply@anthropic.com>
+        """
+        let result = IssueTracker.extractCrowSessionUUIDs(from: msg)
+        #expect(result == [uuid])
+    }
+
+    @Test func extractsMultipleTrailers() {
+        let a = UUID()
+        let b = UUID()
+        let msg = """
+        squash merge of two commits
+
+        Crow-Session: \(a.uuidString)
+        Crow-Session: \(b.uuidString)
+        """
+        let result = IssueTracker.extractCrowSessionUUIDs(from: msg)
+        #expect(Set(result) == Set([a, b]))
+    }
+
+    @Test func ignoresMalformedUUID() {
+        let msg = "subject\n\nCrow-Session: not-a-real-uuid\n"
+        #expect(IssueTracker.extractCrowSessionUUIDs(from: msg).isEmpty)
+    }
+
+    @Test func requiresLineStartAnchor() {
+        // Mid-line "Crow-Session:" doesn't count — trailers are line-anchored
+        // (matches `git interpret-trailers`).
+        let uuid = UUID()
+        let msg = "subject ending with prefix Crow-Session: \(uuid.uuidString) inline"
+        #expect(IssueTracker.extractCrowSessionUUIDs(from: msg).isEmpty)
+    }
+
+    @Test func returnsEmptyWhenNoTrailerPresent() {
+        let msg = "subject\n\nbody with no trailers\n\nCo-Authored-By: Claude\n"
+        #expect(IssueTracker.extractCrowSessionUUIDs(from: msg).isEmpty)
+    }
+
+    // MARK: - crowAuthored
+
+    @Test func crowAuthoredTrueWhenTrailerMatchesKnownSession() {
+        let known = UUID()
+        let messages = [
+            "fix: typo\n",
+            "feat: add\n\nCrow-Session: \(known.uuidString)\n"
+        ]
+        #expect(IssueTracker.crowAuthored(commitMessages: messages, knownSessionIDs: [known]))
+    }
+
+    @Test func crowAuthoredFalseWhenTrailerPointsToUnknownSession() {
+        // Acceptance criterion #4: trailer-with-unknown-session must be
+        // treated as NOT Crow-authored. Prevents someone copy-pasting the
+        // trailer convention into a hand-written commit from triggering us.
+        let known = UUID()
+        let other = UUID()
+        let messages = ["feat: thing\n\nCrow-Session: \(other.uuidString)\n"]
+        #expect(!IssueTracker.crowAuthored(commitMessages: messages, knownSessionIDs: [known]))
+    }
+
+    @Test func crowAuthoredFalseWhenNoTrailers() {
+        // Acceptance criterion #3: a labeled PR with no Crow trailers
+        // (hand-written commits) must be ignored entirely.
+        let messages = ["fix: external contribution\n\nCo-Authored-By: Someone\n"]
+        #expect(!IssueTracker.crowAuthored(commitMessages: messages, knownSessionIDs: [UUID()]))
+    }
+
+    @Test func crowAuthoredFalseOnEmptyCommitList() {
+        #expect(!IssueTracker.crowAuthored(commitMessages: [], knownSessionIDs: [UUID()]))
+    }
+
+    @Test func crowAuthoredTrueWhenAnyCommitMatches() {
+        let known = UUID()
+        let other = UUID()
+        let messages = [
+            "first commit\n\nCrow-Session: \(other.uuidString)\n",     // unknown — ignored
+            "later commit\n\nCrow-Session: \(known.uuidString)\n"      // known — wins
+        ]
+        #expect(IssueTracker.crowAuthored(commitMessages: messages, knownSessionIDs: [known]))
+    }
+}

--- a/Tests/CrowTests/IssueTrackerCompletionTests.swift
+++ b/Tests/CrowTests/IssueTrackerCompletionTests.swift
@@ -69,6 +69,7 @@ struct IssueTrackerCompletionTests {
             headRefOid: "",
             baseRefName: "",
             repoNameWithOwner: "",
+            labels: [],
             linkedIssueReferences: [],
             checksState: "",
             failedCheckNames: [],

--- a/Tests/CrowTests/IssueTrackerDedupTests.swift
+++ b/Tests/CrowTests/IssueTrackerDedupTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import CrowCore
 @testable import Crow
 
 @Suite("IssueTracker PR dedup")
@@ -16,6 +17,7 @@ struct IssueTrackerDedupTests {
         headRefOid: String = "",
         baseRefName: String = "",
         repoNameWithOwner: String = "",
+        labels: [LabelInfo] = [],
         linkedIssueReferences: [IssueTracker.ViewerPR.LinkedIssue] = [],
         checksState: String = "",
         failedCheckNames: [String] = [],
@@ -32,6 +34,7 @@ struct IssueTrackerDedupTests {
             headRefOid: headRefOid,
             baseRefName: baseRefName,
             repoNameWithOwner: repoNameWithOwner,
+            labels: labels,
             linkedIssueReferences: linkedIssueReferences,
             checksState: checksState,
             failedCheckNames: failedCheckNames,

--- a/Tests/CrowTests/IssueTrackerStalePRTests.swift
+++ b/Tests/CrowTests/IssueTrackerStalePRTests.swift
@@ -209,6 +209,7 @@ struct IssueTrackerStalePRTests {
             headRefOid: "",
             baseRefName: "",
             repoNameWithOwner: "",
+            labels: [],
             linkedIssueReferences: [],
             checksState: "",
             failedCheckNames: [],

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -50,6 +50,14 @@ PR #214 added two opt-in toggles that let Crow type a follow-up instruction into
 
 Both toggles read from `AutoRespondSettings` in `AppConfig`. The session must have an active Claude Code terminal for the instruction to land.
 
+### Auto-merge
+
+PR #299 added a single toggle that lets Crow enable GitHub's native auto-merge on Crow-authored PRs carrying the `crow:merge` label. Off by default.
+
+- **Enable `crow:merge` auto-merge for Crow-authored PRs** — when on, Crow watches each session's linked PR. If it sees the `crow:merge` label, the commits include a `Crow-Session: <uuid>` trailer matching a known Crow session, and the PR is not in `CONFLICTING`/`CHANGES_REQUESTED`/draft state, Crow runs `gh pr merge --auto --squash --delete-branch`. GitHub holds the merge server-side until required reviews and checks pass; Crow only enables it once per PR (idempotent via `Session.autoMergeEnabledAt`).
+
+Backed by `AppConfig.autoMergeWatcherEnabled`. Hand-written PRs without the Crow trailer are ignored even when labeled. Crow lazily creates the `crow:merge` label in the repo on first observation so repo owners don't need to pre-seed it.
+
 ## Per-PR feature notes
 
 Short descriptions of each shipped automation, in roughly the order they fire during the lifecycle.
@@ -82,6 +90,14 @@ A per-workspace setting (Workspaces → edit workspace → Auto-review). When on
 
 See the **Auto-respond** toggles in the Settings tab section above. Crow watches the PR for review-changed and check-failed transitions on the standard 60-second polling cycle.
 
+### #299 — Auto-merge on `crow:merge` label
+
+When a PR linked to an active Crow session carries the `crow:merge` label, the IssueTracker enables GitHub native auto-merge on the next poll. Eligibility is conjunctive: the label must be present, at least one commit on the PR must carry a `Crow-Session: <uuid>` trailer whose UUID matches a session this Crow instance knows about, and the PR must not be a draft / conflicting / changes-requested. The merge method is hard-defaulted to **squash with branch delete** to match the existing `/merge-pr` quick action.
+
+Crow does not babysit the merge — GitHub queues it server-side and fires once required checks settle. Enablement is one-shot per PR: `Session.autoMergeEnabledAt` is persisted on success, and an in-memory dedupe set protects the gap between dispatch and persistence. Trailer-with-unknown-session is treated as not-Crow-authored (defensive: someone copy-pasting our trailer convention into a hand-written commit should not be able to trigger auto-merge).
+
+Audit trail: each enable writes `[Crow] Auto-merge enabled on <pr-url> (session <uuid>, squash)` to the system log and posts a banner notification.
+
 ### #137 — Session analytics via OpenTelemetry
 
 Claude Code's OpenTelemetry exporter is wired up so each session emits standard OTLP metrics for token counts, tool-call latency, and turn duration. Configuration follows Claude Code's own env vars (e.g. `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_EXPORTER_OTLP_ENDPOINT`); Crow does not collect telemetry itself.
@@ -95,6 +111,7 @@ Claude Code's OpenTelemetry exporter is wired up so each session emits standard 
 | Manager auto-permission decision | `Sources/Crow/App/AppDelegate.swift` (Manager command rebuild)                                    |
 | Auto-create / auto-respond loop  | `Sources/Crow/App/IssueTracker.swift` (60s polling cycle)                                         |
 | Review session auto-start        | `Sources/Crow/App/IssueTracker.swift` + per-workspace flag in `AppConfig`                         |
+| Auto-merge watcher (`crow:merge`)| `Sources/Crow/App/IssueTracker.swift` (`applyAutoMerge`, `extractCrowSessionUUIDs`, `crowAuthored`) |
 
 ## See also
 


### PR DESCRIPTION
Closes #299

## Summary

- New opt-in toggle **Settings → Automation → Auto-merge** (off by default) makes the existing 60s `IssueTracker` poll watch each session's PR for the `crow:merge` label. When the label is present, the PR's commits include a `Crow-Session:` trailer matching a session this Crow instance knows about, and the PR is OPEN / non-draft / not CONFLICTING / not CHANGES_REQUESTED, Crow runs ``gh pr merge --auto --squash --delete-branch`` from \`\$TMPDIR\` (matches the existing worktree-lock workaround from #298).
- GitHub holds the merge server-side until required reviews/checks settle — Crow only enables it, then walks away.
- One-shot per PR: `Session.autoMergeEnabledAt` is persisted on success; an in-memory dedupe set guards the dispatch ↔ persistence window. Trailer-with-unknown-session is treated as **not** Crow-authored (defensive: blocks copy-pasted trailers from triggering us).
- Merge method is hard-defaulted to **squash + delete branch** (no new UI surface). The `crow:merge` label is lazily created in the target repo on first observation, so repo owners don't have to pre-seed it.
- Audit trail: ``[Crow] Auto-merge enabled on <pr-url> (session <uuid>, squash)`` is written to the system log, plus a banner notification.

Pure decision helpers (`shouldAttemptAutoMerge`, `extractCrowSessionUUIDs`, `crowAuthored`) are factored out as `nonisolated static` so they're trivially unit-testable without spinning up an `IssueTracker`. The viewer PR GraphQL query gained a `labels` block (matching the existing pattern on `reviewPRs`/`openIssues`), and `ViewerPR` gained a corresponding `labels: [LabelInfo]` field.

## Test plan

- [x] `swift test --package-path Packages/CrowCore` — 169 tests pass (includes the new `appConfigAutoMergeWatcher*` round-trip tests).
- [x] `swift test --package-path Packages/{CrowGit,CrowProvider,CrowPersistence,CrowIPC}` — all pass.
- [ ] Full `swift test` on the root package was not run locally — this repo's GhosttyKit binary target only resolves via the `cd Packages/CrowTerminal && swift build` path; the root `swift build` fails on `import GhosttyKit` even on a clean tree. CI should exercise the new `IssueTrackerAutoMergeTests` suite (16 tests covering eligibility guards, trailer parsing, and Crow-authored detection).
- [ ] Manual: toggle on, apply `crow:merge` to a Crow-authored PR, watch for the audit log + native auto-merge enablement.
- [ ] Manual: apply `crow:merge` to a hand-written PR — verify Crow ignores it (look for the "ignored — no Crow-Session trailer matching a known session" log line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)