### PR TITLE
Support multiple Manager sessions

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
@@ -6,15 +6,26 @@ import Foundation
 
 /// Create a new development session.
 ///
-/// Returns the new session's UUID and name as JSON.
+/// Returns the new session's UUID and name as JSON. Pass `--kind manager` to
+/// create a Manager (orchestration) session with its own Claude Code terminal
+/// running in the devRoot.
 public struct NewSession: ParsableCommand {
     public static let configuration = CommandConfiguration(commandName: "new-session", abstract: "Create a new session")
     @Option(name: .long, help: "Session name") var name: String
+    @Option(name: .long, help: "Session kind: work (default), review, or manager") var kind: String?
 
     public init() {}
 
+    public func validate() throws {
+        if let kind, !["work", "review", "manager"].contains(kind) {
+            throw ValidationError("kind must be one of: work, review, manager")
+        }
+    }
+
     public func run() throws {
-        let result = try rpc("new-session", params: ["name": .string(name)])
+        var params: [String: JSONValue] = ["name": .string(name)]
+        if let kind { params["kind"] = .string(kind) }
+        let result = try rpc("new-session", params: params)
         printJSON(result)
     }
 }

--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SessionCommands.swift
@@ -8,17 +8,19 @@ import Foundation
 ///
 /// Returns the new session's UUID and name as JSON. Pass `--kind manager` to
 /// create a Manager (orchestration) session with its own Claude Code terminal
-/// running in the devRoot.
+/// running in the devRoot. The supplied name is used verbatim (the caller is
+/// responsible for uniqueness — sessions are identified by UUID, not name).
+/// Review and job sessions are created through their own setup flows, not here.
 public struct NewSession: ParsableCommand {
     public static let configuration = CommandConfiguration(commandName: "new-session", abstract: "Create a new session")
     @Option(name: .long, help: "Session name") var name: String
-    @Option(name: .long, help: "Session kind: work (default), review, or manager") var kind: String?
+    @Option(name: .long, help: "Session kind: work (default) or manager") var kind: String?
 
     public init() {}
 
     public func validate() throws {
-        if let kind, !["work", "review", "manager"].contains(kind) {
-            throw ValidationError("kind must be one of: work, review, manager")
+        if let kind, !["work", "manager"].contains(kind) {
+            throw ValidationError("kind must be one of: work, manager")
         }
     }
 

--- a/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
@@ -20,6 +20,26 @@ private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     }
 }
 
+@Test func newSessionParsesManagerKind() throws {
+    let cmd = try NewSession.parse(["--name", "Manager 2", "--kind", "manager"])
+    #expect(cmd.name == "Manager 2")
+    #expect(cmd.kind == "manager")
+    try cmd.validate()
+}
+
+@Test func newSessionDefaultsToNoKind() throws {
+    let cmd = try NewSession.parse(["--name", "feature"])
+    #expect(cmd.kind == nil)
+    try cmd.validate()
+}
+
+@Test func newSessionRejectsInvalidKind() {
+    // ArgumentParser runs validate() during parse, so an invalid kind throws here.
+    #expect(throws: (any Error).self) {
+        _ = try NewSession.parse(["--name", "x", "--kind", "bogus"])
+    }
+}
+
 @Test func setStatusParsesArgs() throws {
     let cmd = try SetStatus.parse(["--session", validUUID, "active"])
     #expect(cmd.session == validUUID)

--- a/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
+++ b/Packages/CrowCLI/Tests/CrowCLITests/CommandParsingTests.swift
@@ -40,6 +40,16 @@ private let validUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     }
 }
 
