### PR TITLE
Run Manager session on the tmux backend

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -406,11 +406,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.onWorkOnIssue = { [weak self] issueURL in
             guard let self, let managerTerminals = self.appState.terminals[AppState.managerSessionID],
                   let managerTerminal = managerTerminals.first else { return }
-            // Type the /crow-workspace command into the Manager terminal
-            TerminalManager.shared.send(
-                id: managerTerminal.id,
-                text: "/crow-workspace \(issueURL)\n"
-            )
+            // Type the /crow-workspace command into the Manager terminal.
+            // Route through TerminalRouter so it reaches the Manager regardless
+            // of backend (Ghostty or tmux, #314).
+            TerminalRouter.send(managerTerminal, text: "/crow-workspace \(issueURL)\n")
             // Switch to Manager tab
             self.appState.selectedSessionID = AppState.managerSessionID
         }
@@ -420,10 +419,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self, let managerTerminals = self.appState.terminals[AppState.managerSessionID],
                   let managerTerminal = managerTerminals.first else { return }
             let urls = issueURLs.joined(separator: " ")
-            TerminalManager.shared.send(
-                id: managerTerminal.id,
-                text: "/crow-batch-workspace \(urls)\n"
-            )
+            // Route through TerminalRouter so it reaches the Manager regardless
+            // of backend (Ghostty or tmux, #314).
+            TerminalRouter.send(managerTerminal, text: "/crow-batch-workspace \(urls)\n")
             self.appState.selectedSessionID = AppState.managerSessionID
         }
 
@@ -1020,13 +1018,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                             && !cmd.contains("--rc")
                             && !cmd.contains("--remote-control")
                     }
-                    let trackReadiness = isManaged && sessionID != AppState.managerSessionID
-                    // Decide backend at terminal-create time. Manager terminal
-                    // stays on Ghostty for now (special case; migrating it is
-                    // its own follow-up). Everything else honors the flag.
+                    let trackReadiness = isManaged
+                    // Decide backend at terminal-create time. Every session,
+                    // including the Manager (#314), honors the flag.
                     let useTmux = FeatureFlags.tmuxBackend
                         && !TmuxBackend.shared.tmuxBinary.isEmpty
-                        && sessionID != AppState.managerSessionID
                     var terminal = SessionTerminal(
                         sessionID: sessionID,
                         name: terminalName,

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -498,12 +498,19 @@ final class SessionService {
                 sessionName: "Manager",
                 autoPermissionMode: autoMode
             )
-            let terminal = SessionTerminal(
+            let rawTerminal = SessionTerminal(
                 sessionID: managerID,
                 name: "Manager",
                 cwd: devRoot,
                 command: managerCommand
             )
+
+            // Route through the same backend-selection path as work sessions
+            // (#314). On tmux this registers a window and pastes the `claude`
+            // command into it; on Ghostty it pre-initializes the offscreen
+            // surface. `trackReadiness: false` matches the Manager's
+            // command-launches-claude model — no readiness/launchClaude flow.
+            let terminal = prepareTerminal(rawTerminal, trackReadiness: false)
             appState.terminals[managerID] = [terminal]
 
             store.mutate { data in
@@ -515,9 +522,6 @@ final class SessionService {
             if rcEnabled {
                 appState.remoteControlActiveTerminals.insert(terminal.id)
             }
-
-            // Pre-initialize in offscreen window so Manager terminal starts immediately
-            TerminalManager.shared.preInitialize(id: terminal.id, workingDirectory: devRoot, command: managerCommand)
         }
 
         // Select Manager on launch (selectedSessionID isn't persisted)
@@ -1367,14 +1371,14 @@ final class SessionService {
     /// Decide which backend hosts a brand-new SessionTerminal and prepare it
     /// (register a tmux window or pre-initialize a Ghostty surface). Returns
     /// the (possibly-modified) row with `backend`/`tmuxBinding` set so the
-    /// caller can persist it. The Manager terminal is force-pinned to the
-    /// Ghostty backend until that migration is done as its own follow-up.
+    /// caller can persist it. The Manager terminal goes through this same path
+    /// as every other session (#314); for it, `registerTerminal` pastes the
+    /// stored `claude` command into the tmux window directly.
     @MainActor
     private func prepareTerminal(_ terminal: SessionTerminal, trackReadiness: Bool) -> SessionTerminal {
         var t = terminal
         let useTmux = FeatureFlags.tmuxBackend
             && !TmuxBackend.shared.tmuxBinary.isEmpty
-            && t.sessionID != AppState.managerSessionID
         if useTmux {
             do {
                 let binding = try TmuxBackend.shared.registerTerminal(


### PR DESCRIPTION
Closes #314

## Summary
Routes the Manager session's terminal through the same backend-selection path as work sessions, removing the Manager-specific force-pin to the Ghostty backend. The Manager now honors the tmux backend flag like every other session — so it gets the same persistence/reattach behavior and renders through the shared tmux cockpit surface.

## Changes
- **`prepareTerminal`** (`SessionService.swift`) no longer excludes the Manager from tmux. For the Manager, `TmuxBackend.registerTerminal` pastes the stored `claude` command into the new tmux window directly (`trackReadiness: false`, matching the Manager's command-launches-claude model — no readiness/`launchClaude` flow).
- **`ensureManagerSession`** creates the Manager terminal via `prepareTerminal` and persists the returned backend-tagged row, dropping the direct `TerminalManager.preInitialize` call.
- **`new-terminal` RPC handler** (`AppDelegate.swift`) drops its Manager-specific `useTmux`/`trackReadiness` exclusions, so no separate terminal path remains specific to the Manager.
- **`onWorkOnIssue` / `onBatchWorkOnIssues`** send `/crow-workspace` commands via `TerminalRouter` (backend-aware) so they reach the Manager whether it's on Ghostty or tmux.

## Behavior notes
- Backend choice stays **sticky per persisted terminal row**, consistent with how work-session backends already behave: existing `.ghostty` Manager rows are not migrated; only a newly-created Manager terminal (fresh install / cleared row) gets tmux.
- Reattach on app restart reuses the existing backend-aware rehydrate path — a persisted `.tmux` Manager row re-registers a fresh window and re-pastes its `claude` command, exactly like a work session.
- The `hydrateState` Manager command-rebuild (keeping `--rc` / `--permission-mode auto` in sync) is retained — it's command-string maintenance, not a separate backend path.

## Acceptance criteria
- [x] Manager terminal is created on the tmux backend when the flag is enabled
- [x] No separate/legacy terminal path remains specific to the Manager
- [x] Reattach on restart works for the Manager the same as for work sessions (shared rehydrate path)

## Testing
- `swift build` — clean (full app links).
- `swift test` (root) — 113 tests / 12 suites pass, including `IssueTracker completion decisions` (`managerSessionIsProtected`) and `FeatureFlags tmux backend default`.
- `swift test` (CrowTerminal) — 26 tests / 5 suites pass, including `TmuxBackend integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)