### PR TITLE
feat: opt-in toggle for crow:auto label automation

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -23,6 +23,13 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// authored by Crow (Crow-Session trailer matching a known session).
     /// Opt-in: defaults to false (CROW-299).
     public var autoMergeWatcherEnabled: Bool
+    /// When true, the IssueTracker dispatches `/crow-workspace` to the
+    /// Manager terminal for assigned open issues labeled `crow:auto`.
+    /// Opt-in: defaults to false (CROW-312). The label is still stripped
+    /// after a successful dispatch so the trigger remains one-shot per
+    /// issue. While disabled, the label is left alone so a later opt-in
+    /// can still pick up previously-labeled issues.
+    public var autoCreateWatcherEnabled: Bool
     public var cleanup: CleanupConfig
 
     public init(
@@ -36,6 +43,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoRespond: AutoRespondSettings = AutoRespondSettings(),
         attributionTrailers: Bool = true,
         autoMergeWatcherEnabled: Bool = false,
+        autoCreateWatcherEnabled: Bool = false,
         cleanup: CleanupConfig = CleanupConfig()
     ) {
         self.workspaces = workspaces
@@ -48,6 +56,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.autoRespond = autoRespond
         self.attributionTrailers = attributionTrailers
         self.autoMergeWatcherEnabled = autoMergeWatcherEnabled
+        self.autoCreateWatcherEnabled = autoCreateWatcherEnabled
         self.cleanup = cleanup
     }
 
@@ -63,11 +72,12 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoRespond = try container.decodeIfPresent(AutoRespondSettings.self, forKey: .autoRespond) ?? AutoRespondSettings()
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
         autoMergeWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoMergeWatcherEnabled) ?? false
+        autoCreateWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoCreateWatcherEnabled) ?? false
         cleanup = try container.decodeIfPresent(CleanupConfig.self, forKey: .cleanup) ?? CleanupConfig()
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, cleanup
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -46,6 +46,7 @@ import Testing
     #expect(config.managerAutoPermissionMode == true)
     #expect(config.attributionTrailers == true)
     #expect(config.autoMergeWatcherEnabled == false)
+    #expect(config.autoCreateWatcherEnabled == false)
     #expect(config.cleanup.enabled == false)
     #expect(config.cleanup.retentionHours == 24)
 }
@@ -70,6 +71,28 @@ import Testing
     let json = #"{"workspaces":[]}"#.data(using: .utf8)!
     let config = try JSONDecoder().decode(AppConfig.self, from: json)
     #expect(config.autoMergeWatcherEnabled == false)
