### PR TITLE
feat: scheduled jobs — timed prompt sets scoped to a repo (closes #317)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -31,6 +31,9 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// can still pick up previously-labeled issues.
     public var autoCreateWatcherEnabled: Bool
     public var cleanup: CleanupConfig
+    /// Scheduled jobs: named sets of prompts that fire automatically on a
+    /// schedule, scoped to a repo. Driven by `JobScheduler` (CROW-317).
+    public var jobs: [JobConfig]
 
     public init(
         workspaces: [WorkspaceInfo] = [],
@@ -44,7 +47,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
         attributionTrailers: Bool = true,
         autoMergeWatcherEnabled: Bool = false,
         autoCreateWatcherEnabled: Bool = false,
-        cleanup: CleanupConfig = CleanupConfig()
+        cleanup: CleanupConfig = CleanupConfig(),
+        jobs: [JobConfig] = []
     ) {
         self.workspaces = workspaces
         self.defaults = defaults
@@ -58,6 +62,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.autoMergeWatcherEnabled = autoMergeWatcherEnabled
         self.autoCreateWatcherEnabled = autoCreateWatcherEnabled
         self.cleanup = cleanup
+        self.jobs = jobs
     }
 
     public init(from decoder: Decoder) throws {
@@ -74,10 +79,11 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoMergeWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoMergeWatcherEnabled) ?? false
         autoCreateWatcherEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoCreateWatcherEnabled) ?? false
         cleanup = try container.decodeIfPresent(CleanupConfig.self, forKey: .cleanup) ?? CleanupConfig()
+        jobs = try container.decodeIfPresent([JobConfig].self, forKey: .jobs) ?? []
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, cleanup, jobs
     }
 }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum SessionKind: String, Codable, Sendable {
     case work    // Normal development session (default)
     case review  // PR review session
+    case job     // Session spun up by a scheduled job (CROW-317)
 }
 
 /// Status of a development session.

