### PR TITLE
fix: drop /plan prefix from initial workspace prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,6 @@ The `crow send` command writes text to the terminal. Newlines in the text are co
 - The Manager session UUID is always `00000000-0000-0000-0000-000000000000` — do not delete it
 - Use `/crow-workspace` skill for full workspace setup (worktrees + session + Claude Code)
 - **Worktree paths go DIRECTLY under the workspace folder**: `{devRoot}/{workspace}/{repo}-{number}-{slug}` — NOT in a subfolder
-- The prompt for new Claude Code sessions must start with `/plan` to enter plan mode
 - Use `$TMPDIR` (not `/tmp`) for temporary files
 
 ## Git Worktree Best Practices

--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
@@ -13,9 +13,10 @@ public actor ClaudeLauncher {
         provider: Provider?,
         customInstructions: String? = nil
     ) -> String {
+        // Plan mode is set by the `--permission-mode plan` flag in setup.sh's
+        // launch_claude(); do not prepend `/plan` here — that token is parsed
+        // as a slash command by the receiving session. See issue #313.
         var lines: [String] = []
-        lines.append("/plan")
-        lines.append("")
         lines.append("# Workspace Context")
         lines.append("")
         lines.append("| Repository | Path | Branch | Description |")

--- a/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeLauncherTests.swift
+++ b/Packages/CrowClaude/Tests/CrowClaudeTests/ClaudeLauncherTests.swift
@@ -23,7 +23,7 @@ import Testing
         provider: .github
     )
 
-    #expect(prompt.hasPrefix("/plan"))
+    #expect(prompt.hasPrefix("# Workspace Context"))
     #expect(prompt.contains("| my-repo |"))
     #expect(prompt.contains("feature/42-cool"))
     #expect(prompt.contains("gh issue view"))
@@ -93,7 +93,7 @@ import Testing
         provider: nil
     )
 
-    #expect(prompt.hasPrefix("/plan"))
+    #expect(prompt.hasPrefix("# Workspace Context"))
     #expect(prompt.contains("| repo |"))
     #expect(!prompt.contains("## Ticket"))
     // Without a ticket, the PR step is still present (generic form)
@@ -149,6 +149,22 @@ import Testing
     #expect(!prompt.contains("glab mr create"))
     #expect(!prompt.contains("Closes #"))
     #expect(prompt.contains("pushing the branch updates it"))
+}
+
+@Test func generatePromptDoesNotStartWithPlanSlashCommand() async {
+    // Plan mode is set via the `--permission-mode plan` flag in setup.sh,
+    // not via a `/plan` slash-command prefix on the prompt body. See
+    // issue #313 — a leading `/plan` is parsed as a slash command by the
+    // receiving session and causes problems.
+    let launcher = ClaudeLauncher()
+    let prompt = await launcher.generatePrompt(
+        session: Session(name: "regress"),
+        worktrees: [],
+        ticketURL: nil,
+        provider: nil
+    )
+    #expect(!prompt.hasPrefix("/plan"))
+    #expect(!prompt.contains("\n/plan\n"))
 }
 
 // MARK: - launchCommand()

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -297,7 +297,7 @@ For cross-workspace setups with multiple repos, call `setup.sh` once per repo:
 
 IMPORTANT: Always use full absolute paths, never abbreviated (`...`) or home-relative (`~`) paths.
 
-The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. It starts with `/plan` to enter plan mode.
+The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. Plan mode is set by the `--permission-mode plan` flag in `setup.sh`'s launch command — do not prepend `/plan` to the prompt body (it would be parsed as a slash command by the receiving session). See issue #313.
 
 **Repo descriptions for the prompt table:**
 

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -334,7 +334,7 @@ For cross-workspace setups with multiple repos, call `setup.sh` once per repo:
 
 IMPORTANT: Always use full absolute paths, never abbreviated (`...`) or home-relative (`~`) paths.
 
-The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. It starts with `/plan` to enter plan mode.
+The prompt is written to `{devRoot}/.claude/prompts/crow-prompt-{session_name}.md`. Plan mode is set by the `--permission-mode plan` flag in `setup.sh`'s launch command — do not prepend `/plan` to the prompt body (it would be parsed as a slash command by the receiving session). See issue #313.
 
 **Repo descriptions for the prompt table:**
 


### PR DESCRIPTION
## Summary
- `ClaudeLauncher.generatePrompt()` no longer prepends `/plan\n\n` to the prompt body. Plan mode is set entirely by the `--permission-mode plan` flag in `skills/crow-workspace/setup.sh:560` (and its template at `Resources/crow-workspace-setup.sh.template:476`) — the `/plan` line was a belt-and-suspenders duplicate that the receiving session interpreted as a slash command, causing problems.
- Updated the two existing `prompt.hasPrefix("/plan")` assertions in `ClaudeLauncherTests.swift` to `hasPrefix("# Workspace Context")`, and added a dedicated `generatePromptDoesNotStartWithPlanSlashCommand` regression test that fails if anyone re-adds the prefix.
- Removed the matching prose lines from `skills/crow-workspace/SKILL.md`, `Resources/crow-workspace-SKILL.md.template` (the .app-bundled twin), and the repo-root `CLAUDE.md`.

`/crow-batch-workspace` inherits the fix automatically — its SKILL.md delegates to the `/crow-workspace` First Prompt Template and never named `/plan` explicitly.

Closes #313

## Test plan
- [x] `make build` — clean
- [x] `swift test --filter ClaudeLauncherTests` — 14/14 pass (including new regression test)
- [x] `grep -rn '/plan' skills/ Resources/ Packages/CrowClaude/ CLAUDE.md` returns only the explanatory prose ("do not prepend `/plan`") and the test's own assertions — no live `/plan` emitters
- [x] `grep -n 'permission-mode plan' skills/crow-workspace/setup.sh Resources/crow-workspace-setup.sh.template` confirms the launch flag is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)