### PR TITLE
Restart Manager session after its process exits

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -43,6 +43,11 @@ public final class AppState {
     /// launch; worker sessions and CLI-spawned terminals are unaffected.
     public var managerAutoPermissionMode: Bool = true
 
+    /// `true` when the Manager's `claude` process has exited (crash, kill, OOM)
+    /// and has not yet been restarted. Drives the "Manager process exited" banner
+    /// and enables the "Restart Manager" action. Reset when the Manager relaunches.
+    public var managerProcessExited: Bool = false
+
     /// Terminal IDs whose Claude Code was launched with `--rc` — drives the
     /// per-session indicator badge. Survives toggle changes so existing sessions
     /// keep showing the badge until they're restarted.
@@ -222,6 +227,10 @@ public final class AppState {
 
     /// Called when the user clicks "Retry" on a failed terminal surface.
     public var onRetryTerminal: ((UUID) -> Void)?  // receives terminal ID
+
+    /// Called to relaunch the Manager's `claude` process after it exited, while
+    /// preserving the Manager session identity. Wired to `SessionService.restartManager`.
+    public var onRestartManager: (() -> Void)?
 
     /// Called when the user clicks "Retry" on a terminal whose tmux readiness
     /// watch timed out before the shell signaled it was interactive.

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
@@ -9,6 +9,12 @@ public final class GhosttyApp {
     private(set) var app: ghostty_app_t?
     private(set) var config: ghostty_config_t?
 
+    /// Fired when a surface's child process exits (Ghostty's
+    /// `GHOSTTY_ACTION_SHOW_CHILD_EXITED`). Delivers the terminal UUID and the
+    /// child's exit code. Used to detect a dead Manager `claude` process so the
+    /// UI can offer a restart. Always invoked on the main actor.
+    public var onChildExited: ((UUID, Int32) -> Void)?
+
     private init() {}
 
     public func initialize() {
@@ -98,6 +104,21 @@ public final class GhosttyApp {
         target: ghostty_target_s,
         action: ghostty_action_s
     ) -> Bool {
+        // The child process backing a surface exited (crash, kill, normal quit).
+        // Map the surface back to its terminal UUID via the userdata pointer we
+        // set in GhosttySurfaceView.createSurface, then notify on the main actor.
+        if action.tag == GHOSTTY_ACTION_SHOW_CHILD_EXITED {
+            if target.tag == GHOSTTY_TARGET_SURFACE,
+               let userdata = ghostty_surface_userdata(target.target.surface) {
+                let exitCode = Int32(bitPattern: action.action.child_exited.exit_code)
+                DispatchQueue.main.async {
+                    let view = Unmanaged<GhosttySurfaceView>.fromOpaque(userdata).takeUnretainedValue()
+                    guard let terminalID = view.terminalID else { return }
+                    GhosttyApp.shared.onChildExited?(terminalID, exitCode)
+                }
+            }
+            return true
+        }
         if !silencedActionTags.contains(UInt32(action.tag.rawValue)) {
             NSLog("[GhosttyApp] Unhandled action: tag=\(action.tag)")
         }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -22,6 +22,11 @@ public final class GhosttySurfaceView: NSView {
     /// Called after createSurface() exhausts its retry budget without producing a surface.
     public var onSurfaceCreationFailed: (() -> Void)?
 
+    /// The terminal UUID this surface backs. Set by `TerminalManager` when the
+    /// view is created so Ghostty's child-exit action callback can map a dead
+    /// surface back to its terminal (see `GhosttyApp.handleAction`).
+    public var terminalID: UUID?
+
     /// The working directory for the shell spawned in this surface.
     public var workingDirectory: String?
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalManager.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalManager.swift
@@ -55,6 +55,7 @@ public final class TerminalManager {
             workingDirectory: workingDirectory,
             command: command
         )
+        view.terminalID = id
         view.onSurfaceCreated = { [weak self] in
             NSLog("[TerminalManager] onSurfaceCreated (offscreen) for \(id)")
             self?.surfaceDidCreate(id: id)
@@ -88,6 +89,7 @@ public final class TerminalManager {
         }
         NSLog("[TerminalManager] surface(for: \(id)) — creating NEW view, setting onSurfaceCreated callback")
         let view = GhosttySurfaceView(frame: .zero, workingDirectory: workingDirectory, command: command)
+        view.terminalID = id
         view.onSurfaceCreated = { [weak self] in
             NSLog("[TerminalManager] onSurfaceCreated callback fired for \(id)")
             self?.surfaceDidCreate(id: id)

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -315,13 +315,40 @@ public struct SessionDetailView: View {
             .id(session.id)
         } else if isManager, let terminal = sessionTerminals.first {
             // Manager session: single terminal, no tab bar
-            TerminalSurfaceView(
-                terminalID: terminal.id,
-                workingDirectory: terminal.cwd,
-                command: terminal.command,
-                backend: terminal.backend
-            )
-            .id(terminal.id)
+            ZStack {
+                TerminalSurfaceView(
+                    terminalID: terminal.id,
+                    workingDirectory: terminal.cwd,
+                    command: terminal.command,
+                    backend: terminal.backend
+                )
+                .id(terminal.id)
+
+                if appState.managerProcessExited {
+                    // The Manager's claude process exited (crash, kill, OOM).
+                    // Offer an in-place restart that keeps the session identity.
+                    VStack(spacing: 10) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 28))
+                            .foregroundStyle(.orange)
+                        Text("Manager process exited")
+                            .font(.headline)
+                        Text("The Manager's Claude Code process is no longer running. Restart it to continue orchestrating workspaces.")
+                            .font(.caption)
+                            .foregroundStyle(CorveilTheme.textMuted)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Button("Restart Manager") {
+                            appState.onRestartManager?()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+                    }
+                    .padding(24)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(CorveilTheme.bgDeep.opacity(0.95))
+                }
+            }
         } else {
             VStack(spacing: 0) {
                 TerminalTabBar(

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -340,6 +340,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Ensure manager session exists
         service.ensureManagerSession(devRoot: devRoot)
 
+        // Detect a dead Manager process: Ghostty fires SHOW_CHILD_EXITED when a
+        // surface's child exits. If it's the Manager terminal, surface the
+        // "Manager process exited" banner so the user can restart it in place.
+        GhosttyApp.shared.onChildExited = { [weak self] terminalID, _ in
+            guard let self else { return }
+            let managerID = AppState.managerSessionID
+            if self.appState.terminals(for: managerID).contains(where: { $0.id == terminalID }) {
+                NSLog("[Crow] Manager process exited (terminal %@)", terminalID.uuidString)
+                self.appState.managerProcessExited = true
+            }
+        }
+
         // Wire closures for UI actions
         appState.onDeleteSession = { [weak self, weak service] id in
             self?.notificationManager?.clearSession(id)
@@ -364,6 +376,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         appState.onRetryTerminal = { [weak service] terminalID in
             service?.retryTerminal(terminalID: terminalID)
+        }
+
+        appState.onRestartManager = { [weak service] in
+            service?.restartManager(devRoot: devRoot)
         }
 
         appState.onRetryReadiness = { [weak service] terminalID in
@@ -697,6 +713,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         settingsItem.target = self
         appMenu.addItem(settingsItem)
         appMenu.addItem(NSMenuItem.separator())
+        let restartManagerItem = NSMenuItem(title: "Restart Manager", action: #selector(restartManager), keyEquivalent: "")
+        restartManagerItem.target = self
+        appMenu.addItem(restartManagerItem)
+        appMenu.addItem(NSMenuItem.separator())
         appMenu.addItem(withTitle: "Hide Crow", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h")
         let hideOthersItem = NSMenuItem(title: "Hide Others", action: #selector(NSApplication.hideOtherApplications(_:)), keyEquivalent: "h")
         hideOthersItem.keyEquivalentModifierMask = [.command, .option]
@@ -708,6 +728,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mainMenu.addItem(appMenuItem)
 
         NSApp.mainMenu = mainMenu
+    }
+
+    @objc private func restartManager() {
+        appState.onRestartManager?()
     }
 
     @objc private func showAbout() {

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -526,6 +526,36 @@ final class SessionService {
         }
     }
 
+    /// Relaunch the Manager's `claude` process in place after it has exited
+    /// (crash, kill, OOM). The Manager session row and `AppState.managerSessionID`
+    /// are preserved — only the dead terminal/surface is torn down and replaced.
+    ///
+    /// Tears down the existing Ghostty surface, drops the stale terminal row from
+    /// both memory and disk, clears the exited flag, then re-runs
+    /// `ensureManagerSession` which recreates a fresh Manager terminal (new
+    /// terminal UUID) using the current remote-control / auto-permission args.
+    func restartManager(devRoot: String) {
+        let managerID = AppState.managerSessionID
+        let terminals = appState.terminals(for: managerID)
+        // Fall back to a dead terminal's cwd if the caller's devRoot is empty.
+        let resolvedDevRoot = devRoot.isEmpty ? (terminals.first?.cwd ?? devRoot) : devRoot
+
+        for terminal in terminals {
+            TerminalRouter.destroy(terminal)
+        }
+        appState.terminals.removeValue(forKey: managerID)
+        appState.remoteControlActiveTerminals.subtract(terminals.map(\.id))
+        store.mutate { data in
+            data.terminals.removeAll { $0.sessionID == managerID }
+        }
+
+        appState.managerProcessExited = false
+        NSLog("[CrowTelemetry manager:restart]")
+
+        // Session row still exists, so this only recreates the terminal.
+        ensureManagerSession(devRoot: resolvedDevRoot)
+    }
+
     // MARK: - Delete Session
 
     /// Snapshot of one worktree's cleanup work, captured on the MainActor and


### PR DESCRIPTION
Closes #315

## Problem
The Manager session runs a single `claude` process launched once in `SessionService.ensureManagerSession`. If that process died (crash, manual kill, OOM) there was **no detection and no recovery** — the terminal tab remained but input silently failed, and the only fix was relaunching the whole app.

## Approach
- **Detect** the exit via Ghostty's `GHOSTTY_ACTION_SHOW_CHILD_EXITED` action. The dead surface is mapped back to its terminal UUID (via `ghostty_surface_userdata`), and if it's the Manager terminal, `AppState.managerProcessExited` is set.
- **Surface** it in the UI: a "Manager process exited" banner over the Manager terminal with a **Restart Manager** button, plus a "Restart Manager" item in the app menu (reachable from any tab).
- **Restart** in place: `SessionService.restartManager(devRoot:)` tears down the dead Ghostty surface, drops the stale terminal row (memory + disk), and re-runs `ensureManagerSession` to recreate a fresh Manager terminal with the current `--rc` / auto-permission args. The Manager session row and `AppState.managerSessionID` are preserved.

Restart is **manual-only** (no auto-respawn) to avoid crash-loops when claude fails repeatedly on launch.

## Changes
- `GhosttyApp`: handle `SHOW_CHILD_EXITED`, fire `onChildExited(terminalID, exitCode)` on the main actor (mirrors the existing `wakeup_cb` pattern)
- `GhosttySurfaceView` / `TerminalManager`: tag each surface with its `terminalID`
- `AppState`: `managerProcessExited` flag + `onRestartManager` callback
- `SessionService`: `restartManager(devRoot:)`
- `AppDelegate`: wire detection + restart + "Restart Manager" menu item
- `SessionDetailView`: dead-Manager banner with a Restart button

## Testing
- `CrowCore` builds cleanly (`swift build --package-path Packages/CrowCore`).
- The Ghostty/UI targets could not be linked on this dev host (x86_64) because GhosttyKit ships an arm64-only slice — relying on CI (arm64) to fully type-check/link. The Ghostty change deliberately mirrors the proven `wakeup_cb` callback pattern.
- Manual verification plan: kill the Manager's claude process → banner appears → click **Restart Manager** (and the menu item) → fresh claude launches in the devRoot with the same args, banner clears, session identity unchanged, `crow send` works again; other sessions' terminals untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)