### PR TITLE
docs: document install / launch path + add make install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
-.PHONY: build setup ghostty app release sign clean clean-all check test help
+.PHONY: build setup ghostty app release sign install install-app uninstall clean clean-all check test help
 
 FRAMEWORKS_DIR := Frameworks
 XCFW := $(FRAMEWORKS_DIR)/GhosttyKit.xcframework
 SUBMODULE_MARKER := vendor/ghostty/build.zig
+
+# Install destination and build config (override on the command line, e.g.
+# `make install BINDIR=/usr/local/bin` or `make install CONFIG=release`).
+PREFIX    ?= $(HOME)/.local
+BINDIR    ?= $(PREFIX)/bin
+CONFIG    ?= debug
+BUILD_OUT := .build/$(CONFIG)
 
 # Default target
 build: setup ghostty app
@@ -19,6 +26,9 @@ help:
 	@echo "  app        Swift build only (debug)"
 	@echo "  release    Release build + .app bundle"
 	@echo "  sign       Sign, create DMG, and notarize (requires DEVELOPER_ID_APPLICATION)"
+	@echo "  install    Symlink crow + CrowApp into ~/.local/bin (override BINDIR=, CONFIG=release)"
+	@echo "  install-app Copy Crow.app into /Applications (run 'make release' first)"
+	@echo "  uninstall  Remove installed crow + CrowApp symlinks"
 	@echo "  clean      Remove .build/ (keeps ghostty framework)"
 	@echo "  clean-all  Remove .build/ and Frameworks/ (full rebuild)"
 	@echo ""
@@ -57,6 +67,28 @@ release: $(XCFW)
 
 sign: release
 	bash scripts/sign-and-notarize.sh