+}
+
+@Test func appConfigAutoCreateWatcherEnabledRoundTrip() throws {
+    var config = AppConfig()
+    config.autoCreateWatcherEnabled = true
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.autoCreateWatcherEnabled == true)
+
+    config.autoCreateWatcherEnabled = false
+    let data2 = try JSONEncoder().encode(config)
+    let decoded2 = try JSONDecoder().decode(AppConfig.self, from: data2)
+    #expect(decoded2.autoCreateWatcherEnabled == false)
+}
+
+@Test func appConfigAutoCreateWatcherDefaultsOffWhenKeyMissing() throws {
+    // Legacy configs without the key must default to off — the crow:auto
+    // label automation is opt-in (CROW-312).
+    let json = #"{"workspaces":[]}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.autoCreateWatcherEnabled == false)
 }
 
 @Test func appConfigCleanupRoundTrip() throws {

--- a/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AutomationSettingsView.swift
@@ -11,6 +11,7 @@ public struct AutomationSettingsView: View {
     @Binding var autoRespond: AutoRespondSettings
     @Binding var attributionTrailers: Bool
     @Binding var autoMergeWatcherEnabled: Bool
+    @Binding var autoCreateWatcherEnabled: Bool
     var onSave: (() -> Void)?
 
     @State private var excludeReviewReposText: String
@@ -24,6 +25,7 @@ public struct AutomationSettingsView: View {
         autoRespond: Binding<AutoRespondSettings>,
         attributionTrailers: Binding<Bool>,
         autoMergeWatcherEnabled: Binding<Bool>,
+        autoCreateWatcherEnabled: Binding<Bool>,
         onSave: (() -> Void)? = nil
     ) {
         self._defaults = defaults
@@ -32,6 +34,7 @@ public struct AutomationSettingsView: View {
         self._autoRespond = autoRespond
         self._attributionTrailers = attributionTrailers
         self._autoMergeWatcherEnabled = autoMergeWatcherEnabled
+        self._autoCreateWatcherEnabled = autoCreateWatcherEnabled
         self.onSave = onSave
         self._excludeReviewReposText = State(initialValue: defaults.wrappedValue.excludeReviewRepos.joined(separator: ", "))
         self._ignoreReviewLabelsText = State(initialValue: defaults.wrappedValue.ignoreReviewLabels.joined(separator: ", "))
@@ -106,6 +109,14 @@ public struct AutomationSettingsView: View {
                 Toggle("Add Crow-Session trailer to commits", isOn: $attributionTrailers)
                     .onChange(of: attributionTrailers) { _, _ in onSave?() }
                 Text("Writes a per-worktree .claude/settings.local.json that overrides Claude Code's commit attribution to include a Crow-Session: <uuid> trailer alongside Co-Authored-By: Claude. Applies to new worktrees only.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Auto-launch workspaces") {
+                Toggle("Auto-launch workspaces for crow:auto labeled issues", isOn: $autoCreateWatcherEnabled)
+                    .onChange(of: autoCreateWatcherEnabled) { _, _ in onSave?() }
+                Text("When enabled, the Manager detects assigned issues tagged crow:auto and runs /crow-workspace automatically. The label is removed after dispatch so each issue triggers once. Requires Crow (and the Manager) to be running. Off by default.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -46,6 +46,7 @@ public struct SettingsView: View {
                 autoRespond: $config.autoRespond,
                 attributionTrailers: $config.attributionTrailers,
                 autoMergeWatcherEnabled: $config.autoMergeWatcherEnabled,
+                autoCreateWatcherEnabled: $config.autoCreateWatcherEnabled,
                 onSave: { save() }
             )
                 .tabItem { Label("Automation", systemImage: "bolt.fill") }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -526,6 +526,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         tracker.autoMergeWatcherEnabledProvider = { [weak self] in
             self?.appConfig?.autoMergeWatcherEnabled ?? false
         }
+        tracker.autoCreateWatcherEnabledProvider = { [weak self] in
+            self?.appConfig?.autoCreateWatcherEnabled ?? false
+        }
         tracker.onAutoMergeEnabled = { [weak self] sessionID, prURL, number in
             self?.notificationManager?.notifyAutoMergeEnabled(prURL: prURL, number: number, sessionID: sessionID)
         }

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -47,6 +47,13 @@ final class IssueTracker {
     /// `false` so the watcher is inert until AppDelegate wires it (CROW-299).
     var autoMergeWatcherEnabledProvider: () -> Bool = { false }
 
+    /// Reads the latest `AppConfig.autoCreateWatcherEnabled` snapshot on
+    /// every poll. Closure-based so toggling the setting in Settings takes
+    /// effect on the next refresh without re-initializing the tracker.
+    /// Defaults to `false` so the `crow:auto`-label automation is inert
+    /// until AppDelegate wires it (CROW-312).
+    var autoCreateWatcherEnabledProvider: () -> Bool = { false }
+
     /// Fires after Crow has successfully enabled GitHub native auto-merge
     /// on a PR. Wired in AppDelegate to post the user-facing notification.
     /// (The durable audit-log line is `NSLog`'d at the call site so it
@@ -404,7 +411,12 @@ final class IssueTracker {
     /// is one-shot and visible across machines. Issues that already have an
     /// active session are treated as "work picked up elsewhere" — we still
     /// strip the stale label but don't re-dispatch.
+    ///
+    /// No-op when the global `autoCreateWatcherEnabled` setting is off
+    /// (CROW-312). The label is intentionally left in place while disabled
+    /// so a later opt-in still picks up the issue on the next poll.
     private func detectAutoCreateCandidates(issues: [AssignedIssue], config: AppConfig) {
+        guard autoCreateWatcherEnabledProvider() else { return }
         // Purge in-flight URLs that now have an active session — the dispatch
         // succeeded and the set can shrink.
         if !autoCreateInFlight.isEmpty {


### PR DESCRIPTION
Closes #312.

## Summary

- New top-level `autoCreateWatcherEnabled: Bool` on `AppConfig`, default `false` — covers all `crow:auto`-label automation.
- New "Auto-launch workspaces" section in **Settings → Automation** (placed above "Auto-merge") with the toggle and help text.
- `IssueTracker.detectAutoCreateCandidates` early-returns when the toggle is off, so no `/crow-workspace` dispatch happens regardless of how the label was applied (manual, webhook, bot). The label is intentionally left in place while disabled so a later opt-in still picks up previously-labeled issues.
- Mirrors the `autoMergeWatcherEnabled` (CROW-299) pattern: closure provider on the tracker, wired from `AppDelegate`, so flipping the toggle takes effect on the next poll without re-init.
- Legacy `config.json` files decode with the field defaulting to `false`, satisfying the "default off for everyone, including current installs" requirement.

## Test plan

- [x] `make build` succeeds.
- [x] `swift test --package-path Packages/CrowCore` passes (171 tests, including 3 new ones: round-trip, default-off-on-missing-key, extended empty-JSON check).
- [x] `swift test --filter IssueTrackerAutoMergeTests` still green (no regression to the sibling watcher).
- [ ] Manual smoke:
  - Settings → Automation shows the new "Auto-launch workspaces" section above "Auto-merge"; toggle is off.
  - With toggle **off**: applying `crow:auto` to an assigned issue does not launch a workspace and the label remains. Verified by waiting through one 60s poll cycle.
  - Toggle on: next poll launches the workspace and strips the label (pre-change behavior).
  - Toggle state persists across app restart (written to `~/.claude/config.json`).