### PR TITLE
fix: delete review-session clone on disk (closes #305)

### DIFF
--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -630,11 +630,9 @@ final class SessionService {
         var firstFatalError: String? = nil
 
         for item in items {
-            if item.isMainCheckout {
-                NSLog("Skipping worktree cleanup for main checkout: \(item.worktreePath) (branch: \(item.branch))")
-                continue
-            }
-
+            // Review clones are standalone `git clone` checkouts (not `git worktree add`
+            // artifacts) and always have repoPath == worktreePath, which would otherwise
+            // trip the main-checkout guard below and leave the clone orphaned on disk.
             if isReview {
                 guard FileManager.default.fileExists(atPath: item.worktreePath) else { continue }
                 do {
@@ -645,6 +643,11 @@ final class SessionService {
                     NSLog("[SessionService] \(msg) (\(item.worktreePath))")
                     if firstFatalError == nil { firstFatalError = msg }
                 }
+                continue
+            }
+
+            if item.isMainCheckout {
+                NSLog("Skipping worktree cleanup for main checkout: \(item.worktreePath) (branch: \(item.branch))")
                 continue
             }
 

--- a/Tests/CrowTests/SessionServiceDiskCleanupTests.swift
+++ b/Tests/CrowTests/SessionServiceDiskCleanupTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import Crow
+
+/// Covers the disk-cleanup branch hit when a review session is deleted.
+/// Regression guard for #305: review clones were being skipped because
+/// `isMainCheckout` was checked before the `isReview` branch.
+@Suite("SessionService.performDiskCleanup")
+struct SessionServiceDiskCleanupTests {
+
+    private static func makeTempDir(name: String = "crow-cleanup-test") -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("\(name)-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test func deletesReviewClone() {
+        let clone = Self.makeTempDir(name: "review-clone")
+        defer { try? FileManager.default.removeItem(at: clone) }
+
+        // Matches how `deleteSession` builds the item for review sessions:
+        // repoPath == worktreePath == clonePath, isMainCheckout: true (because
+        // SessionWorktree.isMainRepoCheckout returns true when the paths match).
+        let item = SessionService.WorktreeCleanupItem(
+            repoPath: clone.path,
+            worktreePath: clone.path,
+            branch: "feature/some-pr",
+            isMainCheckout: true
+        )
+
+        let error = SessionService.performDiskCleanup(items: [item], isReview: true)
+
+        #expect(error == nil)
+        #expect(!FileManager.default.fileExists(atPath: clone.path))
+    }
+
+    @Test func reviewCleanupIsIdempotent() {
+        let clone = Self.makeTempDir(name: "review-clone-gone")
+        try? FileManager.default.removeItem(at: clone)
+        #expect(!FileManager.default.fileExists(atPath: clone.path))
+
+        let item = SessionService.WorktreeCleanupItem(
+            repoPath: clone.path,
+            worktreePath: clone.path,
+            branch: "feature/some-pr",
+            isMainCheckout: true
+        )
+
+        let error = SessionService.performDiskCleanup(items: [item], isReview: true)
+
+        #expect(error == nil)
+    }
+
+    @Test func nonReviewMainCheckoutIsSkipped() {
+        let checkout = Self.makeTempDir(name: "main-checkout")
+        defer { try? FileManager.default.removeItem(at: checkout) }
+
+        let item = SessionService.WorktreeCleanupItem(
+            repoPath: checkout.path,
+            worktreePath: checkout.path,
+            branch: "main",
+            isMainCheckout: true
+        )
+
+        let error = SessionService.performDiskCleanup(items: [item], isReview: false)
+
+        #expect(error == nil)
+        #expect(FileManager.default.fileExists(atPath: checkout.path))
+    }
+
+    @Test func reviewCleanupDoesNotRemoveParent() {
+        let parent = Self.makeTempDir(name: "reviews-parent")
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let clone = parent.appendingPathComponent("repo-pr-123")
+        try? FileManager.default.createDirectory(at: clone, withIntermediateDirectories: true)
+
+        let item = SessionService.WorktreeCleanupItem(
+            repoPath: clone.path,
+            worktreePath: clone.path,
+            branch: "feature/some-pr",
+            isMainCheckout: true
+        )
+
+        let error = SessionService.performDiskCleanup(items: [item], isReview: true)
+
+        #expect(error == nil)
+        #expect(!FileManager.default.fileExists(atPath: clone.path))
+        #expect(FileManager.default.fileExists(atPath: parent.path))
+    }
+}


### PR DESCRIPTION
## Summary

- Deleting a review session left `{devRoot}/crow-reviews/<cloneDirName>` orphaned on disk. Over time these full clones accumulate and grow disk usage.
- Root cause was different from the ticket's hypothesis: review clones **are** registered as `SessionWorktree`s, but `performDiskCleanup` checked `item.isMainCheckout` before the `isReview` branch. Review-session worktrees always have `repoPath == worktreePath == clonePath`, so `SessionWorktree.isMainRepoCheckout` returns `true` and the loop hit `continue` before the clone-removal code ran.
- Fix is a localized swap of the two early-exit branches in `performDiskCleanup` so `if isReview` runs first. Review clones are standalone `git clone` checkouts (not `git worktree add` artifacts) and don't need the main-checkout protection.
- Non-review session cleanup is unchanged.
- Existing retry-on-failure UX (`sessionDeletionError[id]`) is preserved.

## Test plan

- [x] `swift test --no-parallel` — 107 tests pass (full suite is green serially; the `FeatureFlags` suite has a pre-existing parallel env-var ordering flake unrelated to this change).
- [x] `swift build` — clean.
- [x] New tests in `Tests/CrowTests/SessionServiceDiskCleanupTests.swift`:
  - `deletesReviewClone` — confirms the clone dir is removed.
  - `reviewCleanupIsIdempotent` — no error when the dir is already gone.
  - `nonReviewMainCheckoutIsSkipped` — regression guard for the main-checkout protection on regular sessions.
  - `reviewCleanupDoesNotRemoveParent` — enforces "only the per-session subdir is removed, never `crow-reviews/`".
- [ ] Manual smoke: trigger a review on a real PR, confirm `~/Dev/crow-reviews/<name>` exists, delete the review session from the UI, confirm the directory is gone and the row disappears.
- [ ] Regression smoke: delete a regular (non-review) work session; confirm worktree-remove behavior is unchanged.

## Notes

- **Forward-looking only.** Existing orphaned directories under `crow-reviews/` from previously-deleted review sessions need a one-shot manual `rm`. A bulk purge tool is out of scope per the ticket.

Closes #305

🐦‍⬛ Generated with Claude Code, orchestrated by Crow