+
+# --- Install ---
+
+install:
+	@test -x "$(CURDIR)/$(BUILD_OUT)/crow" && test -x "$(CURDIR)/$(BUILD_OUT)/CrowApp" || \
+		{ echo "ERROR: binaries not found in $(BUILD_OUT)/. Run 'make build' (debug) or 'make release' (then 'make install CONFIG=release') first."; exit 1; }
+	@mkdir -p "$(BINDIR)"
+	@ln -sf "$(CURDIR)/$(BUILD_OUT)/crow" "$(BINDIR)/crow"
+	@ln -sf "$(CURDIR)/$(BUILD_OUT)/CrowApp" "$(BINDIR)/CrowApp"
+	@echo "Symlinked crow + CrowApp into $(BINDIR) (from $(BUILD_OUT)/)"
+	@case ":$$PATH:" in *":$(BINDIR):"*) ;; \
+		*) echo "NOTE: $(BINDIR) is not on PATH. Add to your shell rc: export PATH=\"$(BINDIR):\$$PATH\"";; esac
+
+install-app:
+	@test -d "$(CURDIR)/Crow.app" || { echo "ERROR: Crow.app not found. Run 'make release' first."; exit 1; }
+	rm -rf "/Applications/Crow.app"
+	cp -R "$(CURDIR)/Crow.app" "/Applications/Crow.app"
+	@echo "Installed Crow.app to /Applications"
+
+uninstall:
+	@rm -f "$(BINDIR)/crow" "$(BINDIR)/CrowApp"
+	@echo "Removed crow + CrowApp symlinks from $(BINDIR)"
 
 # --- Test ---
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ On first launch, a setup wizard guides you through choosing your development roo
 
 > **Note:** The required GitHub scope is the **write** `project` scope — `read:project` is insufficient because Crow updates ticket status via the `updateProjectV2ItemFieldValue` GraphQL mutation. See [docs/getting-started.md](docs/getting-started.md#3-github-authentication) for details.
 
+### Install (put `crow` on your PATH)
+
+The Manager terminal and the `/crow-workspace` skill call bare `crow ...`, so a fresh build that you can only launch by full path will break those workflows. Install the binaries so they're invokable from anywhere:
+
+```bash
+make install                       # symlinks crow + CrowApp into ~/.local/bin
+```
+
+If `~/.local/bin` isn't already on your `PATH`, add this to `~/.zshrc` (then restart your shell):
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Use a different directory with `BINDIR`, e.g. `make install BINDIR=/usr/local/bin`.
+
+`make install` creates **symlinks** into `.build/debug/`, so a later `make build` updates them in place — no need to re-run it. Re-run `make install` only when you switch to a release build (`make release && make install CONFIG=release`) or after `make clean` (which removes `.build/` and leaves the symlinks dangling until the next build). Remove the symlinks with `make uninstall`.
+
+**GUI install:** for a `.app` bundle in `/Applications` (launchable from Spotlight/Dock), run `make release && make install-app`. See [Releases](#releases) if macOS quarantines the unsigned bundle.
+
 ## Documentation
 
 - [**Getting Started**](docs/getting-started.md) — Clone, build, authenticate, and launch

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,6 +39,9 @@ This runs `setup` (initializes submodules and checks prerequisites), `ghostty` (
 | `app`        | Run `swift build` (debug) without touching ghostty                            |
 | `release`    | Release build + `.app` bundle via `scripts/bundle.sh`                         |
 | `sign`       | Sign, create DMG, and notarize (requires `DEVELOPER_ID_APPLICATION`)          |
+| `install`    | Symlink `crow` + `CrowApp` into `~/.local/bin` (override `BINDIR=`, `CONFIG=`) |
+| `install-app`| Copy `Crow.app` into `/Applications` (run `make release` first)               |
+| `uninstall`  | Remove the `crow` + `CrowApp` symlinks created by `install`                   |
 | `test`       | Run all package tests                                                         |
 | `clean`      | Remove `.build/` (keeps the ghostty framework)                                |
 | `clean-all`  | Remove `.build/` and `Frameworks/` (full rebuild)                             |
@@ -165,6 +168,68 @@ Alternatively, you can scaffold without launching the GUI by running the CLI set
 .build/debug/crow setup            # prompts interactively
 .build/debug/crow setup --dev-root ~/Dev   # skip the devRoot prompt
 ```
+
+## 6. Install (Optional)
+
+Running the binaries by full path (`.build/debug/CrowApp`, `.build/debug/crow`) works, but the Manager terminal and the `/crow-workspace` skill invoke bare `crow ...` — so for day-to-day use you'll want `crow` (and optionally `CrowApp`) on your `PATH`.
+
+### Put the binaries on PATH
+
+```bash
+make install
+```
+
+This symlinks both binaries into `~/.local/bin`:
+
+- `~/.local/bin/crow` → `.build/debug/crow`
+- `~/.local/bin/CrowApp` → `.build/debug/CrowApp`
+
+If `~/.local/bin` isn't on your `PATH`, `make install` prints a reminder. Add this to your shell rc (e.g. `~/.zshrc`) and restart the shell:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+**Overrides:**
+
+| Variable  | Default          | Example                                  |
+| --------- | ---------------- | ---------------------------------------- |
+| `BINDIR`  | `~/.local/bin`   | `make install BINDIR=/usr/local/bin`     |
+| `CONFIG`  | `debug`          | `make install CONFIG=release`            |
+
+`CONFIG` selects which build directory the symlinks point at — `.build/debug/` (from `make build`) or `.build/release/` (from `make release`). If the chosen binaries don't exist yet, `make install` errors and tells you to build first.
+
+### Rebuilds and re-pointing
+
+Because `install` creates **symlinks** (not copies), `swift build` overwrites the underlying `.build/debug/` binaries in place and the symlinks keep working — no need to re-run `make install` after a normal `make build`.
+
+Re-run `make install` only when:
+
+- You switch debug ↔ release: `make release && make install CONFIG=release`.
+- You ran `make clean` (or `mise clean`), which deletes `.build/` and leaves the symlinks dangling until the next build.
+
+Remove the symlinks at any time:
+
+```bash
+make uninstall
+```
+
+### GUI install (`/Applications`)
+
+For a proper `.app` bundle you can launch from Spotlight or the Dock:
+
+```bash
+make release        # produces ./Crow.app
+make install-app    # copies Crow.app into /Applications
+```
+
+Builds from source are unsigned. If macOS quarantines the bundle on first launch, clear the attribute:
+
+```bash
+xattr -cr /Applications/Crow.app
+```
+
+Official signed/notarized builds are available on the [Releases](https://github.com/radiusmethod/crow/releases) page and install without Gatekeeper warnings.
 
 ## Next Steps
 


### PR DESCRIPTION
Closes #307

## Problem

After `make build`, the only documented way to launch Crow was by full binary path (`.build/debug/CrowApp`, `.build/debug/crow`). But `CLAUDE.md`, the `/crow-workspace` skill, and the Manager terminal all invoke bare `crow ...` — so a first-time user who follows the Quick Start exactly ends up with binaries they can't invoke the way the rest of the project assumes, silently breaking the documented workflows the moment they start a session.

## Changes

**`Makefile`**
- `install` — symlinks `crow` + `CrowApp` into `~/.local/bin`. Overridable: `BINDIR=` (e.g. `/usr/local/bin`) and `CONFIG=` (`debug`/`release`). Guards against missing binaries (errors with a build-first hint) and prints a PATH reminder only when the target dir isn't on `PATH`.
- `install-app` — copies `Crow.app` into `/Applications` (run `make release` first).
- `uninstall` — removes the symlinks.
- New entries in `make help`.

Symlinks (not copies) are deliberate: `swift build` overwrites `.build/debug/` binaries in place, so the symlinks self-heal on rebuild — you only re-run `make install` when switching debug↔release or after `make clean`.

**`README.md`** — adds an "Install (put `crow` on your PATH)" subsection to Quick Start.

**`docs/getting-started.md`** — adds a "6. Install (Optional)" section (PATH setup, `BINDIR`/`CONFIG` overrides, rebuild/re-point behavior, `/Applications` GUI install) plus `install`/`install-app`/`uninstall` rows in the Makefile Targets table.

## Verification

- `make help` lists the three new targets.
- `make install` with no binaries → errors with build-first hint (exit 1).
- `make install-app` with no `Crow.app` → errors (exit 1).
- `make install` (happy path, stub binaries) → creates absolute-path symlinks; PATH NOTE prints only when `BINDIR` isn't on `PATH`.
- `make uninstall` → removes the symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)