--- a/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// A scheduled job: one or more prompts that fire automatically on a schedule,
+/// scoped to a repo within a workspace.
+///
+/// When a job fires, the scheduler creates a fresh worktree + session + Claude
+/// Code terminal in `{devRoot}/{workspace}/{repo}` and sends `prompts` in order.
+/// Persisted as part of `AppConfig` in `{devRoot}/.claude/config.json`.
+///
+/// Like `WorkspaceInfo`, decoding is forward-compatible: missing keys fall back
+/// to defaults so older config files keep working.
+public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
+    public let id: UUID
+    public var name: String
+    /// Workspace name (matches `WorkspaceInfo.name`).
+    public var workspace: String
+    /// Repo folder name within the workspace (the checkout at `{devRoot}/{workspace}/{repo}`).
+    public var repo: String
+    /// Ordered prompts. The first launches Claude; the rest are sent after launch.
+    public var prompts: [String]
+    public var schedule: JobSchedule
+    public var enabled: Bool
+    /// When the job last fired. Runtime state, persisted so restarts don't replay.
+    public var lastRunAt: Date?
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        workspace: String,
+        repo: String,
+        prompts: [String],
+        schedule: JobSchedule,
+        enabled: Bool = true,
+        lastRunAt: Date? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.workspace = workspace
+        self.repo = repo
+        self.prompts = prompts
+        self.schedule = schedule
+        self.enabled = enabled
+        self.lastRunAt = lastRunAt
+        self.createdAt = createdAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        workspace = try container.decodeIfPresent(String.self, forKey: .workspace) ?? ""
+        repo = try container.decodeIfPresent(String.self, forKey: .repo) ?? ""
+        prompts = try container.decodeIfPresent([String].self, forKey: .prompts) ?? []
+        schedule = try container.decodeIfPresent(JobSchedule.self, forKey: .schedule) ?? .interval(seconds: 86400)
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        lastRunAt = try container.decodeIfPresent(Date.self, forKey: .lastRunAt)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, workspace, repo, prompts, schedule, enabled, lastRunAt, createdAt
+    }
+
+    /// Validate a job name, returning an error message or `nil` if valid.
+    public static func validateName(_ name: String, existingNames: [String]) -> String? {
+        if name.isEmpty {
+            return "Name is required"
+        }
+        let lowercased = name.lowercased()
+        if existingNames.contains(where: { $0.lowercased() == lowercased }) {
+            return "A job with this name already exists"
+        }
+        return nil
+    }
+
+    /// The next time this job should fire strictly after `reference`.
+    ///
+    /// The scheduler treats the job as due when
+    /// `nextRunDate(after: lastRunAt ?? createdAt) <= now`. Returns `nil` for an
+    /// unsatisfiable schedule (e.g. a non-positive interval).
+    public func nextRunDate(after reference: Date, calendar: Calendar = .current) -> Date? {
+        schedule.nextRunDate(after: reference, calendar: calendar)
+    }
+}
+
+/// How often a `JobConfig` fires.
+///
+/// Encoded with a `type` discriminator (`"interval"` / `"dailyAt"`) so the JSON
+/// stays readable and tolerant of future cases.
+public enum JobSchedule: Codable, Sendable, Equatable {
+    /// Fire every `seconds` after the previous run (or after `createdAt`).
+    case interval(seconds: Int)
+    /// Fire daily at `hour`:`minute` (local time) on the given `weekdays`.
+    /// Weekday integers follow `Calendar`'s convention (1 = Sunday … 7 = Saturday).
+    /// An empty set means every day.
+    case dailyAt(hour: Int, minute: Int, weekdays: Set<Int>)
+
+    private enum CodingKeys: String, CodingKey {
+        case type, seconds, hour, minute, weekdays
+    }
+
+    private enum Kind: String, Codable {
+        case interval, dailyAt
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .interval(let seconds):
+            try c.encode(Kind.interval, forKey: .type)
+            try c.encode(seconds, forKey: .seconds)
+        case .dailyAt(let hour, let minute, let weekdays):
+            try c.encode(Kind.dailyAt, forKey: .type)
+            try c.encode(hour, forKey: .hour)
+            try c.encode(minute, forKey: .minute)
+            try c.encode(weekdays.sorted(), forKey: .weekdays)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try c.decode(Kind.self, forKey: .type)
+        switch type {
+        case .interval:
+            self = .interval(seconds: try c.decode(Int.self, forKey: .seconds))
+        case .dailyAt:
+            let hour = try c.decode(Int.self, forKey: .hour)
+            let minute = try c.decode(Int.self, forKey: .minute)
+            let weekdays = try c.decodeIfPresent([Int].self, forKey: .weekdays) ?? []
+            self = .dailyAt(hour: hour, minute: minute, weekdays: Set(weekdays))
+        }
+    }
+
+    /// Next fire time strictly after `reference`, or `nil` if unsatisfiable.
+    public func nextRunDate(after reference: Date, calendar: Calendar = .current) -> Date? {
+        switch self {
+        case .interval(let seconds):
+            guard seconds > 0 else { return nil }
+            return reference.addingTimeInterval(TimeInterval(seconds))
+        case .dailyAt(let hour, let minute, let weekdays):
+            var match = DateComponents()
+            match.hour = hour
+            match.minute = minute
+            match.second = 0
+            guard var candidate = calendar.nextDate(
+                after: reference, matching: match, matchingPolicy: .nextTime
+            ) else { return nil }
+            guard !weekdays.isEmpty else { return candidate }
+            // Advance day-by-day until the weekday matches (bounded to a week).
+            var attempts = 0
+            while !weekdays.contains(calendar.component(.weekday, from: candidate)) {
+                guard let next = calendar.nextDate(
+                    after: candidate, matching: match, matchingPolicy: .nextTime
+                ) else { return nil }
+                candidate = next
+                attempts += 1
+                if attempts > 7 { return nil }
+            }
+            return candidate
+        }
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+@Test func jobConfigRoundTripInterval() throws {
+    let config = AppConfig(jobs: [
+        JobConfig(
+            name: "Nightly Audit",
+            workspace: "Acme",
+            repo: "api",
+            prompts: ["Run the audit", "Summarize findings"],
+            schedule: .interval(seconds: 3600),
+            enabled: true
+        )
+    ])
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+    #expect(decoded.jobs.count == 1)
+    let job = decoded.jobs[0]
+    #expect(job.name == "Nightly Audit")
+    #expect(job.workspace == "Acme")
+    #expect(job.repo == "api")
+    #expect(job.prompts == ["Run the audit", "Summarize findings"])
+    #expect(job.schedule == .interval(seconds: 3600))
+    #expect(job.enabled == true)
+}
+
+@Test func jobConfigRoundTripDailyAt() throws {
+    let job = JobConfig(
+        name: "Standup",
+        workspace: "Acme",
+        repo: "web",
+        prompts: ["Generate the standup report"],
+        schedule: .dailyAt(hour: 9, minute: 30, weekdays: [2, 3, 4, 5, 6]),
+        lastRunAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    let data = try JSONEncoder().encode(job)
+    let decoded = try JSONDecoder().decode(JobConfig.self, from: data)
+
+    #expect(decoded.schedule == .dailyAt(hour: 9, minute: 30, weekdays: [2, 3, 4, 5, 6]))
+    #expect(decoded.lastRunAt == Date(timeIntervalSince1970: 1_700_000_000))
+}
+
+/// A config file written before jobs existed must still decode (jobs → []).
+@Test func appConfigForwardCompatNoJobs() throws {
+    let json = """
+    {"remoteControlEnabled": true, "attributionTrailers": false}
+    """
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+    #expect(decoded.jobs.isEmpty)
+    #expect(decoded.remoteControlEnabled == true)
+}
+
+@Test func jobScheduleIntervalNextRun() {
+    let base = Date(timeIntervalSince1970: 1_000_000)
+    let schedule = JobSchedule.interval(seconds: 600)
+    #expect(schedule.nextRunDate(after: base) == base.addingTimeInterval(600))
+}
+
+@Test func jobScheduleIntervalRejectsNonPositive() {
+    #expect(JobSchedule.interval(seconds: 0).nextRunDate(after: Date()) == nil)
+}
+
+@Test func jobScheduleDailyAtNextRunIsInFutureAtTime() throws {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "UTC")!
+
+    // Reference: 2024-01-01 08:00 UTC (a Monday). Daily at 09:00, every day.
+    let reference = cal.date(from: DateComponents(year: 2024, month: 1, day: 1, hour: 8))!
+    let schedule = JobSchedule.dailyAt(hour: 9, minute: 0, weekdays: [])
+    let next = try #require(schedule.nextRunDate(after: reference, calendar: cal))
+
+    let comps = cal.dateComponents([.year, .month, .day, .hour, .minute], from: next)
+    #expect(comps.hour == 9)
+    #expect(comps.minute == 0)
+    #expect(comps.day == 1) // same day, later that morning
+    #expect(next > reference)
+}
+
+@Test func jobScheduleDailyAtSkipsToAllowedWeekday() throws {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "UTC")!
+
+    // 2024-01-05 is a Friday (weekday 6). Reference is that morning, after the
+    // fire time. With weekdays = {Monday=2}, the next run is Monday 2024-01-08.
+    let reference = cal.date(from: DateComponents(year: 2024, month: 1, day: 5, hour: 10))!
+    let schedule = JobSchedule.dailyAt(hour: 9, minute: 0, weekdays: [2])
+    let next = try #require(schedule.nextRunDate(after: reference, calendar: cal))
+
+    #expect(cal.component(.weekday, from: next) == 2) // Monday
+    let comps = cal.dateComponents([.year, .month, .day], from: next)
+    #expect(comps.year == 2024)
+    #expect(comps.month == 1)
+    #expect(comps.day == 8)
+}
+
+@Test func jobConfigValidateName() {
+    #expect(JobConfig.validateName("", existingNames: []) != nil)
+    #expect(JobConfig.validateName("Audit", existingNames: ["audit"]) != nil) // case-insensitive dupe
+    #expect(JobConfig.validateName("Audit", existingNames: ["Other"]) == nil)
+}

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+import CrowCore
+
+/// Form for creating or editing a scheduled job (CROW-317).
+///
+/// Mirrors `WorkspaceFormView`: holds field state, validates, and constructs a
+/// `JobConfig` on save. A job is scoped to a workspace + repo, carries one or
+/// more prompts, and fires on an interval or daily at a time.
+public struct JobFormView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String
+    @State private var workspace: String
+    @State private var repo: String
+    @State private var prompts: [String]
+    @State private var scheduleMode: ScheduleMode
+    @State private var intervalValue: Int
+    @State private var intervalUnit: IntervalUnit
+    @State private var dailyTime: Date
+    @State private var weekdays: Set<Int>
+    @State private var enabled: Bool
+
+    private let existingID: UUID?
+    private let existingLastRunAt: Date?
+    private let existingCreatedAt: Date
+    private let existingNames: [String]
+    private let workspaces: [WorkspaceInfo]
+    private let onSave: (JobConfig) -> Void
+
+    enum ScheduleMode: Hashable { case interval, daily }
+
+    enum IntervalUnit: String, CaseIterable, Identifiable {
+        case minutes, hours, days
+        var id: String { rawValue }
+        var seconds: Int {
+            switch self {
+            case .minutes: return 60
+            case .hours: return 3600
+            case .days: return 86400
+            }
+        }
+        var label: String { rawValue.capitalized }
+    }
+
+    /// Weekday options in display order, mapped to `Calendar`'s ints (Sun = 1 … Sat = 7).
+    private static let weekdayOptions: [(label: String, value: Int)] = [
+        ("Mon", 2), ("Tue", 3), ("Wed", 4), ("Thu", 5), ("Fri", 6), ("Sat", 7), ("Sun", 1),
+    ]
+
+    /// - Parameters:
+    ///   - job: An existing job to edit, or `nil` to create a new one.
+    ///   - workspaces: All configured workspaces (for the workspace/repo pickers).
+    ///   - existingNames: Names of other jobs, used for duplicate detection.
+    ///   - onSave: Called with the validated `JobConfig` when the user taps Save/Add.
+    public init(
+        job: JobConfig? = nil,
+        workspaces: [WorkspaceInfo] = [],
+        existingNames: [String] = [],
+        onSave: @escaping (JobConfig) -> Void
+    ) {
+        self.existingID = job?.id
+        self.existingLastRunAt = job?.lastRunAt
+        self.existingCreatedAt = job?.createdAt ?? Date()
+        self.existingNames = existingNames
+        self.workspaces = workspaces
+        self.onSave = onSave
+
+        self._name = State(initialValue: job?.name ?? "")
+        self._workspace = State(initialValue: job?.workspace ?? workspaces.first?.name ?? "")
+        self._repo = State(initialValue: job?.repo ?? "")
+        self._prompts = State(initialValue: job?.prompts.isEmpty == false ? job!.prompts : [""])
+        self._enabled = State(initialValue: job?.enabled ?? true)
+
+        // Decompose the schedule into editable fields.
+        switch job?.schedule {
+        case .interval(let seconds):
+            let (value, unit) = Self.decomposeInterval(seconds)
+            self._scheduleMode = State(initialValue: .interval)
+            self._intervalValue = State(initialValue: value)
+            self._intervalUnit = State(initialValue: unit)
+            self._dailyTime = State(initialValue: Self.time(hour: 9, minute: 0))
+            self._weekdays = State(initialValue: [])
+        case .dailyAt(let hour, let minute, let days):
+            self._scheduleMode = State(initialValue: .daily)
+            self._intervalValue = State(initialValue: 1)
+            self._intervalUnit = State(initialValue: .hours)
+            self._dailyTime = State(initialValue: Self.time(hour: hour, minute: minute))
+            self._weekdays = State(initialValue: days)
+        case nil:
+            self._scheduleMode = State(initialValue: .interval)
+            self._intervalValue = State(initialValue: 1)
+            self._intervalUnit = State(initialValue: .hours)
+            self._dailyTime = State(initialValue: Self.time(hour: 9, minute: 0))
+            self._weekdays = State(initialValue: [])
+        }
+    }
+
+    private var trimmedName: String { name.trimmingCharacters(in: .whitespaces) }
+
+    private var nonEmptyPrompts: [String] {
+        prompts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private var nameValidationError: String? {
+        JobConfig.validateName(trimmedName, existingNames: existingNames)
+    }
+
+    /// Repos to offer for the selected workspace (its `alwaysInclude`), plus the
+    /// current value if it isn't listed (so editing an off-list repo still works).
+    private var repoOptions: [String] {
+        var options = workspaces.first(where: { $0.name == workspace })?.alwaysInclude ?? []
+        if !repo.isEmpty, !options.contains(repo) { options.insert(repo, at: 0) }
+        return options
+    }
+
+    private var isValid: Bool {
+        nameValidationError == nil
+            && !workspace.isEmpty
+            && !repo.trimmingCharacters(in: .whitespaces).isEmpty
+            && !nonEmptyPrompts.isEmpty
+            && (scheduleMode == .daily || intervalValue >= 1)
+    }
+
+    public var body: some View {
+        Form {
+            Section("Job") {
+                TextField("Name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                if let error = nameValidationError, !trimmedName.isEmpty {
+                    Text(error).font(.caption).foregroundStyle(.red)
+                }
+
+                Picker("Workspace", selection: $workspace) {
+                    ForEach(workspaces) { ws in Text(ws.name).tag(ws.name) }
+                }
+                .onChange(of: workspace) { _, _ in
+                    // Reset repo when it no longer belongs to the chosen workspace.
+                    if !repoOptions.contains(repo) { repo = "" }
+                }
+
+                if repoOptions.isEmpty {
+                    TextField("Repo", text: $repo)
+                        .textFieldStyle(.roundedBorder)
+                    Text("Folder name of the repo under the workspace (e.g. \"api\").")
+                        .font(.caption).foregroundStyle(.secondary)
+                } else {
+                    Picker("Repo", selection: $repo) {
+                        Text("Select…").tag("")
+                        ForEach(repoOptions, id: \.self) { Text($0).tag($0) }
+                    }
+                }
+
+                Toggle("Enabled", isOn: $enabled)
+            }
+
+            Section {
+                ForEach(prompts.indices, id: \.self) { idx in
+                    HStack(alignment: .top) {
+                        TextField("Prompt \(idx + 1)", text: $prompts[idx], axis: .vertical)
+                            .textFieldStyle(.roundedBorder)
+                            .lineLimit(1...6)
+                        Button(role: .destructive) {
+                            prompts.remove(at: idx)
+                            if prompts.isEmpty { prompts = [""] }
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(prompts.count == 1)
+                        .accessibilityLabel("Remove prompt \(idx + 1)")
+                    }
+                }
+            } header: {
+                HStack {
+                    Text("Prompts")
+                    Spacer()
+                    Button {
+                        prompts.append("")
+                    } label: {
+                        Label("Add", systemImage: "plus").font(.caption)
+                    }
+                    .buttonStyle(.borderless)
+                }
+            } footer: {
+                Text("Sent in order. The first launches Claude Code; the rest follow after it starts.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            Section("Schedule") {
+                Picker("Run", selection: $scheduleMode) {
+                    Text("Every").tag(ScheduleMode.interval)
+                    Text("Daily at").tag(ScheduleMode.daily)
+                }
+                .pickerStyle(.segmented)
+
+                if scheduleMode == .interval {
+                    HStack {
+                        TextField("Every", value: $intervalValue, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 70)
+                        Picker("", selection: $intervalUnit) {
+                            ForEach(IntervalUnit.allCases) { Text($0.label).tag($0) }
+                        }
+                        .labelsHidden()
+                    }
+                    if intervalValue < 1 {
+                        Text("Interval must be at least 1.").font(.caption).foregroundStyle(.red)
+                    }
+                } else {
+                    DatePicker("Time", selection: $dailyTime, displayedComponents: .hourAndMinute)
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 4) {
+                            ForEach(Self.weekdayOptions, id: \.value) { option in
+                                let on = weekdays.contains(option.value)
+                                Button(option.label) {
+                                    if on { weekdays.remove(option.value) }
+                                    else { weekdays.insert(option.value) }
+                                }
+                                .buttonStyle(.bordered)
+                                .tint(on ? .accentColor : .secondary)
+                            }
+                        }
+                        Text("No day selected = every day.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .safeAreaInset(edge: .bottom) {
+            HStack {
+                Button("Cancel") { dismiss() }
+                Spacer()
+                Button(existingID != nil ? "Save" : "Add") {
+                    onSave(buildJob())
+                    dismiss()
+                }
+                .disabled(!isValid)
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .frame(width: 460, height: 600)
+    }
+
+    private func buildJob() -> JobConfig {
+        let schedule: JobSchedule
+        switch scheduleMode {
+        case .interval:
+            schedule = .interval(seconds: max(1, intervalValue) * intervalUnit.seconds)
+        case .daily:
+            let comps = Calendar.current.dateComponents([.hour, .minute], from: dailyTime)
+            schedule = .dailyAt(hour: comps.hour ?? 9, minute: comps.minute ?? 0, weekdays: weekdays)
+        }
+        return JobConfig(
+            id: existingID ?? UUID(),
+            name: trimmedName,
+            workspace: workspace,
+            repo: repo.trimmingCharacters(in: .whitespaces),
+            prompts: nonEmptyPrompts,
+            schedule: schedule,
+            enabled: enabled,
+            lastRunAt: existingLastRunAt,
+            createdAt: existingCreatedAt
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func decomposeInterval(_ seconds: Int) -> (Int, IntervalUnit) {
+        if seconds > 0, seconds % 86400 == 0 { return (seconds / 86400, .days) }
+        if seconds > 0, seconds % 3600 == 0 { return (seconds / 3600, .hours) }
+        return (max(1, seconds / 60), .minutes)
+    }
+
+    private static func time(hour: Int, minute: Int) -> Date {
+        Calendar.current.date(
+            from: DateComponents(hour: hour, minute: minute)
+        ) ?? Date()
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -14,6 +14,8 @@ public struct SettingsView: View {
     @State var config: AppConfig
     @State private var isAddingWorkspace = false
     @State private var editingWorkspace: WorkspaceInfo?
+    @State private var isAddingJob = false
+    @State private var editingJob: JobConfig?
 
     public var onSave: ((String, AppConfig) -> Void)?
     public var onRescaffold: ((String) -> Void)?
@@ -52,6 +54,8 @@ public struct SettingsView: View {
                 .tabItem { Label("Automation", systemImage: "bolt.fill") }
             workspacesTab
                 .tabItem { Label("Workspaces", systemImage: "rectangle.stack") }
+            jobsTab
+                .tabItem { Label("Jobs", systemImage: "clock.badge") }
             NotificationSettingsView(
                 settings: $config.notifications,
                 onSave: { save() }
@@ -78,6 +82,32 @@ public struct SettingsView: View {
                 }
             }
         }
+        .sheet(isPresented: $isAddingJob) {
+            JobFormView(
+                workspaces: config.workspaces,
+                existingNames: otherJobNames()
+            ) { job in
+                config.jobs.append(job)
+                save()
+            }
+        }
+        .sheet(item: $editingJob) { job in
+            JobFormView(
+                job: job,
+                workspaces: config.workspaces,
+                existingNames: otherJobNames(excluding: job.id)
+            ) { updated in
+                if let idx = config.jobs.firstIndex(where: { $0.id == updated.id }) {
+                    config.jobs[idx] = updated
+                    save()
+                }
+            }
+        }
+    }
+
+    /// Names of all jobs except the one currently being edited.
+    private func otherJobNames(excluding id: UUID? = nil) -> [String] {
+        config.jobs.filter { $0.id != id }.map(\.name)
     }
 
     // MARK: - General Tab
@@ -289,6 +319,114 @@ public struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    // MARK: - Jobs Tab
+
+    private var jobsTab: some View {
+        Form {
+            Section {
+                if config.jobs.isEmpty {
+                    Text("No jobs configured")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach($config.jobs) { $job in
+                        HStack(alignment: .top) {
+                            Toggle("", isOn: $job.enabled)
+                                .labelsHidden()
+                                .onChange(of: job.enabled) { _, _ in save() }
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(job.name).fontWeight(.medium)
+                                Text("\(job.workspace)/\(job.repo) · \(scheduleSummary(job.schedule))")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text("\(lastRunText(job)) · \(nextRunText(job))")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Spacer()
+
+                            Button {
+                                editingJob = job
+                            } label: {
+                                Image(systemName: "pencil")
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel("Edit \(job.name)")
+
+                            Button(role: .destructive) {
+                                config.jobs.removeAll { $0.id == job.id }
+                                save()
+                            } label: {
+                                Image(systemName: "trash")
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel("Delete \(job.name)")
+                        }
+                    }
+                }
+            } header: {
+                HStack {
+                    Text("Jobs")
+                    Spacer()
+                    Button {
+                        isAddingJob = true
+                    } label: {
+                        Label("Add", systemImage: "plus")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(config.workspaces.isEmpty)
+                }
+            } footer: {
+                if config.workspaces.isEmpty {
+                    Text("Add a workspace first — jobs are scoped to a repo in a workspace.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Scheduled prompt sets. When a job fires, Crow creates a worktree + session in the scoped repo and runs its prompts.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    /// Human-readable summary of a job's schedule (e.g. "every 4 hours", "Mon,Wed at 09:00").
+    private func scheduleSummary(_ schedule: JobSchedule) -> String {
+        switch schedule {
+        case .interval(let seconds):
+            let value: Int
+            let unit: String
+            if seconds > 0, seconds % 86400 == 0 { value = seconds / 86400; unit = "day" }
+            else if seconds > 0, seconds % 3600 == 0 { value = seconds / 3600; unit = "hour" }
+            else { value = max(1, seconds / 60); unit = "minute" }
+            return "every \(value) \(unit)\(value == 1 ? "" : "s")"
+        case .dailyAt(let hour, let minute, let weekdays):
+            let time = String(format: "%02d:%02d", hour, minute)
+            guard !weekdays.isEmpty else { return "daily at \(time)" }
+            let names = [1: "Sun", 2: "Mon", 3: "Tue", 4: "Wed", 5: "Thu", 6: "Fri", 7: "Sat"]
+            let days = weekdays
+                .sorted { (($0 + 5) % 7) < (($1 + 5) % 7) } // Monday-first ordering
+                .compactMap { names[$0] }
+                .joined(separator: ",")
+            return "\(days) at \(time)"
+        }
+    }
+
+    private func lastRunText(_ job: JobConfig) -> String {
+        guard let last = job.lastRunAt else { return "Last run: never" }
+        return "Last run: \(last.formatted(date: .abbreviated, time: .shortened))"
+    }
+
+    private func nextRunText(_ job: JobConfig) -> String {
+        guard job.enabled else { return "disabled" }
+        let baseline = job.lastRunAt ?? job.createdAt
+        guard let next = job.nextRunDate(after: baseline) else { return "Next: —" }
+        return "Next: \(next.formatted(date: .abbreviated, time: .shortened))"
     }
 
     private func save() {

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -18,6 +18,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var sessionService: SessionService?
     private var socketServer: SocketServer?
     private var issueTracker: IssueTracker?
+    private var jobScheduler: JobScheduler?
     private var notificationManager: NotificationManager?
     private var autoRespondCoordinator: AutoRespondCoordinator?
     private var allowListService: AllowListService?
@@ -533,6 +534,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         tracker.start()
         self.issueTracker = tracker
 
+        // Scheduled jobs (CROW-317): fire repo-scoped prompt sets on a schedule.
+        let scheduler = JobScheduler(appState: appState, sessionService: service)
+        scheduler.jobsProvider = { [weak self] in self?.appConfig?.jobs ?? [] }
+        scheduler.devRootProvider = { [weak self] in self?.devRoot }
+        scheduler.onJobRan = { [weak self] jobID, ranAt in
+            self?.recordJobRun(jobID: jobID, ranAt: ranAt)
+        }
+        scheduler.start()
+        self.jobScheduler = scheduler
+
         appState.onMarkInReview = { [weak tracker] id in
             Task { await tracker?.markInReview(sessionID: id) }
         }
@@ -808,6 +819,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
+    }
+
+    /// Record a job's run time in the canonical `appConfig` and persist it, so
+    /// the scheduler doesn't replay the job after a restart (CROW-317). Called
+    /// by `JobScheduler.onJobRan`.
+    private func recordJobRun(jobID: UUID, ranAt: Date) {
+        guard var config = appConfig, let devRoot,
+              let idx = config.jobs.firstIndex(where: { $0.id == jobID }) else { return }
+        config.jobs[idx].lastRunAt = ranAt
+        self.appConfig = config
+        do {
+            try ConfigStore.saveConfig(config, devRoot: devRoot)
+        } catch {
+            NSLog("[Crow] Failed to persist job run time: %@", error.localizedDescription)
+        }
     }
 
     // MARK: - Socket Server
@@ -1446,6 +1472,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         NSLog("[Crow] Application terminating — beginning cleanup")
         issueTracker?.stop()
+        jobScheduler?.stop()
         sessionService?.persistState()
         // Persist config in case settings changed during this session
         if let devRoot, let appConfig {

--- a/Sources/Crow/App/JobScheduler.swift
+++ b/Sources/Crow/App/JobScheduler.swift
@@ -1,0 +1,133 @@
+import Foundation
+import CrowCore
+import CrowTerminal
+
+/// Drives scheduled jobs (CROW-317).
+///
+/// Ticks on a `Timer` (like `IssueTracker`) and, for each enabled job that is
+/// due, asks `SessionService.runJob` to spin up a worktree + session + Claude
+/// terminal in the job's scoped repo. The first prompt is dispatched by the
+/// terminal-readiness machine on launch; any remaining prompts are delivered
+/// here once the terminal reports `.claudeLaunched`, spaced by a fixed gap.
+///
+/// Job config (including `lastRunAt`) lives in `AppConfig`; this class reads it
+/// through `jobsProvider`/`devRootProvider` closures and reports each run back
+/// via `onJobRan` so AppDelegate can persist `lastRunAt`. Keeping the canonical
+/// config in AppDelegate avoids a second source of truth.
+@MainActor
+final class JobScheduler {
+    private let appState: AppState
+    private let sessionService: SessionService
+    private var timer: Timer?
+
+    /// How often to evaluate jobs. A job fires within one tick of becoming due.
+    private let tickInterval: TimeInterval = 30
+    /// Gap between consecutive prompt sends after Claude has launched.
+    private let promptGap: TimeInterval = 20
+    /// Max polls (× 5s) to wait for `.claudeLaunched` before giving up on the
+    /// follow-up prompts for a run.
+    private let maxLaunchWaitPolls = 60
+
+    /// Jobs currently being created — guards against a long worktree creation
+    /// double-firing on the next tick before `lastRunAt` is persisted.
+    private var inFlight: Set<UUID> = []
+
+    /// Reads the current job list (from AppDelegate's `appConfig`).
+    var jobsProvider: () -> [JobConfig] = { [] }
+    /// Reads the configured dev root.
+    var devRootProvider: () -> String? = { nil }
+    /// Reports a successful run so AppDelegate can persist the job's `lastRunAt`.
+    var onJobRan: (UUID, Date) -> Void = { _, _ in }
+
+    init(appState: AppState, sessionService: SessionService) {
+        self.appState = appState
+        self.sessionService = sessionService
+    }
+
+    func start() {
+        // First tick after one interval — gives the app a grace period at
+        // launch and lets overdue jobs fire shortly after.
+        timer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+        timer?.tolerance = tickInterval / 4
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // MARK: - Tick
+
+    private func tick() {
+        guard let devRoot = devRootProvider() else { return }
+        let now = Date()
+        for job in jobsProvider() where job.enabled {
+            guard !inFlight.contains(job.id) else { continue }
+            let baseline = job.lastRunAt ?? job.createdAt
+            guard let next = job.nextRunDate(after: baseline), next <= now else { continue }
+
+            inFlight.insert(job.id)
+            let captured = job
+            Task { @MainActor in
+                defer { self.inFlight.remove(captured.id) }
+                if let result = await self.sessionService.runJob(captured, devRoot: devRoot) {
+                    // Persist run time first so the job isn't re-fired next tick.
+                    self.onJobRan(captured.id, Date())
+                    self.deliverRemainingPrompts(captured, terminalID: result.terminalID)
+                }
+            }
+        }
+    }
+
+    // MARK: - Multi-prompt delivery (best-effort)
+
+    /// Deliver every prompt after the first non-empty one, once Claude has
+    /// launched, spaced by `promptGap`.
+    private func deliverRemainingPrompts(_ job: JobConfig, terminalID: UUID) {
+        let remaining = job.prompts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .dropFirst()
+        guard !remaining.isEmpty else { return }
+
+        waitForClaudeLaunched(terminalID: terminalID, polls: 0) { [weak self] in
+            self?.sendSequentially(Array(remaining), terminalID: terminalID)
+        }
+    }
+
+    /// Poll the readiness machine until the terminal reports `.claudeLaunched`,
+    /// then run `then`. Bounded so a stuck launch doesn't poll forever.
+    private func waitForClaudeLaunched(terminalID: UUID, polls: Int, then: @escaping () -> Void) {
+        if appState.terminalReadiness[terminalID] == .claudeLaunched {
+            then()
+            return
+        }
+        guard polls < maxLaunchWaitPolls else {
+            NSLog("[JobScheduler] gave up waiting for claude launch on \(terminalID)")
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+            self?.waitForClaudeLaunched(terminalID: terminalID, polls: polls + 1, then: then)
+        }
+    }
+
+    /// Send prompts one at a time, waiting `promptGap` before each so they don't
+    /// collide with Claude still processing the previous one. Stops if the
+    /// terminal disappears (e.g. the session was deleted).
+    private func sendSequentially(_ prompts: [String], terminalID: UUID) {
+        guard !prompts.isEmpty else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + promptGap) { [weak self] in
+            guard let self else { return }
+            guard let terminal = self.appState.terminals.values
+                .flatMap({ $0 })
+                .first(where: { $0.id == terminalID }) else {
+                NSLog("[JobScheduler] terminal \(terminalID) gone; stopping prompt delivery")
+                return
+            }
+            TerminalRouter.send(terminal, text: prompts[0] + "\n")
+            self.sendSequentially(Array(prompts.dropFirst()), terminalID: terminalID)
+        }
+    }
+}

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import CrowCore
+import CrowGit
 import CrowPersistence
 import CrowTerminal
 
@@ -404,18 +405,19 @@ final class SessionService {
         let routedTerminal: SessionTerminal? = sessionID.flatMap { sid in
             appState.terminals[sid]?.first(where: { $0.id == terminalID })
         }
-        // Review-kind sessions dispatch their `/crow-review-pr` prompt on first
-        // launch only — on subsequent app restarts, fall through to
+        // Review- and job-kind sessions dispatch their initial prompt file on
+        // first launch only — on subsequent app restarts, fall through to
         // `claude --continue` so the existing conversation resumes instead of
-        // re-running the entire review (CROW-224).
+        // re-running the prompt (CROW-224, CROW-317). `reviewPromptDispatched`
+        // is reused as the generic "initial prompt dispatched" gate.
         var reviewPromptJustDispatched = false
         let claudeText: String = {
             if let sessionID,
                let session = appState.sessions.first(where: { $0.id == sessionID }),
-               session.kind == .review,
                !session.reviewPromptDispatched,
+               let promptFile = Self.initialPromptFileName(for: session.kind),
                let worktree = appState.primaryWorktree(for: sessionID) {
-                let promptPath = (worktree.worktreePath as NSString).appendingPathComponent(".crow-review-prompt.md")
+                let promptPath = (worktree.worktreePath as NSString).appendingPathComponent(promptFile)
                 reviewPromptJustDispatched = true
                 return "\(envPrefix)\(claudePath)\(rcArgs) \"$(cat \(promptPath))\"\n"
             } else {
@@ -1248,6 +1250,128 @@ final class SessionService {
 
         NSLog("[SessionService] Created review session '\(session.name)' for \(prURL)")
         return session.id
+    }
+
+    // MARK: - Scheduled Jobs (CROW-317)
+
+    /// File name holding the initial prompt for a session kind that auto-dispatches
+    /// one on first launch. `nil` for kinds that resume with `--continue` only.
+    private static func initialPromptFileName(for kind: SessionKind) -> String? {
+        switch kind {
+        case .review: return ".crow-review-prompt.md"
+        case .job: return ".crow-job-prompt.md"
+        case .work: return nil
+        }
+    }
+
+    /// Run a scheduled job: create a fresh worktree + session + managed Claude
+    /// terminal in the job's scoped repo and arm auto-launch so the first prompt
+    /// dispatches once the shell is ready.
+    ///
+    /// Mirrors `createReviewSession`, but the worktree is a real git worktree off
+    /// the repo's default branch (via `GitManager`) rather than a clone. The
+    /// returned terminal id lets the caller (`JobScheduler`) deliver any
+    /// remaining prompts after launch. Returns `nil` if the repo is missing or
+    /// the worktree can't be created.
+    func runJob(_ job: JobConfig, devRoot: String) async -> (sessionID: UUID, terminalID: UUID)? {
+        guard let firstPrompt = job.prompts.first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            NSLog("[SessionService] Job '\(job.name)' has no prompts; skipping")
+            return nil
+        }
+
+        let workspacePath = (devRoot as NSString).appendingPathComponent(job.workspace)
+        let repoPath = (workspacePath as NSString).appendingPathComponent(job.repo)
+        let gitDir = (repoPath as NSString).appendingPathComponent(".git")
+        guard FileManager.default.fileExists(atPath: gitDir) else {
+            NSLog("[SessionService] Job '\(job.name)': repo not found at \(repoPath)")
+            return nil
+        }
+
+        let slug = Self.slugify(job.name)
+        let stamp = Self.runStamp()
+        let branch = "feature/job-\(slug)-\(stamp)"
+        let worktreePath = (workspacePath as NSString)
+            .appendingPathComponent("\(job.repo)-job-\(slug)-\(stamp)")
+
+        // Create the worktree on disk (fetch + new branch off default + retry).
+        let gitManager = GitManager(config: WorkspaceConfig(
+            devRoot: devRoot, workspaces: [:], defaults: WorkspaceDefaults()
+        ))
+        do {
+            try await gitManager.createWorktree(
+                repoPath: repoPath, worktreePath: worktreePath, branch: branch
+            )
+        } catch {
+            NSLog("[SessionService] Job '\(job.name)': createWorktree failed: \(error.localizedDescription)")
+            return nil
+        }
+
+        // Write the first prompt to the file launchClaude reads on first launch.
+        let promptPath = (worktreePath as NSString).appendingPathComponent(".crow-job-prompt.md")
+        try? firstPrompt.write(toFile: promptPath, atomically: true, encoding: .utf8)
+
+        let session = Session(
+            name: "job-\(slug)-\(stamp)",
+            kind: .job
+        )
+        let worktree = SessionWorktree(
+            sessionID: session.id,
+            repoName: job.repo,
+            repoPath: repoPath,
+            worktreePath: worktreePath,
+            branch: branch,
+            isPrimary: true
+        )
+        let terminal = SessionTerminal(
+            sessionID: session.id,
+            name: "Claude Code",
+            cwd: worktreePath,
+            isManaged: true
+        )
+
+        // Backend dispatch — starts the surface / tmux window and tracks readiness.
+        let preparedTerminal = prepareTerminal(terminal, trackReadiness: true)
+
+        appState.sessions.append(session)
+        appState.worktrees[session.id] = [worktree]
+        appState.terminals[session.id] = [preparedTerminal]
+        appState.terminalReadiness[preparedTerminal.id] = .uninitialized
+        appState.autoLaunchTerminals.insert(preparedTerminal.id)
+
+        store.mutate { data in
+            data.sessions.append(session)
+            data.worktrees.append(worktree)
+            data.terminals.append(preparedTerminal)
+        }
+
+        NSLog("[SessionService] Job '\(job.name)': created session '\(session.name)' at \(worktreePath)")
+        return (session.id, preparedTerminal.id)
+    }
+
+    /// A filesystem/branch-safe slug derived from a job name.
+    private static func slugify(_ name: String) -> String {
+        let lowered = name.lowercased()
+        var slug = ""
+        var lastWasDash = false
+        for scalar in lowered.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                slug.unicodeScalars.append(scalar)
+                lastWasDash = false
+            } else if !lastWasDash {
+                slug.append("-")
+                lastWasDash = true
+            }
+        }
+        slug = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return slug.isEmpty ? "job" : String(slug.prefix(40))
+    }
+
+    /// A compact `yyyyMMdd-HHmmss` timestamp that makes each run's branch/worktree unique.
+    private static func runStamp() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter.string(from: Date())
     }
 
     // MARK: - Review Prompt


### PR DESCRIPTION
Closes #317

## Summary
Adds **Crow Jobs**: named, repo-scoped sets of prompts that fire automatically on a schedule. Jobs live in a new **Settings → Jobs** tab, persist in `{devRoot}/.claude/config.json`, and can be enabled/disabled with last-run / next-run shown in the UI.

When a job fires, the scheduler creates a **fresh worktree + session + Claude Code terminal** in the scoped repo (off `origin/main`) and sends the job's prompts in order.

## What's included
- **Model** (`CrowCore`): `JobConfig` + `JobSchedule` (interval **or** daily-at-`HH:MM` on selected weekdays), forward-compatible `Codable`; added `jobs` to `AppConfig`; new `SessionKind.job`.
- **Scheduler** (`JobScheduler`): a `Timer`-driven evaluator modeled on `IssueTracker`. Fires due jobs, persists `lastRunAt` (so restarts don't replay), and delivers follow-up prompts once the terminal reports `.claudeLaunched`. Wired into `AppDelegate` (start in `launchMainApp`, stop on terminate).
- **Session** (`SessionService.runJob`): mirrors `createReviewSession` — creates a real git worktree via `GitManager.createWorktree`, writes the first prompt to `.crow-job-prompt.md`, builds a `.job` session + managed terminal, and arms auto-launch. `launchClaude` generalized to dispatch the initial prompt file for `.job` (and `.review`) kinds.
- **UI**: Settings **Jobs** tab + `JobFormView` (workspace/repo pickers, editable prompt list, interval/daily schedule editor, enable toggle), mirroring `WorkspaceFormView`.

## Design decisions
- **Schedule**: interval or daily-at-time (no raw cron parser — covers the common cases with a validatable form).
- **Worktree**: fresh worktree + session per run, matching the normal session pattern; runs accumulate as ordinary sessions you can review and clean up (existing `CleanupConfig` applies).
- Multi-prompt delivery is best-effort timed sends (first prompt launches Claude; the rest follow spaced by a fixed gap).

## Acceptance criteria
- [x] Define a repo-scoped job of one or more prompts on a schedule from Settings → Jobs.
- [x] The job fires on schedule, launches Claude Code in the scoped repo, and sends the prompt(s).
- [x] Jobs persist across app restarts and can be enabled/disabled.

## Testing
- New `JobConfigTests`: `JobConfig`/`JobSchedule` round-trip (interval + daily), `nextRunDate` for interval and weekday skipping, forward-compat decode (old config → `jobs: []`), name validation.
- `swift build` (arm64) succeeds; full test suites pass: **CrowCore 177**, **CrowUI 31**, root **113**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)