### PR TITLE
fix: skip auto-respond automation on review sessions

### DIFF
--- a/Sources/Crow/App/AutoRespondCoordinator.swift
+++ b/Sources/Crow/App/AutoRespondCoordinator.swift
@@ -29,6 +29,11 @@ final class AutoRespondCoordinator {
     func handle(_ transitions: [PRStatusTransition]) {
         let cfg = settingsProvider()
         for t in transitions {
+            if shouldSkipReviewSession(t) {
+                NSLog("[AutoRespond] Skipping %@ for session %@: review session",
+                      t.kind.rawValue, t.sessionID.uuidString)
+                continue
+            }
             switch t.kind {
             case .changesRequested where cfg.respondToChangesRequested:
                 dispatch(t)
@@ -38,6 +43,14 @@ final class AutoRespondCoordinator {
                 continue
             }
         }
+    }
+
+    /// Review sessions exist to review someone else's PR. Auto-respond would
+    /// have Crow committing on behalf of the reviewer to the branch under
+    /// review — never correct. This gate is policy, independent of the
+    /// `AutoRespondSettings` toggles, and applies even when both toggles are on.
+    func shouldSkipReviewSession(_ transition: PRStatusTransition) -> Bool {
+        appState.sessions.first(where: { $0.id == transition.sessionID })?.kind == .review
     }
 
     private func dispatch(_ transition: PRStatusTransition) {

--- a/Tests/CrowTests/AutoRespondCoordinatorReviewSessionTests.swift
+++ b/Tests/CrowTests/AutoRespondCoordinatorReviewSessionTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+/// Verifies the policy gate added for #311: review sessions must never
+/// trigger auto-respond automation, regardless of the global
+/// `respondToChangesRequested` / `respondToFailedChecks` toggles. Work
+/// sessions continue to flow through unaffected.
+@Suite("AutoRespondCoordinator review-session gate")
+@MainActor
+struct AutoRespondCoordinatorReviewSessionTests {
+
+    private func makeCoordinator(sessions: [Session]) -> AutoRespondCoordinator {
+        let state = AppState()
+        state.sessions = sessions
+        return AutoRespondCoordinator(
+            appState: state,
+            settingsProvider: { AutoRespondSettings(respondToChangesRequested: true, respondToFailedChecks: true) }
+        )
+    }
+
+    @Test func skipsReviewSessionOnChangesRequested() {
+        let review = Session(name: "review-crow-123", kind: .review)
+        let coord = makeCoordinator(sessions: [review])
+        let t = PRStatusTransition(
+            kind: .changesRequested,
+            sessionID: review.id,
+            prURL: "https://github.com/radiusmethod/crow/pull/123",
+            prNumber: 123
+        )
+        #expect(coord.shouldSkipReviewSession(t))
+    }
+
+    @Test func skipsReviewSessionOnChecksFailing() {
+        let review = Session(name: "review-crow-456", kind: .review)
+        let coord = makeCoordinator(sessions: [review])
+        let t = PRStatusTransition(
+            kind: .checksFailing,
+            sessionID: review.id,
+            prURL: "https://github.com/radiusmethod/crow/pull/456",
+            prNumber: 456
+        )
+        #expect(coord.shouldSkipReviewSession(t))
+    }
+
+    @Test func doesNotSkipWorkSession() {
+        let work = Session(name: "feature-crow-789", kind: .work)
+        let coord = makeCoordinator(sessions: [work])
+        let t = PRStatusTransition(
+            kind: .changesRequested,
+            sessionID: work.id,
+            prURL: "https://github.com/radiusmethod/crow/pull/789",
+            prNumber: 789
+        )
+        #expect(!coord.shouldSkipReviewSession(t))
+    }
+
+    /// If the transition references a session ID that's no longer in
+    /// `appState.sessions` (race with delete, stale poll), the gate should
+    /// not pretend it was a review — fall through to the normal toggle path.
+    @Test func unknownSessionIsNotTreatedAsReview() {
+        let coord = makeCoordinator(sessions: [])
+        let t = PRStatusTransition(
+            kind: .changesRequested,
+            sessionID: UUID(),
+            prURL: "https://github.com/radiusmethod/crow/pull/1",
+            prNumber: 1
+        )
+        #expect(!coord.shouldSkipReviewSession(t))
+    }
+}


### PR DESCRIPTION
## Summary

- Gate `AutoRespondCoordinator.handle(_:)` on `Session.kind` so review sessions never trigger the auto-fix prompts.
- Review sessions exist to leave comments on someone else's PR; auto-respond would have Crow committing and pushing on the reviewer's behalf to the branch under review.
- Work sessions are untouched — they continue to auto-respond per the existing `respondToChangesRequested` / `respondToFailedChecks` toggles.
- The macOS notification still fires for review sessions, so the user can act manually if they choose.

## Why this is small

The existing `SessionKind` enum (`.work` / `.review`) and the persisted `Session.kind` field already carry the policy. `SessionService.createReviewSession()` already stamps `kind: .review`. No schema change, no migration — existing review sessions on disk are already classified correctly.

## Out of scope

- Manual quick-action buttons (`dispatchManual`) remain enabled on all sessions: a button click is the user's explicit consent.
- Per-session config overrides for auto-respond.

Closes #311

## Test plan

- [x] `make build` — clean
- [x] `swift test --filter AutoRespondCoordinatorReviewSessionTests` — 4/4 pass
- [x] Full `swift test` — 117/117 pass
- [ ] Manual smoke (optional, live PR): start `/review-pr <url>` with both auto-respond toggles enabled, trigger a "changes requested" review on that PR, confirm no prompt is injected into the review session's Claude Code terminal and no commits land on the branch under review. Repeat against a normal work session and confirm auto-respond still fires.