+@Test func newSessionRejectsReviewAndJobKinds() {
+    // Review and job sessions need dedicated setup flows, so new-session only
+    // accepts work and manager.
+    for kind in ["review", "job"] {
+        #expect(throws: (any Error).self) {
+            _ = try NewSession.parse(["--name", "x", "--kind", kind])
+        }
+    }
+}
+
 @Test func setStatusParsesArgs() throws {
     let cmd = try SetStatus.parse(["--session", validUUID, "active"])
     #expect(cmd.session == validUUID)

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -82,8 +82,22 @@ public final class AppState {
     /// Fixed UUID for the global terminals page.
     nonisolated public static let globalTerminalSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
 
+    /// The primary (back-compat) Manager session identified by the well-known UUID.
     public var managerSession: Session? {
         sessions.first { $0.id == Self.managerSessionID }
+    }
+
+    /// All Manager-kind sessions (primary + any additional ones).
+    public var managerSessions: [Session] {
+        sessions.filter { $0.isManager }
+    }
+
+    /// Whether the session with the given id is a Manager. Falls back to the
+    /// well-known primary UUID when the session isn't loaded yet (e.g. during
+    /// terminal creation before the session row is present).
+    public func isManagerSession(_ id: UUID) -> Bool {
+        if let session = sessions.first(where: { $0.id == id }) { return session.isManager }
+        return id == Self.managerSessionID
     }
 
     // MARK: - Issue Tracking
@@ -210,6 +224,9 @@ public final class AppState {
         _sessionState.removeValue(forKey: sessionID)
     }
 
+    /// Called when the user clicks the sidebar "+" to spawn a new Manager session.
+    public var onCreateManager: (() -> Void)?
+
     /// Called when user clicks "Work on" for an assigned issue.
     public var onWorkOnIssue: ((String) -> Void)?  // receives issue URL
 
@@ -317,11 +334,11 @@ public final class AppState {
     }
 
     public var inReviewSessions: [Session] {
-        sessions.filter { $0.status == .inReview && $0.id != Self.managerSessionID }
+        sessions.filter { $0.status == .inReview && !$0.isManager }
     }
 
     public var completedSessions: [Session] {
-        sessions.filter { $0.status == .completed || $0.status == .archived }
+        sessions.filter { ($0.status == .completed || $0.status == .archived) && !$0.isManager }
     }
 
     public var reviewSessions: [Session] {

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -330,7 +330,7 @@ public final class AppState {
     }
 
     public var activeSessions: [Session] {
-        sessions.filter { $0.status == .active && $0.id != Self.managerSessionID && $0.kind == .work }
+        sessions.filter { $0.status == .active && $0.kind == .work }
     }
 
     public var inReviewSessions: [Session] {

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -92,9 +92,11 @@ public final class AppState {
         sessions.filter { $0.isManager }
     }
 
-    /// Whether the session with the given id is a Manager. Falls back to the
-    /// well-known primary UUID when the session isn't loaded yet (e.g. during
-    /// terminal creation before the session row is present).
+    /// Whether the session with the given id is a Manager. When the session row
+    /// isn't loaded yet (e.g. during terminal creation before it's inserted) the
+    /// fallback only recognizes the well-known *primary* UUID — a not-yet-loaded
+    /// non-primary manager id returns `false`, so callers must not rely on this
+    /// for non-primary managers pre-load.
     public func isManagerSession(_ id: UUID) -> Bool {
         if let session = sessions.first(where: { $0.id == id }) { return session.isManager }
         return id == Self.managerSessionID

--- a/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
@@ -1,10 +1,12 @@
 import Foundation
 
-/// Whether a session is a normal work session or a PR review session.
+/// What kind of session this is. Multiple `.manager` sessions can coexist;
+/// the one with `AppState.managerSessionID` is the back-compat "primary".
 public enum SessionKind: String, Codable, Sendable {
     case work    // Normal development session (default)
     case review  // PR review session
     case job     // Session spun up by a scheduled job (CROW-317)
+    case manager // Orchestration session running Claude Code in the devRoot
 }
 
 /// Status of a development session.

--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -28,6 +28,10 @@ public struct Session: Identifiable, Codable, Sendable {
     // run; the auto-merge watcher skips this session on subsequent polls.
     public var autoMergeEnabledAt: Date?
 
+    /// Whether this session is a Manager (orchestration) session. Managers run
+    /// Claude Code in the devRoot and are excluded from PR/issue tracking.
+    public var isManager: Bool { kind == .manager }
+
     public init(
         id: UUID = UUID(),
         name: String,

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppStateLookupTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppStateLookupTests.swift
@@ -105,6 +105,44 @@ import Testing
     #expect(appState.labels(forSession: session).isEmpty)
 }
 
+// MARK: - Manager Session Lookups
+
+@MainActor @Test func managerSessionsIncludesPrimaryAndAdditional() {
+    let appState = AppState()
+    let primary = Session(id: AppState.managerSessionID, name: "Manager", kind: .manager)
+    let extra = Session(name: "Manager 2", kind: .manager)
+    let work = Session(name: "work")
+    appState.sessions = [primary, extra, work]
+
+    #expect(Set(appState.managerSessions.map(\.id)) == [primary.id, extra.id])
+    #expect(appState.managerSession?.id == primary.id)
+}
+
+@MainActor @Test func isManagerSessionRecognizesAllManagers() {
+    let appState = AppState()
+    let primary = Session(id: AppState.managerSessionID, name: "Manager", kind: .manager)
+    let extra = Session(name: "Manager 2", kind: .manager)
+    let work = Session(name: "work")
+    appState.sessions = [primary, extra, work]
+
+    #expect(appState.isManagerSession(primary.id))
+    #expect(appState.isManagerSession(extra.id))
+    #expect(appState.isManagerSession(work.id) == false)
+    // Falls back to the well-known UUID when the session isn't loaded yet.
+    #expect(appState.isManagerSession(AppState.managerSessionID))
+}
+
+@MainActor @Test func managerSessionsExcludedFromActiveAndCompleted() {
+    let appState = AppState()
+    let manager = Session(name: "Manager 2", status: .active, kind: .manager)
+    let completedManager = Session(name: "Manager 3", status: .completed, kind: .manager)
+    let work = Session(name: "work", status: .active)
+    appState.sessions = [manager, completedManager, work]
+
+    #expect(appState.activeSessions.map(\.id) == [work.id])
+    #expect(appState.completedSessions.isEmpty)
+}
+
 // MARK: - LabelInfo Tests
 
 @Test func labelInfoCodableRoundTripWithColor() throws {

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
@@ -83,7 +83,27 @@ import Testing
     #expect(decoded.lastReviewedHeadSha == "deadbeef")
 }
 
+@Test func sessionManagerKindRoundTrip() throws {
+    let session = Session(name: "Manager 2", kind: .manager)
+    #expect(session.isManager)
+    let data = try JSONEncoder().encode(session)
+    let decoded = try JSONDecoder().decode(Session.self, from: data)
+    #expect(decoded.kind == .manager)
+    #expect(decoded.isManager)
+}
+
+@Test func sessionWorkKindIsNotManager() {
+    #expect(Session(name: "work").isManager == false)
+    #expect(Session(name: "review", kind: .review).isManager == false)
+}
+
 // MARK: - Enum Raw Values
+
+@Test func sessionKindRawValues() {
+    #expect(SessionKind.work.rawValue == "work")
+    #expect(SessionKind.review.rawValue == "review")
+    #expect(SessionKind.manager.rawValue == "manager")
+}
 
 @Test func sessionStatusRawValues() {
     #expect(SessionStatus.active.rawValue == "active")

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -28,7 +28,7 @@ public struct SessionDetailView: View {
     public var body: some View {
         VStack(spacing: 0) {
             sessionHeader
-            if session.id == AppState.managerSessionID {
+            if session.isManager {
                 SectionHelpBanner(
                     description: "Orchestration hub for Crow workspaces. Use /crow-workspace to set up new sessions with worktrees, ticket tracking, and auto-launched Claude Code.",
                     storageKey: "helpDismissed_manager"
@@ -97,7 +97,7 @@ public struct SessionDetailView: View {
             }
 
             // Row 3: Links + Actions (only if there's content to show)
-            if session.ticketURL != nil || !sessionLinks.isEmpty || session.id != AppState.managerSessionID {
+            if session.ticketURL != nil || !sessionLinks.isEmpty || !session.isManager {
                 Divider().overlay(CorveilTheme.borderSubtle).padding(.horizontal, 16)
 
                 HStack(spacing: 8) {
@@ -128,7 +128,7 @@ public struct SessionDetailView: View {
                 Spacer()
 
                 // Action buttons (not for Manager)
-                if session.id != AppState.managerSessionID {
+                if !session.isManager {
                     quickActionButtons
 
                     if appState.vsCodeAvailable, primaryWorktree != nil {
@@ -306,7 +306,7 @@ public struct SessionDetailView: View {
     @ViewBuilder
     private var terminalArea: some View {
         let sessionTerminals = appState.terminals(for: session.id)
-        let isManager = session.id == AppState.managerSessionID
+        let isManager = session.isManager
         if sessionTerminals.isEmpty {
             TerminalSurfaceView(
                 terminalID: session.id,

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -84,6 +84,23 @@ public struct SessionListView: View {
                     .listRowBackground(Color.clear)
             }
 
+            // Additional (non-primary) Manager sessions, each deletable.
+            let extraManagers = appState.managerSessions.filter { $0.id != AppState.managerSessionID }
+            ForEach(extraManagers) { session in
+                ManagerSessionRow(session: session, appState: appState)
+                    .tag(session.id)
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            sessionToDelete = session
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .disabled(appState.isDeletingSession[session.id] == true)
+                    }
+            }
+
             // Active sessions
             if !appState.activeSessions.isEmpty {
                 SectionDivider(
@@ -387,6 +404,27 @@ struct ManagerAllowListRow: View {
             ) {
                 appState.selectedSessionID = AppState.allowListSessionID
             }
+
+            Button {
+                appState.onCreateManager?()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(CorveilTheme.goldDark)
+                    .frame(width: 28)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(CorveilTheme.bgSurface)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .strokeBorder(CorveilTheme.goldDark.opacity(0.3), lineWidth: 1)
+                            )
+                    )
+            }
+            .buttonStyle(.plain)
+            .help("New Manager session")
+            .accessibilityLabel("New Manager session")
         }
         .padding(.vertical, 2)
     }
@@ -411,6 +449,60 @@ struct ManagerAllowListRow: View {
                 )
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Manager Session Row
+
+/// Sidebar row for an additional (non-primary) Manager session. Renders a
+/// full-width selectable button with the manager's name, a remote-control
+/// badge, and a deletion spinner when cleanup is in flight.
+struct ManagerSessionRow: View {
+    let session: Session
+    @Bindable var appState: AppState
+
+    private var isActive: Bool { appState.selectedSessionID == session.id }
+    private var isDeleting: Bool { appState.isDeletingSession[session.id] == true }
+
+    var body: some View {
+        Button {
+            appState.selectedSessionID = session.id
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "person.2.fill")
+                    .font(.system(size: 11))
+                Text(session.name)
+                    .font(.system(size: 12, weight: .bold))
+                    .lineLimit(1)
+                Spacer()
+                if isDeleting {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(
+                                isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
+                                lineWidth: 1
+                            )
+                    )
+            )
+            .overlay(alignment: .topTrailing) {
+                if appState.isRemoteControlActive(sessionID: session.id) {
+                    RemoteControlBadge(compact: true)
+                        .padding(4)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 2)
     }
 }
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -419,6 +419,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             service?.openTerminal(sessionID: sessionID)
         }
 
+        // Wire create-manager action — spawns an additional Manager session
+        // (auto-named "Manager N") with its own Claude-Code terminal in the devRoot.
+        appState.onCreateManager = { [weak self, weak service] in
+            guard let self, let service else { return }
+            let name = "Manager \(self.appState.managerSessions.count + 1)"
+            let id = service.createManagerSession(name: name, cwd: devRoot)
+            self.appState.selectedSessionID = id
+        }
+
         // Wire "Work on" issue action — sends issue URL to Manager terminal
         appState.onWorkOnIssue = { [weak self] issueURL in
             guard let self, let managerTerminals = self.appState.terminals[AppState.managerSessionID],
@@ -889,8 +898,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard AppDelegate.isValidSessionName(name) else {
                     throw RPCError.invalidParams("Invalid session name (max \(AppDelegate.maxSessionNameLength) chars, no control characters)")
                 }
+                let kindStr = params["kind"]?.stringValue
+                guard kindStr == nil || SessionKind(rawValue: kindStr!) != nil else {
+                    throw RPCError.invalidParams("Invalid kind (expected work, review, or manager)")
+                }
+                let kind = kindStr.flatMap(SessionKind.init(rawValue:)) ?? .work
                 return await MainActor.run {
-                    let session = Session(name: name)
+                    // Manager sessions get their own Claude-Code terminal in the
+                    // devRoot, mirroring the primary Manager.
+                    if kind == .manager {
+                        let id = capturedService.createManagerSession(name: name, cwd: devRoot)
+                        let createdName = capturedAppState.sessions.first(where: { $0.id == id })?.name ?? name
+                        return ["session_id": .string(id.uuidString), "name": .string(createdName)]
+                    }
+                    let session = Session(name: name, kind: kind)
                     capturedAppState.sessions.append(session)
                     capturedStore.mutate { $0.sessions.append(session) }
                     return ["session_id": .string(session.id.uuidString), "name": .string(session.name)]

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -917,20 +917,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard AppDelegate.isValidSessionName(name) else {
                     throw RPCError.invalidParams("Invalid session name (max \(AppDelegate.maxSessionNameLength) chars, no control characters)")
                 }
+                // Only work and manager sessions can be created here. Review and
+                // job sessions need their dedicated setup (worktree, prompt files,
+                // scheduler) and would be malformed if created bare via this path.
                 let kindStr = params["kind"]?.stringValue
-                guard kindStr == nil || SessionKind(rawValue: kindStr!) != nil else {
-                    throw RPCError.invalidParams("Invalid kind (expected work, review, or manager)")
+                guard kindStr == nil || kindStr == "work" || kindStr == "manager" else {
+                    throw RPCError.invalidParams("Invalid kind (expected work or manager)")
                 }
-                let kind = kindStr.flatMap(SessionKind.init(rawValue:)) ?? .work
+                let isManagerKind = kindStr == "manager"
                 return await MainActor.run {
                     // Manager sessions get their own Claude-Code terminal in the
                     // devRoot, mirroring the primary Manager.
-                    if kind == .manager {
+                    if isManagerKind {
                         let id = capturedService.createManagerSession(name: name, cwd: devRoot)
                         let createdName = capturedAppState.sessions.first(where: { $0.id == id })?.name ?? name
                         return ["session_id": .string(id.uuidString), "name": .string(createdName)]
                     }
-                    let session = Session(name: name, kind: kind)
+                    let session = Session(name: name, kind: .work)
                     capturedAppState.sessions.append(session)
                     capturedStore.mutate { $0.sessions.append(session) }
                     return ["session_id": .string(session.id.uuidString), "name": .string(session.name)]

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -423,8 +423,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // (auto-named "Manager N") with its own Claude-Code terminal in the devRoot.
         appState.onCreateManager = { [weak self, weak service] in
             guard let self, let service else { return }
-            let name = "Manager \(self.appState.managerSessions.count + 1)"
-            let id = service.createManagerSession(name: name, cwd: devRoot)
+            // Pick the lowest unused "Manager N" so a delete-in-the-middle
+            // doesn't produce a duplicate name.
+            let existingNames = Set(self.appState.managerSessions.map(\.name))
+            var n = 2
+            while existingNames.contains("Manager \(n)") { n += 1 }
+            let id = service.createManagerSession(name: "Manager \(n)", cwd: devRoot)
             self.appState.selectedSessionID = id
         }
 

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -723,7 +723,7 @@ final class IssueTracker {
     /// during the cycle they auto-complete and is preserved thereafter.
     private func collectStalePRURLs(excluding openPRURLs: Set<String>) -> [String] {
         var urls: Set<String> = []
-        for session in appState.sessions where session.id != AppState.managerSessionID {
+        for session in appState.sessions where !session.isManager {
             switch session.status {
             case .active, .paused, .inReview:
                 break
@@ -1289,7 +1289,7 @@ final class IssueTracker {
         let store = JSONStore()
 
         for session in appState.sessions {
-            guard session.id != AppState.managerSessionID else { continue }
+            guard !session.isManager else { continue }
             let wts = appState.worktrees(for: session.id)
             let links = appState.links(for: session.id)
 
@@ -1404,7 +1404,7 @@ final class IssueTracker {
     private func buildReconcileCandidates() -> [ReconcileCandidate] {
         var out: [ReconcileCandidate] = []
         for session in appState.sessions {
-            guard session.id != AppState.managerSessionID else { continue }
+            guard !session.isManager else { continue }
             guard session.status != .archived else { continue }
             guard session.kind == .work else { continue }  // review sessions get PR links at creation
             let links = appState.links(for: session.id)
@@ -1719,7 +1719,7 @@ final class IssueTracker {
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
         var transitions: [PRStatusTransition] = []
-        let sessionsWithPRs = appState.sessions.filter { $0.id != AppState.managerSessionID }
+        let sessionsWithPRs = appState.sessions.filter { !$0.isManager }
         for session in sessionsWithPRs {
             let links = appState.links(for: session.id)
             guard let prLink = links.first(where: { $0.linkType == .pr }) else { continue }
@@ -1844,7 +1844,7 @@ final class IssueTracker {
         guard !viewerPRs.isEmpty else { return }
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
-        for session in appState.sessions where session.id != AppState.managerSessionID {
+        for session in appState.sessions where !session.isManager {
             guard let prLink = appState.links(for: session.id).first(where: { $0.linkType == .pr }) else { continue }
             guard !autoMergeInFlight.contains(prLink.url) else { continue }
             guard let pr = byURL[prLink.url] else { continue }
@@ -2187,7 +2187,7 @@ final class IssueTracker {
         let prsByURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
         let candidateSessions = appState.sessions.filter {
-            $0.id != AppState.managerSessionID &&
+            !$0.isManager &&
             ($0.status == .active || $0.status == .paused || $0.status == .inReview)
         }
         var linksBySessionID: [UUID: [SessionLink]] = [:]
@@ -2273,6 +2273,7 @@ final class IssueTracker {
         let cutoff = now.addingTimeInterval(-Double(retentionHours) * 3600)
         return sessions.compactMap { session in
             guard !protectedSessionIDs.contains(session.id) else { return nil }
+            guard !session.isManager else { return nil }
             guard session.status == .completed || session.status == .archived else { return nil }
             guard session.updatedAt < cutoff else { return nil }
             return session.id

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -36,7 +36,7 @@ final class SessionService {
             appState.links[session.id] = data.links.filter { $0.sessionID == session.id }
 
             var terminals = data.terminals.filter { $0.sessionID == session.id }
-            if session.id != AppState.managerSessionID {
+            if !session.isManager {
                 // Backward-compat migration: if no terminal is marked managed,
                 // heuristically mark the first "Claude Code" terminal.
                 let hasManagedTerminal = terminals.contains { $0.isManaged }
@@ -75,7 +75,7 @@ final class SessionService {
                 let autoMode = appState.managerAutoPermissionMode
                 let managerCommand = claudePath + ClaudeLaunchArgs.argsSuffix(
                     remoteControl: rcEnabled,
-                    sessionName: "Manager",
+                    sessionName: session.name,
                     autoPermissionMode: autoMode
                 )
                 for i in terminals.indices {
@@ -99,7 +99,7 @@ final class SessionService {
             // and tmux's onReadinessChanged) have something to update. The
             // actual trackReadiness/registerTerminal call happens in
             // rehydrateTerminalSurface below.
-            if session.id != AppState.managerSessionID {
+            if !session.isManager {
                 for terminal in terminals where terminal.isManaged {
                     appState.terminalReadiness[terminal.id] = .uninitialized
                     appState.autoLaunchTerminals.insert(terminal.id)
@@ -133,7 +133,7 @@ final class SessionService {
         // call to TmuxBackend.registerTerminal spawns a subprocess) — #293.
         for session in appState.sessions {
             guard let terminals = appState.terminals[session.id] else { continue }
-            let isManagerSession = session.id == AppState.managerSessionID
+            let isManagerSession = session.isManager
             let sid = session.id
             for original in terminals {
                 let trackReadiness = !isManagerSession && original.isManaged
@@ -474,11 +474,24 @@ final class SessionService {
 
     func ensureManagerSession(devRoot: String) {
         let managerID = AppState.managerSessionID
-        if !appState.sessions.contains(where: { $0.id == managerID }) {
+        if let idx = appState.sessions.firstIndex(where: { $0.id == managerID }) {
+            // Migrate a legacy primary Manager (created before SessionKind.manager
+            // existed, so persisted as .work) to the .manager kind so all the
+            // kind-based special-casing recognizes it.
+            if appState.sessions[idx].kind != .manager {
+                appState.sessions[idx].kind = .manager
+                store.mutate { data in
+                    if let i = data.sessions.firstIndex(where: { $0.id == managerID }) {
+                        data.sessions[i].kind = .manager
+                    }
+                }
+            }
+        } else {
             let manager = Session(
                 id: managerID,
                 name: "Manager",
-                status: .active
+                status: .active,
+                kind: .manager
             )
             appState.sessions.insert(manager, at: 0)
 
@@ -491,39 +504,7 @@ final class SessionService {
 
         // Ensure manager has a terminal
         if appState.terminals(for: managerID).isEmpty {
-            // Find the real claude binary (skip CMUX wrapper)
-            let claudePath = Self.findClaudeBinary() ?? "claude"
-            let rcEnabled = appState.remoteControlEnabled
-            let autoMode = appState.managerAutoPermissionMode
-            let managerCommand = claudePath + ClaudeLaunchArgs.argsSuffix(
-                remoteControl: rcEnabled,
-                sessionName: "Manager",
-                autoPermissionMode: autoMode
-            )
-            let rawTerminal = SessionTerminal(
-                sessionID: managerID,
-                name: "Manager",
-                cwd: devRoot,
-                command: managerCommand
-            )
-
-            // Route through the same backend-selection path as work sessions
-            // (#314). On tmux this registers a window and pastes the `claude`
-            // command into it; on Ghostty it pre-initializes the offscreen
-            // surface. `trackReadiness: false` matches the Manager's
-            // command-launches-claude model — no readiness/launchClaude flow.
-            let terminal = prepareTerminal(rawTerminal, trackReadiness: false)
-            appState.terminals[managerID] = [terminal]
-
-            store.mutate { data in
-                if !data.terminals.contains(where: { $0.sessionID == managerID }) {
-                    data.terminals.append(terminal)
-                }
-            }
-
-            if rcEnabled {
-                appState.remoteControlActiveTerminals.insert(terminal.id)
-            }
+            createManagerTerminal(sessionID: managerID, sessionName: "Manager", cwd: devRoot)
         }
 
         // Select Manager on launch (selectedSessionID isn't persisted)
@@ -560,6 +541,61 @@ final class SessionService {
 
         // Session row still exists, so this only recreates the terminal.
         ensureManagerSession(devRoot: resolvedDevRoot)
+    }
+
+    /// Build the claude shell command for a Manager terminal, reflecting the
+    /// current remote-control and auto-permission-mode preferences. Managers
+    /// launch claude directly as the terminal's shell command.
+    private func managerCommand(sessionName: String) -> String {
+        // Find the real claude binary (skip CMUX wrapper)
+        let claudePath = Self.findClaudeBinary() ?? "claude"
+        return claudePath + ClaudeLaunchArgs.argsSuffix(
+            remoteControl: appState.remoteControlEnabled,
+            sessionName: sessionName,
+            autoPermissionMode: appState.managerAutoPermissionMode
+        )
+    }
+
+    /// Create the single Claude-Code terminal for a Manager session and persist
+    /// it. Routes through the same backend-selection path as work sessions
+    /// (#314): on tmux this registers a window and pastes the `claude` command
+    /// into it; on Ghostty it pre-initializes the offscreen surface.
+    /// `trackReadiness: false` matches the Manager's command-launches-claude
+    /// model — no readiness/launchClaude flow.
+    @discardableResult
+    private func createManagerTerminal(sessionID: UUID, sessionName: String, cwd: String) -> SessionTerminal {
+        let command = managerCommand(sessionName: sessionName)
+        let rawTerminal = SessionTerminal(
+            sessionID: sessionID,
+            name: sessionName,
+            cwd: cwd,
+            command: command
+        )
+
+        let terminal = prepareTerminal(rawTerminal, trackReadiness: false)
+        appState.terminals[sessionID] = [terminal]
+
+        store.mutate { data in
+            if !data.terminals.contains(where: { $0.sessionID == sessionID }) {
+                data.terminals.append(terminal)
+            }
+        }
+
+        if appState.remoteControlEnabled {
+            appState.remoteControlActiveTerminals.insert(terminal.id)
+        }
+        return terminal
+    }
+
+    /// Create an additional (non-primary) Manager session with its own
+    /// Claude-Code terminal running in `cwd`. Returns the new session's id.
+    @discardableResult
+    func createManagerSession(name: String, cwd: String) -> UUID {
+        let session = Session(name: name, status: .active, kind: .manager)
+        appState.sessions.append(session)
+        store.mutate { $0.sessions.append(session) }
+        createManagerTerminal(sessionID: session.id, sessionName: name, cwd: cwd)
+        return session.id
     }
 
     // MARK: - Delete Session
@@ -631,9 +667,12 @@ final class SessionService {
         appState.sessions.removeAll { $0.id == id }
         appState.worktrees.removeValue(forKey: id)
         appState.links.removeValue(forKey: id)
-        // Clean up auto-launch set for deleted session's terminals
+        // Clean up auto-launch and remote-control sets for deleted session's terminals
         if let terms = appState.terminals[id] {
-            for t in terms { appState.autoLaunchTerminals.remove(t.id) }
+            for t in terms {
+                appState.autoLaunchTerminals.remove(t.id)
+                appState.remoteControlActiveTerminals.remove(t.id)
+            }
         }
         appState.terminals.removeValue(forKey: id)
         appState.activeTerminalID.removeValue(forKey: id)
@@ -1417,7 +1456,9 @@ final class SessionService {
 
     /// Update a session's status and persist the change.
     private func updateSessionStatus(_ id: UUID, to status: SessionStatus) {
-        guard id != AppState.managerSessionID else { return }
+        // Managers stay always-active; never transition them through the
+        // review/complete lifecycle.
+        guard !appState.isManagerSession(id) else { return }
 
         if let idx = appState.sessions.firstIndex(where: { $0.id == id }) {
             appState.sessions[idx].status = status

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -92,26 +92,21 @@ final class SessionService {
             } else {
                 // Manager terminal: rebuild its claude command to match the
                 // current remoteControlEnabled and managerAutoPermissionMode
-                // preferences. Unlike worker sessions the Manager launches
-                // claude directly as the shell command, so the stored string
-                // needs to be correct before preInitialize runs.
-                let claudePath = Self.findClaudeBinary() ?? "claude"
-                let rcEnabled = appState.remoteControlEnabled
-                let autoMode = appState.managerAutoPermissionMode
-                let managerCommand = claudePath + ClaudeLaunchArgs.argsSuffix(
-                    remoteControl: rcEnabled,
-                    sessionName: session.name,
-                    autoPermissionMode: autoMode
-                )
+                // preferences, using this session's own name for the --name
+                // label. Unlike worker sessions the Manager launches claude
+                // directly as the shell command, so the stored string needs to
+                // be correct before preInitialize runs. Built via the shared
+                // `managerCommand` helper so the name flow has one source.
+                let rebuiltCommand = managerCommand(sessionName: session.name)
                 for i in terminals.indices {
                     if let cmd = terminals[i].command, cmd.contains("claude") {
                         terminals[i] = SessionTerminal(
                             id: terminals[i].id, sessionID: terminals[i].sessionID,
                             name: terminals[i].name, cwd: terminals[i].cwd,
-                            command: managerCommand, isManaged: terminals[i].isManaged,
+                            command: rebuiltCommand, isManaged: terminals[i].isManaged,
                             createdAt: terminals[i].createdAt
                         )
-                        if rcEnabled {
+                        if appState.remoteControlEnabled {
                             appState.remoteControlActiveTerminals.insert(terminals[i].id)
                         }
                     }
@@ -567,8 +562,10 @@ final class SessionService {
 
     /// Build the claude shell command for a Manager terminal, reflecting the
     /// current remote-control and auto-permission-mode preferences. Managers
-    /// launch claude directly as the terminal's shell command.
-    private func managerCommand(sessionName: String) -> String {
+    /// launch claude directly as the terminal's shell command. Used by both
+    /// fresh-terminal creation and the hydrate rebuild so the per-session
+    /// `--name` label has a single source. `internal` for unit testing.
+    func managerCommand(sessionName: String) -> String {
         // Find the real claude binary (skip CMUX wrapper)
         let claudePath = Self.findClaudeBinary() ?? "claude"
         return claudePath + ClaudeLaunchArgs.argsSuffix(
@@ -609,8 +606,8 @@ final class SessionService {
         return terminal
     }
 
-    /// Create an additional (non-primary) Manager session with its own
-    /// Claude-Code terminal running in `cwd`. Returns the new session's id.
+    /// Create an additional (non-primary) Manager session in `cwd`. Returns the
+    /// new session's id. The terminal is set up by `createManagerTerminal`.
     @discardableResult
     func createManagerSession(name: String, cwd: String) -> UUID {
         let session = Session(name: name, status: .active, kind: .manager)

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -18,11 +18,36 @@ final class SessionService {
         self.telemetryPort = telemetryPort
     }
 
+    /// Upgrade the well-known primary Manager session from `.work` (how it was
+    /// persisted before `SessionKind.manager` existed) to `.manager`. Returns
+    /// `true` when a migration was applied. Pure/`nonisolated` so it can run on
+    /// both the in-memory `appState.sessions` and the persisted `store` copy,
+    /// and be unit-tested without a live app.
+    nonisolated static func migrateLegacyManagerKind(_ sessions: inout [Session]) -> Bool {
+        guard let idx = sessions.firstIndex(where: {
+            $0.id == AppState.managerSessionID && $0.kind != .manager
+        }) else { return false }
+        sessions[idx].kind = .manager
+        return true
+    }
+
     // MARK: - Hydrate State from Store
 
     func hydrateState() {
         let data = store.data
         appState.sessions = data.sessions
+
+        // Migrate a legacy primary Manager (persisted as `.work` before
+        // SessionKind.manager existed) to `.manager` BEFORE the per-session loop.
+        // Otherwise the `!session.isManager` hydration branch clears its claude
+        // command and reroutes it through the work-session auto-launch path,
+        // silently dropping the Manager's --auto-permission-mode args (#316).
+        // Persist so the upgrade is one-shot.
+        if Self.migrateLegacyManagerKind(&appState.sessions) {
+            store.mutate { data in
+                _ = Self.migrateLegacyManagerKind(&data.sessions)
+            }
+        }
 
         // Backfill provider from ticketURL for sessions that predate provider tracking
         for i in appState.sessions.indices {
@@ -474,16 +499,13 @@ final class SessionService {
 
     func ensureManagerSession(devRoot: String) {
         let managerID = AppState.managerSessionID
-        if let idx = appState.sessions.firstIndex(where: { $0.id == managerID }) {
-            // Migrate a legacy primary Manager (created before SessionKind.manager
-            // existed, so persisted as .work) to the .manager kind so all the
-            // kind-based special-casing recognizes it.
-            if appState.sessions[idx].kind != .manager {
-                appState.sessions[idx].kind = .manager
+        if appState.sessions.contains(where: { $0.id == managerID }) {
+            // Defense-in-depth: `hydrateState` already migrates a legacy `.work`
+            // primary Manager before this runs, but migrate here too in case the
+            // session was created/mutated via another path.
+            if Self.migrateLegacyManagerKind(&appState.sessions) {
                 store.mutate { data in
-                    if let i = data.sessions.firstIndex(where: { $0.id == managerID }) {
-                        data.sessions[i].kind = .manager
-                    }
+                    _ = Self.migrateLegacyManagerKind(&data.sessions)
                 }
             }
         } else {
@@ -614,7 +636,8 @@ final class SessionService {
     /// Performs a full cascade: destroys terminal surfaces, removes worktrees from disk
     /// (with branch deletion for non-protected branches), removes hook configs, and cleans
     /// up all in-memory state (sessions, worktrees, links, terminals, hook state, PR status).
-    /// The manager session cannot be deleted.
+    /// The primary Manager session (well-known UUID) cannot be deleted;
+    /// additional Manager sessions are deletable.
     ///
     /// The slow filesystem/git work runs in a detached task so the main thread stays
     /// responsive. While cleanup is in flight, `appState.isDeletingSession[id]` is `true`
@@ -1329,7 +1352,7 @@ final class SessionService {
         switch kind {
         case .review: return ".crow-review-prompt.md"
         case .job: return ".crow-job-prompt.md"
-        case .work: return nil
+        case .work, .manager: return nil
         }
     }
 

--- a/Tests/CrowTests/IssueTrackerCompletionTests.swift
+++ b/Tests/CrowTests/IssueTrackerCompletionTests.swift
@@ -500,6 +500,23 @@ struct IssueTrackerCompletionTests {
     }
 
     @Test
+    func nonPrimaryManagerIsExcludedFromCleanup() {
+        // A non-primary manager has a fresh UUID (not in protectedSessionIDs),
+        // so it must be excluded via its kind rather than its ID.
+        let session = makeSession(
+            name: "Manager 2",
+            status: .completed,
+            kind: .manager,
+            updatedAt: hoursAgo(48)
+        )
+        let eligible = IssueTracker.sessionsEligibleForCleanup(
+            sessions: [session],
+            retentionHours: 24
+        )
+        #expect(eligible.isEmpty)
+    }
+
+    @Test
     func virtualTabSessionsAreProtected() {
         let protectedIDs = [
             AppState.ticketBoardSessionID,

--- a/Tests/CrowTests/ManagerMigrationTests.swift
+++ b/Tests/CrowTests/ManagerMigrationTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+/// Locks down the legacy primary-Manager migration (#316). Before
+/// SessionKind.manager existed the primary Manager was persisted as `.work`;
+/// on upgrade it must become `.manager` BEFORE hydration's per-session loop,
+/// otherwise the work-session branch clears its claude command and reroutes it
+/// through the auto-launch path (dropping --auto-permission-mode).
+@Suite("SessionService.migrateLegacyManagerKind")
+struct ManagerMigrationTests {
+
+    @Test
+    func migratesLegacyWorkPrimaryManager() {
+        var sessions = [
+            Session(id: AppState.managerSessionID, name: "Manager", kind: .work),
+            Session(name: "feature", kind: .work),
+        ]
+        let migrated = SessionService.migrateLegacyManagerKind(&sessions)
+        #expect(migrated)
+        #expect(sessions.first { $0.id == AppState.managerSessionID }?.kind == .manager)
+        // Non-primary work session is untouched.
+        #expect(sessions.first { $0.name == "feature" }?.kind == .work)
+    }
+
+    @Test
+    func noOpWhenPrimaryAlreadyManager() {
+        var sessions = [Session(id: AppState.managerSessionID, name: "Manager", kind: .manager)]
+        #expect(SessionService.migrateLegacyManagerKind(&sessions) == false)
+        #expect(sessions[0].kind == .manager)
+    }
+
+    @Test
+    func noOpWhenNoPrimaryManager() {
+        var sessions = [Session(name: "work", kind: .work)]
+        #expect(SessionService.migrateLegacyManagerKind(&sessions) == false)
+    }
+}

--- a/Tests/CrowTests/ManagerMigrationTests.swift
+++ b/Tests/CrowTests/ManagerMigrationTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import CrowCore
+import CrowPersistence
 @testable import Crow
 
 /// Locks down the legacy primary-Manager migration (#316). Before
@@ -35,5 +36,29 @@ struct ManagerMigrationTests {
     func noOpWhenNoPrimaryManager() {
         var sessions = [Session(name: "work", kind: .work)]
         #expect(SessionService.migrateLegacyManagerKind(&sessions) == false)
+    }
+
+    /// Locks in the per-session `--name` label flow that `hydrateState` and
+    /// `createManagerTerminal` both rely on (#316 review): distinct manager
+    /// names must produce distinct `--name '…'` flags so additional managers
+    /// show correct labels in the Remote Control panel.
+    @MainActor
+    @Test
+    func managerCommandUsesSessionNameForRemoteControlLabel() {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-mgr-cmd-\(UUID().uuidString)")
+        let appState = AppState()
+        appState.remoteControlEnabled = true
+        appState.managerAutoPermissionMode = true
+        let service = SessionService(store: JSONStore(directory: tmp), appState: appState)
+
+        let cmd2 = service.managerCommand(sessionName: "Manager 2")
+        let cmd3 = service.managerCommand(sessionName: "Manager 3")
+
+        #expect(cmd2.contains("--name 'Manager 2'"))
+        #expect(cmd3.contains("--name 'Manager 3'"))
+        #expect(cmd2 != cmd3)
+        #expect(cmd2.contains("--permission-mode auto"))
+        #expect(cmd2.contains("--rc"))
     }
 }


### PR DESCRIPTION
Closes #316

## Summary
Moves the Manager from a hardcoded-UUID singleton to a `SessionKind.manager` *kind*, so multiple Manager sessions can run concurrently — each with its own Claude Code terminal running in the devRoot.

The well-known UUID (`00000000-0000-0000-0000-000000000000`) is retained as the **primary** Manager for back-compat: it's the only one protected from deletion, and `/crow-workspace` ("Work on this issue") routing stays pinned to it.

## Changes
- **Model:** add `SessionKind.manager` + `Session.isManager`. The legacy primary Manager (persisted as `.work`) is migrated to `.manager` on launch in `ensureManagerSession`.
- **Generalized special-casing:** every `id == managerSessionID` check became `isManager` across `SessionService` (hydration, readiness, status, Ghostty pin), `AppDelegate` (new-terminal), and `IssueTracker` (PR/issue tracking + auto-cleanup).
- **Creation:** new `SessionService.createManagerSession(name:cwd:)` + a reusable terminal helper. CLI gains `crow new-session --kind manager`; the `new-session` RPC accepts an optional `kind`.
- **UI:** sidebar "+" button spawns a Manager (auto-named "Manager N"); additional managers render as selectable rows with a Delete context menu; `SessionDetailView` special-cases switch to `isManager`.
- **Cleanup:** all managers excluded from auto-cleanup and PR/issue reconciliation; the remote-control set is cleaned up on session deletion (pre-existing latent leak).

## Acceptance
- ✅ More than one Manager can exist and run concurrently.
- ✅ Each Manager has an independent terminal/process; deleting a non-primary Manager is allowed (primary stays protected).
- ✅ Existing single-Manager behavior is the default.

## Testing
- `swift build --arch arm64` — full app builds.
- Tests pass: CrowCore (175), CrowCLI (38), CrowUI (31), app target (114). Added coverage for manager Codable/`isManager`, AppState lookups, CLI `--kind` parsing, and a non-primary-manager cleanup-exclusion case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)