### PR TITLE
docs: surface Metal Toolchain + pin Zig 0.15 in Quick Start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,11 @@ $(SUBMODULE_MARKER):
 	git submodule update --init --recursive
 
 setup: $(SUBMODULE_MARKER)
-	@command -v zig >/dev/null 2>&1 || { echo "ERROR: zig not found. Install with: brew install zig"; exit 1; }
+	@command -v zig >/dev/null 2>&1 || { echo "ERROR: zig not found. Install with: brew install zig@0.15"; exit 1; }
 	@ZIG_VER=$$(zig version); \
 	if [ "$$ZIG_VER" != "0.15.2" ]; then \
-		echo "WARNING: Zig 0.15.2 required, found: $$ZIG_VER"; \
+		echo "ERROR: Zig 0.15.2 required, found: $$ZIG_VER. Install with: brew install zig@0.15"; \
+		exit 1; \
 	fi
 	@xcrun -sdk macosx metal --version >/dev/null 2>&1 || { echo "ERROR: Metal Toolchain not installed. Run: xcodebuild -downloadComponent MetalToolchain"; exit 1; }
 	@echo "Prerequisites OK"

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ A native macOS application for managing AI-powered development sessions. Orchest
 
 ### Build Dependencies
 
-| Tool  | Version | Purpose                                | Install                                                                           |
-| ----- | ------- | -------------------------------------- | --------------------------------------------------------------------------------- |
-| Swift | 6.0+    | Compiler (ships with Xcode)            | `xcode-select --install`                                                          |
-| Zig   | 0.15.2  | Builds the Ghostty terminal framework  | `brew install zig` or [ziglang.org](https://ziglang.org/download/)                |
-| mise  | latest  | Task runner (optional)                 | `brew install mise`                                                               |
+| Tool             | Version | Purpose                                | Install                                                                  |
+| ---------------- | ------- | -------------------------------------- | ------------------------------------------------------------------------ |
+| Swift            | 6.0+    | Compiler (ships with Xcode)            | `xcode-select --install`                                                 |
+| Zig              | 0.15.2  | Builds the Ghostty terminal framework  | `brew install zig@0.15` or [ziglang.org](https://ziglang.org/download/)  |
+| Metal Toolchain  | bundled | Compiles Ghostty's Metal shaders       | `xcodebuild -downloadComponent MetalToolchain`                           |
+| mise             | latest  | Task runner (optional)                 | `brew install mise`                                                      |
 
 ### Runtime Dependencies
 
@@ -37,14 +38,17 @@ A native macOS application for managing AI-powered development sessions. Orchest
 git clone --recurse-submodules https://github.com/radiusmethod/crow.git
 cd crow
 
-# 2. Build (submodules + GhosttyKit + swift build in one shot)
+# 2. Install the Metal Toolchain (required to compile Ghostty's Metal shaders)
+xcodebuild -downloadComponent MetalToolchain
+
+# 3. Build (submodules + GhosttyKit + swift build in one shot)
 make build
 
-# 3. Authenticate GitHub CLI — the write `project` scope is required
+# 4. Authenticate GitHub CLI — the write `project` scope is required
 gh auth login
 gh auth refresh -s project,read:org,repo
 
-# 4. Run
+# 5. Run
 .build/debug/CrowApp
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,8 +4,8 @@
 
 | Problem                                                  | Solution                                                                 |
 | -------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `zig` not found                                          | `brew install zig` or download from [ziglang.org](https://ziglang.org/download/) |
-| Zig version mismatch                                     | Version **0.15.2** is required. Check with `zig version`                 |
+| `zig` not found                                          | `brew install zig@0.15` or download from [ziglang.org](https://ziglang.org/download/) |
+| Zig version mismatch                                     | Version **0.15.2** is required (plain `brew install zig` is now 0.16.0 — use `brew install zig@0.15`). Check with `zig version` |
 | Metal toolchain not found                                | Run `xcodebuild -downloadComponent MetalToolchain`                       |
 | Ghostty submodule missing                                | Run `git submodule update --init vendor/ghostty`                         |
 | `swift build` fails with linker errors                   | Build `GhosttyKit` first: `./scripts/build-ghostty.sh` (or just run `make build`) |

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -36,7 +36,7 @@ REQUIRED_ZIG="0.15.2"
 CURRENT_ZIG=$(zig version 2>/dev/null || echo "not found")
 if [ "$CURRENT_ZIG" != "$REQUIRED_ZIG" ]; then
     echo "ERROR: Zig $REQUIRED_ZIG required, found: $CURRENT_ZIG"
-    echo "Install with: brew install zig"
+    echo "Install with: brew install zig@0.15"
     exit 1
 fi
 


### PR DESCRIPTION
Closes #306

Following the README Quick Start on a fresh macOS machine failed `make build` twice: once on the missing Metal Toolchain (not documented in Prerequisites) and once on the Zig version, since `brew install zig` now installs 0.16.0 while the build pins 0.15.2.

## Changes
- **README** — add **Metal Toolchain** to the Build Dependencies table and a `xcodebuild -downloadComponent MetalToolchain` step to Quick Start (before `make build`, where users hit the first failure). Zig install hint → `brew install zig@0.15`.
- **Makefile** — make the `setup` prereq check authoritative: a Zig version mismatch now **errors and exits** (was only a warning that still printed "Prerequisites OK", letting the failure surface later in `build-ghostty.sh`). Install hint → `brew install zig@0.15`.
- **scripts/build-ghostty.sh** — install hint → `brew install zig@0.15`.
- **docs/troubleshooting.md** — install hint → `brew install zig@0.15`, with a note that plain `brew install zig` is now 0.16.0.

## Verification
- No bare `brew install zig` remains in README, Makefile, scripts, or docs.
- On Zig 0.16.x, `make setup` now exits non-zero with a clear error + the `zig@0.15` hint instead of printing "Prerequisites OK".

🤖 Generated with [Claude Code](https://claude.com/claude-code)