### PR TITLE
feat: jobs — provider-sourced repo picker scoped to a workspace (closes #327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Backfill of merged PRs since the 0.1.0 release, grouped by theme.
 - #214 — Optional auto-respond toggles: when enabled, Crow types an instruction into the session's Claude Code terminal in response to changes-requested reviews and failed CI checks. Off by default.
 - #222 — PRs opened from a Crow session are auto-labeled `crow:auto`.
 - #228 — Settings split into discrete tabs; every automation toggle lives under Settings → Automation. New `docs/automation.md` covers the full lifecycle.
+- #327 — Scheduled Jobs scope to a workspace + repo, where the repo picker is populated from the workspace's provider by expanding its "Always Include Repos" specs (`owner/*` globs or `owner/repo` slugs). Repos not yet checked out are cloned on demand when the job fires.
 
 ### Review Board & Sessions
 

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -135,6 +135,11 @@ public final class AppState {
     /// Called to promote selected patterns to the global settings.
     public var onPromoteToGlobal: ((Set<String>) -> Void)?
 
+    /// Lists the repos available to a workspace, as `owner/repo` slugs, by
+    /// expanding its `alwaysInclude` specs against the provider. Wired in
+    /// AppDelegate; used by the Jobs form's repo picker.
+    public var onListWorkspaceRepos: ((WorkspaceInfo) async -> [String])?
+
     /// Called when the user clicks the gear icon in the sidebar toolbar.
     /// AppDelegate wires this to its `showSettings()` method.
     public var onShowSettings: (() -> Void)?

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -202,6 +202,11 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         if name.unicodeScalars.contains(where: { unsafeCharacters.contains($0) }) {
             return "Name cannot contain /, :, or null characters"
         }
+        // The name becomes a path component under devRoot; "." / ".." would
+        // resolve outside the intended directory.
+        if name == "." || name == ".." {
+            return "Name cannot be “.” or “..”"
+        }
         let lowercased = name.lowercased()
         if existingNames.contains(where: { $0.lowercased() == lowercased }) {
             return "A workspace with this name already exists"

--- a/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
@@ -1,20 +1,24 @@
 import Foundation
 
 /// A scheduled job: one or more prompts that fire automatically on a schedule,
-/// scoped to a repo.
+/// scoped to a repo within a workspace.
 ///
-/// When a job fires, the scheduler resolves `repo` to a checkout under the dev
-/// root (by folder name), creates a fresh worktree + session + Claude Code
-/// terminal there, and sends `prompts` in order. Persisted as part of
-/// `AppConfig` in `{devRoot}/.claude/config.json`.
+/// When a job fires, the scheduler resolves the repo under
+/// `{devRoot}/{workspace}/` — cloning it on demand if it isn't checked out yet —
+/// then creates a fresh worktree + session + Claude Code terminal there and
+/// sends `prompts` in order. Persisted as part of `AppConfig` in
+/// `{devRoot}/.claude/config.json`.
 ///
 /// Like `WorkspaceInfo`, decoding is forward-compatible: missing keys fall back
-/// to defaults so older config files keep working (a legacy `workspace` key is
-/// simply ignored).
+/// to defaults so older config files keep working.
 public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     public let id: UUID
     public var name: String
-    /// Repo folder name. Resolved to a checkout under the dev root at run time.
+    /// Workspace name (matches `WorkspaceInfo.name`); the repo's parent folder
+    /// under the dev root and the source of its provider/host.
+    public var workspace: String
+    /// The repo as an `owner/repo` slug (chosen from the workspace's provider).
+    /// Its last path component is the local folder name under the workspace.
     public var repo: String
     /// Ordered prompts. The first launches Claude; the rest are sent after launch.
     public var prompts: [String]
@@ -27,6 +31,7 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     public init(
         id: UUID = UUID(),
         name: String,
+        workspace: String,
         repo: String,
         prompts: [String],
         schedule: JobSchedule,
@@ -36,6 +41,7 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     ) {
         self.id = id
         self.name = name
+        self.workspace = workspace
         self.repo = repo
         self.prompts = prompts
         self.schedule = schedule
@@ -48,6 +54,7 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
+        workspace = try container.decodeIfPresent(String.self, forKey: .workspace) ?? ""
         repo = try container.decodeIfPresent(String.self, forKey: .repo) ?? ""
         prompts = try container.decodeIfPresent([String].self, forKey: .prompts) ?? []
         schedule = try container.decodeIfPresent(JobSchedule.self, forKey: .schedule) ?? .interval(seconds: 86400)
@@ -57,7 +64,7 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, repo, prompts, schedule, enabled, lastRunAt, createdAt
+        case id, name, workspace, repo, prompts, schedule, enabled, lastRunAt, createdAt
     }
 
     /// Validate a job name, returning an error message or `nil` if valid.

--- a/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 /// A scheduled job: one or more prompts that fire automatically on a schedule,
-/// scoped to a repo within a workspace.
+/// scoped to a repo.
 ///
-/// When a job fires, the scheduler creates a fresh worktree + session + Claude
-/// Code terminal in `{devRoot}/{workspace}/{repo}` and sends `prompts` in order.
-/// Persisted as part of `AppConfig` in `{devRoot}/.claude/config.json`.
+/// When a job fires, the scheduler resolves `repo` to a checkout under the dev
+/// root (by folder name), creates a fresh worktree + session + Claude Code
+/// terminal there, and sends `prompts` in order. Persisted as part of
+/// `AppConfig` in `{devRoot}/.claude/config.json`.
 ///
 /// Like `WorkspaceInfo`, decoding is forward-compatible: missing keys fall back
-/// to defaults so older config files keep working.
+/// to defaults so older config files keep working (a legacy `workspace` key is
+/// simply ignored).
 public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     public let id: UUID
     public var name: String
-    /// Workspace name (matches `WorkspaceInfo.name`).
-    public var workspace: String
-    /// Repo folder name within the workspace (the checkout at `{devRoot}/{workspace}/{repo}`).
+    /// Repo folder name. Resolved to a checkout under the dev root at run time.
     public var repo: String
     /// Ordered prompts. The first launches Claude; the rest are sent after launch.
     public var prompts: [String]
@@ -27,7 +27,6 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     public init(
         id: UUID = UUID(),
         name: String,
-        workspace: String,
         repo: String,
         prompts: [String],
         schedule: JobSchedule,
@@ -37,7 +36,6 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     ) {
         self.id = id
         self.name = name
-        self.workspace = workspace
         self.repo = repo
         self.prompts = prompts
         self.schedule = schedule
@@ -50,7 +48,6 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
-        workspace = try container.decodeIfPresent(String.self, forKey: .workspace) ?? ""
         repo = try container.decodeIfPresent(String.self, forKey: .repo) ?? ""
         prompts = try container.decodeIfPresent([String].self, forKey: .prompts) ?? []
         schedule = try container.decodeIfPresent(JobSchedule.self, forKey: .schedule) ?? .interval(seconds: 86400)
@@ -60,7 +57,7 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, workspace, repo, prompts, schedule, enabled, lastRunAt, createdAt
+        case id, name, repo, prompts, schedule, enabled, lastRunAt, createdAt
     }
 
     /// Validate a job name, returning an error message or `nil` if valid.

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -252,6 +252,12 @@ import Testing
     #expect(WorkspaceInfo.validateName("My/Org", existingNames: []) != nil)
     #expect(WorkspaceInfo.validateName("My:Org", existingNames: []) != nil)
 
+    // Path-traversal names (would escape devRoot)
+    #expect(WorkspaceInfo.validateName(".", existingNames: []) != nil)
+    #expect(WorkspaceInfo.validateName("..", existingNames: []) != nil)
+    // A name merely containing a dot is still fine.
+    #expect(WorkspaceInfo.validateName("my.org", existingNames: []) == nil)
+
     // Valid with existing names that don't conflict
     #expect(WorkspaceInfo.validateName("NewOrg", existingNames: ["OtherOrg"]) == nil)
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
@@ -6,7 +6,8 @@ import Testing
     let config = AppConfig(jobs: [
         JobConfig(
             name: "Nightly Audit",
-            repo: "api",
+            workspace: "RadiusMethod",
+            repo: "radiusmethod/api",
             prompts: ["Run the audit", "Summarize findings"],
             schedule: .interval(seconds: 3600),
             enabled: true
@@ -21,7 +22,8 @@ import Testing
     #expect(decoded.jobs.count == 1)
     let job = decoded.jobs[0]
     #expect(job.name == "Nightly Audit")
-    #expect(job.repo == "api")
+    #expect(job.workspace == "RadiusMethod")
+    #expect(job.repo == "radiusmethod/api")
     #expect(job.prompts == ["Run the audit", "Summarize findings"])
     #expect(job.schedule == .interval(seconds: 3600))
     #expect(job.enabled == true)
@@ -30,7 +32,8 @@ import Testing
 @Test func jobConfigRoundTripDailyAt() throws {
     let job = JobConfig(
         name: "Standup",
-        repo: "web",
+        workspace: "Acme",
+        repo: "acme/web",
         prompts: ["Generate the standup report"],
         schedule: .dailyAt(hour: 9, minute: 30, weekdays: [2, 3, 4, 5, 6]),
         lastRunAt: Date(timeIntervalSince1970: 1_700_000_000)
@@ -39,21 +42,25 @@ import Testing
     let data = try JSONEncoder().encode(job)
     let decoded = try JSONDecoder().decode(JobConfig.self, from: data)
 
+    #expect(decoded.workspace == "Acme")
+    #expect(decoded.repo == "acme/web")
     #expect(decoded.schedule == .dailyAt(hour: 9, minute: 30, weekdays: [2, 3, 4, 5, 6]))
     #expect(decoded.lastRunAt == Date(timeIntervalSince1970: 1_700_000_000))
 }
 
-/// A job persisted before the workspace field was dropped must still decode:
-/// the stale `workspace` key is ignored and `repo` is preserved.
-@Test func jobConfigForwardCompatLegacyWorkspaceKey() throws {
+/// A job persisted before the workspace field returned (the brief free-form
+/// `repo`-only era) must still decode: the missing `workspace` defaults to ""
+/// and `repo` is preserved so it resolves by folder name at run time.
+@Test func jobConfigBackCompatMissingWorkspaceKey() throws {
     let json = """
-    {"id":"\(UUID().uuidString)","name":"Legacy","workspace":"Acme","repo":"api",
+    {"id":"\(UUID().uuidString)","name":"FreeForm","repo":"api",
      "prompts":["go"],"schedule":{"type":"interval","seconds":3600},
      "enabled":true,"createdAt":0}
     """
     let decoded = try JSONDecoder().decode(JobConfig.self, from: Data(json.utf8))
+    #expect(decoded.workspace == "")
     #expect(decoded.repo == "api")
-    #expect(decoded.name == "Legacy")
+    #expect(decoded.name == "FreeForm")
     #expect(decoded.prompts == ["go"])
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
@@ -6,7 +6,6 @@ import Testing
     let config = AppConfig(jobs: [
         JobConfig(
             name: "Nightly Audit",
-            workspace: "Acme",
             repo: "api",
             prompts: ["Run the audit", "Summarize findings"],
             schedule: .interval(seconds: 3600),
@@ -22,7 +21,6 @@ import Testing
     #expect(decoded.jobs.count == 1)
     let job = decoded.jobs[0]
     #expect(job.name == "Nightly Audit")
-    #expect(job.workspace == "Acme")
     #expect(job.repo == "api")
     #expect(job.prompts == ["Run the audit", "Summarize findings"])
     #expect(job.schedule == .interval(seconds: 3600))
@@ -32,7 +30,6 @@ import Testing
 @Test func jobConfigRoundTripDailyAt() throws {
     let job = JobConfig(
         name: "Standup",
-        workspace: "Acme",
         repo: "web",
         prompts: ["Generate the standup report"],
         schedule: .dailyAt(hour: 9, minute: 30, weekdays: [2, 3, 4, 5, 6]),
@@ -44,6 +41,20 @@ import Testing
 
     #expect(decoded.schedule == .dailyAt(hour: 9, minute: 30, weekdays: [2, 3, 4, 5, 6]))
     #expect(decoded.lastRunAt == Date(timeIntervalSince1970: 1_700_000_000))
+}
+
+/// A job persisted before the workspace field was dropped must still decode:
+/// the stale `workspace` key is ignored and `repo` is preserved.
+@Test func jobConfigForwardCompatLegacyWorkspaceKey() throws {
+    let json = """
+    {"id":"\(UUID().uuidString)","name":"Legacy","workspace":"Acme","repo":"api",
+     "prompts":["go"],"schedule":{"type":"interval","seconds":3600},
+     "enabled":true,"createdAt":0}
+    """
+    let decoded = try JSONDecoder().decode(JobConfig.self, from: Data(json.utf8))
+    #expect(decoded.repo == "api")
+    #expect(decoded.name == "Legacy")
+    #expect(decoded.prompts == ["go"])
 }
 
 /// A config file written before jobs existed must still decode (jobs → []).

--- a/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
@@ -62,6 +62,8 @@ import Testing
     #expect(decoded.repo == "api")
     #expect(decoded.name == "FreeForm")
     #expect(decoded.prompts == ["go"])
+    // createdAt:0 decodes as seconds since the reference date (2001-01-01).
+    #expect(decoded.createdAt == Date(timeIntervalSinceReferenceDate: 0))
 }
 
 /// A config file written before jobs existed must still decode (jobs → []).

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -111,6 +111,91 @@ public actor ProviderManager {
         )
     }
 
+    // MARK: - Repo listing (Jobs repo picker)
+
+    /// Expand a workspace's repo specs into a sorted, de-duplicated list of
+    /// `owner/repo` slugs.
+    ///
+    /// Each spec is either a glob (`owner/*` — list every repo owned by `owner`
+    /// via the provider) or an explicit slug (`owner/repo` — passed through
+    /// verbatim). Used to populate the Jobs form's repo picker from a
+    /// workspace's `alwaysInclude` entries.
+    public func reposForSpecs(_ specs: [String], provider: Provider, host: String?) async -> [String] {
+        var slugs: Set<String> = []
+        for spec in specs {
+            switch Self.classifySpec(spec) {
+            case .glob(let owner):
+                for slug in await listRepos(owner: owner, provider: provider, host: host) {
+                    slugs.insert(slug)
+                }
+            case .explicit(let slug):
+                slugs.insert(slug)
+            case .invalid:
+                continue
+            }
+        }
+        return slugs.sorted()
+    }
+
+    /// List every repo owned by `owner` as `owner/repo` slugs.
+    ///
+    /// Shells out to the provider CLI. Returns `[]` (logged) on any failure so
+    /// the form degrades to an empty picker rather than throwing.
+    public func listRepos(owner: String, provider: Provider, host: String?) async -> [String] {
+        do {
+            switch provider {
+            case .github:
+                let out = try await shell(
+                    "gh", "repo", "list", owner,
+                    "--limit", "1000", "--json", "nameWithOwner", "--jq", ".[].nameWithOwner"
+                )
+                return Self.nonEmptyLines(out)
+            case .gitlab:
+                var env: [String: String] = [:]
+                if let host { env["GITLAB_HOST"] = host }
+                let out = try await shell(
+                    env: env, cwd: NSHomeDirectory(),
+                    "glab", "api", "--paginate",
+                    "groups/\(owner)/projects?per_page=100&include_subgroups=true",
+                    "--jq", ".[].path_with_namespace"
+                )
+                return Self.nonEmptyLines(out)
+            }
+        } catch {
+            NSLog("[ProviderManager] listRepos failed for owner '\(owner)': \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// How a repo spec resolves: a glob over an owner, an explicit slug, or unusable.
+    enum RepoSpec: Equatable {
+        case glob(owner: String)
+        case explicit(slug: String)
+        case invalid
+    }
+
+    /// Classify a raw `alwaysInclude` entry. `owner/*` → glob; `owner/repo`
+    /// (or deeper, e.g. GitLab nested groups) → explicit slug; anything else
+    /// (empty, or a bare name with no owner) → invalid.
+    nonisolated static func classifySpec(_ raw: String) -> RepoSpec {
+        let spec = raw.trimmingCharacters(in: .whitespaces)
+        guard !spec.isEmpty else { return .invalid }
+        if spec.hasSuffix("/*") {
+            let owner = String(spec.dropLast(2)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            return owner.isEmpty ? .invalid : .glob(owner: owner)
+        }
+        // A usable explicit entry needs an owner and a repo (at least one "/").
+        guard spec.contains("/"), !spec.contains("*") else { return .invalid }
+        return .explicit(slug: spec)
+    }
+
+    private static func nonEmptyLines(_ output: String) -> [String] {
+        output
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
     private func extractTitle(from output: String) -> String? {
         // Try JSON first (GitHub gh output)
         if let data = output.data(using: .utf8),

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -153,10 +153,13 @@ public actor ProviderManager {
             case .gitlab:
                 var env: [String: String] = [:]
                 if let host { env["GITLAB_HOST"] = host }
+                // GitLab's group-by-path endpoint needs the full group path
+                // URL-encoded (`group/sub` → `group%2Fsub`); the raw slash 404s.
+                let encodedOwner = Self.encodeGitLabGroupPath(owner)
                 let out = try await shell(
                     env: env, cwd: NSHomeDirectory(),
                     "glab", "api", "--paginate",
-                    "groups/\(owner)/projects?per_page=100&include_subgroups=true",
+                    "groups/\(encodedOwner)/projects?per_page=100&include_subgroups=true",
                     "--jq", ".[].path_with_namespace"
                 )
                 return Self.nonEmptyLines(out)
@@ -194,6 +197,14 @@ public actor ProviderManager {
             .split(whereSeparator: \.isNewline)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+    }
+
+    /// Percent-encode a GitLab group path for the `groups/:id` API, where the
+    /// id may be a path like `group/sub` that must arrive as `group%2Fsub`.
+    /// Group paths are otherwise `[A-Za-z0-9_.-]`, so encoding the separators is
+    /// sufficient.
+    nonisolated static func encodeGitLabGroupPath(_ owner: String) -> String {
+        owner.replacingOccurrences(of: "/", with: "%2F")
     }
 
     private func extractTitle(from output: String) -> String? {

--- a/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
@@ -190,6 +190,16 @@ struct ProviderManagerTests {
         #expect(ProviderManager.classifySpec("/*") == .invalid)
     }
 
+    @Test func encodeGitLabGroupPathEncodesSeparators() {
+        // A nested-group glob (group/sub/*) yields owner "group/sub", which the
+        // GitLab groups endpoint needs as "group%2Fsub".
+        #expect(ProviderManager.encodeGitLabGroupPath("group/sub") == "group%2Fsub")
+    }
+
+    @Test func encodeGitLabGroupPathLeavesSimpleOwnerUnchanged() {
+        #expect(ProviderManager.encodeGitLabGroupPath("radiusmethod") == "radiusmethod")
+    }
+
     @Test func reposForSpecsKeepsExplicitSlugsSortedAndDeduped() async {
         // Explicit-only specs need no provider call, so this exercises the
         // merge/dedup/sort path without shelling out.

--- a/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
@@ -159,6 +159,47 @@ struct ProviderManagerTests {
         #expect(result?.repo == "sub")
     }
 
+    // MARK: - classifySpec (Jobs repo specs)
+
+    @Test func classifySpecGlobExtractsOwner() {
+        #expect(ProviderManager.classifySpec("radiusmethod/*") == .glob(owner: "radiusmethod"))
+    }
+
+    @Test func classifySpecNestedGroupGlob() {
+        #expect(ProviderManager.classifySpec("group/subgroup/*") == .glob(owner: "group/subgroup"))
+    }
+
+    @Test func classifySpecExplicitSlugPassesThrough() {
+        #expect(ProviderManager.classifySpec("radiusmethod/api") == .explicit(slug: "radiusmethod/api"))
+    }
+
+    @Test func classifySpecTrimsWhitespace() {
+        #expect(ProviderManager.classifySpec("  radiusmethod/api  ") == .explicit(slug: "radiusmethod/api"))
+    }
+
+    @Test func classifySpecBareNameIsInvalid() {
+        // No owner — can't list or clone it.
+        #expect(ProviderManager.classifySpec("api") == .invalid)
+    }
+
+    @Test func classifySpecEmptyIsInvalid() {
+        #expect(ProviderManager.classifySpec("   ") == .invalid)
+    }
+
+    @Test func classifySpecBareGlobIsInvalid() {
+        #expect(ProviderManager.classifySpec("/*") == .invalid)
+    }
+
+    @Test func reposForSpecsKeepsExplicitSlugsSortedAndDeduped() async {
+        // Explicit-only specs need no provider call, so this exercises the
+        // merge/dedup/sort path without shelling out.
+        let result = await manager.reposForSpecs(
+            ["org/zeta", "org/alpha", "org/alpha", "bare"],
+            provider: .github, host: nil
+        )
+        #expect(result == ["org/alpha", "org/zeta"])
+    }
+
     // MARK: - ProviderError
 
     @Test func providerErrorInvalidURLStoresURL() {

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -188,7 +188,7 @@ public struct JobFormView: View {
                     }
                 }
                 if didLoadRepos, !isLoadingRepos, repoOptions.isEmpty {
-                    Text("No repos found for this workspace. Set its “Always Include Repos” to e.g. owner/* or owner/repo in Workspaces settings, and check that gh/glab is authenticated.")
+                    Text("No repos found. In Workspaces settings, set this workspace's Always Include Repos to e.g. owner/* or owner/repo — and check that gh/glab is authenticated.")
                         .font(.caption).foregroundStyle(.secondary)
                 }
 

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -4,13 +4,13 @@ import CrowCore
 /// Form for creating or editing a scheduled job (CROW-317).
 ///
 /// Mirrors `WorkspaceFormView`: holds field state, validates, and constructs a
-/// `JobConfig` on save. A job is scoped to a workspace + repo, carries one or
-/// more prompts, and fires on an interval or daily at a time.
+/// `JobConfig` on save. A job is scoped to a repo (resolved by name under the
+/// dev root), carries one or more prompts, and fires on an interval or daily at
+/// a time.
 public struct JobFormView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var name: String
-    @State private var workspace: String
     @State private var repo: String
     @State private var prompts: [String]
     @State private var scheduleMode: ScheduleMode
@@ -24,7 +24,6 @@ public struct JobFormView: View {
     private let existingLastRunAt: Date?
     private let existingCreatedAt: Date
     private let existingNames: [String]
-    private let workspaces: [WorkspaceInfo]
     private let onSave: (JobConfig) -> Void
 
     enum ScheduleMode: Hashable { case interval, daily }
@@ -49,12 +48,10 @@ public struct JobFormView: View {
 
     /// - Parameters:
     ///   - job: An existing job to edit, or `nil` to create a new one.
-    ///   - workspaces: All configured workspaces (for the workspace/repo pickers).
     ///   - existingNames: Names of other jobs, used for duplicate detection.
     ///   - onSave: Called with the validated `JobConfig` when the user taps Save/Add.
     public init(
         job: JobConfig? = nil,
-        workspaces: [WorkspaceInfo] = [],
         existingNames: [String] = [],
         onSave: @escaping (JobConfig) -> Void
     ) {
@@ -62,11 +59,9 @@ public struct JobFormView: View {
         self.existingLastRunAt = job?.lastRunAt
         self.existingCreatedAt = job?.createdAt ?? Date()
         self.existingNames = existingNames
-        self.workspaces = workspaces
         self.onSave = onSave
 
         self._name = State(initialValue: job?.name ?? "")
-        self._workspace = State(initialValue: job?.workspace ?? workspaces.first?.name ?? "")
         self._repo = State(initialValue: job?.repo ?? "")
         self._prompts = State(initialValue: job?.prompts.isEmpty == false ? job!.prompts : [""])
         self._enabled = State(initialValue: job?.enabled ?? true)
@@ -107,17 +102,8 @@ public struct JobFormView: View {
         JobConfig.validateName(trimmedName, existingNames: existingNames)
     }
 
-    /// Repos to offer for the selected workspace (its `alwaysInclude`), plus the
-    /// current value if it isn't listed (so editing an off-list repo still works).
-    private var repoOptions: [String] {
-        var options = workspaces.first(where: { $0.name == workspace })?.alwaysInclude ?? []
-        if !repo.isEmpty, !options.contains(repo) { options.insert(repo, at: 0) }
-        return options
-    }
-
     private var isValid: Bool {
         nameValidationError == nil
-            && !workspace.isEmpty
             && !repo.trimmingCharacters(in: .whitespaces).isEmpty
             && !nonEmptyPrompts.isEmpty
             && (scheduleMode == .daily || intervalValue >= 1)
@@ -132,25 +118,10 @@ public struct JobFormView: View {
                     Text(error).font(.caption).foregroundStyle(.red)
                 }
 
-                Picker("Workspace", selection: $workspace) {
-                    ForEach(workspaces) { ws in Text(ws.name).tag(ws.name) }
-                }
-                .onChange(of: workspace) { _, _ in
-                    // Reset repo when it no longer belongs to the chosen workspace.
-                    if !repoOptions.contains(repo) { repo = "" }
-                }
-
-                if repoOptions.isEmpty {
-                    TextField("Repo", text: $repo)
-                        .textFieldStyle(.roundedBorder)
-                    Text("Folder name of the repo under the workspace (e.g. \"api\").")
-                        .font(.caption).foregroundStyle(.secondary)
-                } else {
-                    Picker("Repo", selection: $repo) {
-                        Text("Select…").tag("")
-                        ForEach(repoOptions, id: \.self) { Text($0).tag($0) }
-                    }
-                }
+                TextField("Repo", text: $repo)
+                    .textFieldStyle(.roundedBorder)
+                Text("Folder name of the repo under the dev root (e.g. \"api\").")
+                    .font(.caption).foregroundStyle(.secondary)
 
                 Toggle("Enabled", isOn: $enabled)
             }
@@ -257,7 +228,6 @@ public struct JobFormView: View {
         return JobConfig(
             id: existingID ?? UUID(),
             name: trimmedName,
-            workspace: workspace,
             repo: repo.trimmingCharacters(in: .whitespaces),
             prompts: nonEmptyPrompts,
             schedule: schedule,

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -4,13 +4,14 @@ import CrowCore
 /// Form for creating or editing a scheduled job (CROW-317).
 ///
 /// Mirrors `WorkspaceFormView`: holds field state, validates, and constructs a
-/// `JobConfig` on save. A job is scoped to a repo (resolved by name under the
-/// dev root), carries one or more prompts, and fires on an interval or daily at
-/// a time.
+/// `JobConfig` on save. A job is scoped to a repo within a workspace; the repo
+/// list is loaded from the workspace's provider. The job carries one or more
+/// prompts and fires on an interval or daily at a time.
 public struct JobFormView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var name: String
+    @State private var workspace: String
     @State private var repo: String
     @State private var prompts: [String]
     @State private var scheduleMode: ScheduleMode
@@ -20,6 +21,13 @@ public struct JobFormView: View {
     @State private var weekdays: Set<Int>
     @State private var enabled: Bool
 
+    /// Repo slugs for the selected workspace, loaded via `listRepos`.
+    @State private var repoOptions: [String] = []
+    @State private var isLoadingRepos = false
+    @State private var didLoadRepos = false
+
+    private let workspaces: [WorkspaceInfo]
+    private let listRepos: (WorkspaceInfo) async -> [String]
     private let existingID: UUID?
     private let existingLastRunAt: Date?
     private let existingCreatedAt: Date
@@ -48,13 +56,19 @@ public struct JobFormView: View {
 
     /// - Parameters:
     ///   - job: An existing job to edit, or `nil` to create a new one.
+    ///   - workspaces: Workspaces to choose from; their providers source the repo list.
     ///   - existingNames: Names of other jobs, used for duplicate detection.
+    ///   - listRepos: Loads the `owner/repo` slugs available to a workspace.
     ///   - onSave: Called with the validated `JobConfig` when the user taps Save/Add.
     public init(
         job: JobConfig? = nil,
+        workspaces: [WorkspaceInfo] = [],
         existingNames: [String] = [],
+        listRepos: @escaping (WorkspaceInfo) async -> [String] = { _ in [] },
         onSave: @escaping (JobConfig) -> Void
     ) {
+        self.workspaces = workspaces
+        self.listRepos = listRepos
         self.existingID = job?.id
         self.existingLastRunAt = job?.lastRunAt
         self.existingCreatedAt = job?.createdAt ?? Date()
@@ -62,6 +76,8 @@ public struct JobFormView: View {
         self.onSave = onSave
 
         self._name = State(initialValue: job?.name ?? "")
+        // Default to the job's workspace, else the first available workspace.
+        self._workspace = State(initialValue: job?.workspace ?? workspaces.first?.name ?? "")
         self._repo = State(initialValue: job?.repo ?? "")
         self._prompts = State(initialValue: job?.prompts.isEmpty == false ? job!.prompts : [""])
         self._enabled = State(initialValue: job?.enabled ?? true)
@@ -102,11 +118,36 @@ public struct JobFormView: View {
         JobConfig.validateName(trimmedName, existingNames: existingNames)
     }
 
+    /// The currently selected workspace, if any.
+    private var selectedWorkspace: WorkspaceInfo? {
+        workspaces.first { $0.name == workspace }
+    }
+
+    /// Repo options shown in the picker. Includes the current `repo` (when
+    /// editing) even if it isn't in the loaded list, so the saved value survives.
+    private var repoChoices: [String] {
+        var choices = repoOptions
+        if !repo.isEmpty, !choices.contains(repo) { choices.insert(repo, at: 0) }
+        return choices
+    }
+
     private var isValid: Bool {
         nameValidationError == nil
+            && !workspace.isEmpty
             && !repo.trimmingCharacters(in: .whitespaces).isEmpty
             && !nonEmptyPrompts.isEmpty
             && (scheduleMode == .daily || intervalValue >= 1)
+    }
+
+    /// Load the selected workspace's repo list, replacing any prior options.
+    private func loadRepos() async {
+        guard let ws = selectedWorkspace else {
+            repoOptions = []
+            return
+        }
+        isLoadingRepos = true
+        defer { isLoadingRepos = false; didLoadRepos = true }
+        repoOptions = await listRepos(ws)
     }
 
     public var body: some View {
@@ -118,10 +159,29 @@ public struct JobFormView: View {
                     Text(error).font(.caption).foregroundStyle(.red)
                 }
 
-                TextField("Repo", text: $repo)
-                    .textFieldStyle(.roundedBorder)
-                Text("Folder name of the repo under the dev root (e.g. \"api\").")
-                    .font(.caption).foregroundStyle(.secondary)
+                Picker("Workspace", selection: $workspace) {
+                    ForEach(workspaces) { ws in Text(ws.name).tag(ws.name) }
+                }
+                .onChange(of: workspace) { _, _ in
+                    // Reset repo when it no longer belongs to the chosen workspace.
+                    repo = ""
+                    Task { await loadRepos() }
+                }
+
+                HStack {
+                    Picker("Repo", selection: $repo) {
+                        Text("Select…").tag("")
+                        ForEach(repoChoices, id: \.self) { Text($0).tag($0) }
+                    }
+                    .disabled(isLoadingRepos)
+                    if isLoadingRepos {
+                        ProgressView().controlSize(.small)
+                    }
+                }
+                if didLoadRepos, !isLoadingRepos, repoOptions.isEmpty {
+                    Text("No repos found for this workspace. Set its “Always Include Repos” to e.g. \(workspace.isEmpty ? "owner" : workspace.lowercased())/* in Workspaces settings.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
 
                 Toggle("Enabled", isOn: $enabled)
             }
@@ -214,6 +274,7 @@ public struct JobFormView: View {
             .padding()
         }
         .frame(width: 460, height: 600)
+        .task { await loadRepos() }
     }
 
     private func buildJob() -> JobConfig {
@@ -228,6 +289,7 @@ public struct JobFormView: View {
         return JobConfig(
             id: existingID ?? UUID(),
             name: trimmedName,
+            workspace: workspace,
             repo: repo.trimmingCharacters(in: .whitespaces),
             prompts: nonEmptyPrompts,
             schedule: schedule,

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -25,6 +25,8 @@ public struct JobFormView: View {
     @State private var repoOptions: [String] = []
     @State private var isLoadingRepos = false
     @State private var didLoadRepos = false
+    /// Bumped on each load so a stale slow response can't clobber a newer one.
+    @State private var loadGeneration = 0
 
     private let workspaces: [WorkspaceInfo]
     private let listRepos: (WorkspaceInfo) async -> [String]
@@ -140,14 +142,21 @@ public struct JobFormView: View {
     }
 
     /// Load the selected workspace's repo list, replacing any prior options.
+    /// Discards the result if the selection changed while loading.
     private func loadRepos() async {
         guard let ws = selectedWorkspace else {
             repoOptions = []
             return
         }
+        loadGeneration += 1
+        let generation = loadGeneration
         isLoadingRepos = true
-        defer { isLoadingRepos = false; didLoadRepos = true }
-        repoOptions = await listRepos(ws)
+        let result = await listRepos(ws)
+        // A newer load started while we were awaiting — drop this stale result.
+        guard generation == loadGeneration else { return }
+        repoOptions = result
+        isLoadingRepos = false
+        didLoadRepos = true
     }
 
     public var body: some View {
@@ -179,7 +188,7 @@ public struct JobFormView: View {
                     }
                 }
                 if didLoadRepos, !isLoadingRepos, repoOptions.isEmpty {
-                    Text("No repos found for this workspace. Set its “Always Include Repos” to e.g. \(workspace.isEmpty ? "owner" : workspace.lowercased())/* in Workspaces settings.")
+                    Text("No repos found for this workspace. Set its “Always Include Repos” to e.g. owner/* or owner/repo in Workspaces settings, and check that gh/glab is authenticated.")
                         .font(.caption).foregroundStyle(.secondary)
                 }
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -85,7 +85,6 @@ public struct SettingsView: View {
         }
         .sheet(isPresented: $isAddingJob) {
             JobFormView(
-                workspaces: config.workspaces,
                 existingNames: otherJobNames()
             ) { job in
                 config.jobs.append(job)
@@ -95,7 +94,6 @@ public struct SettingsView: View {
         .sheet(item: $editingJob) { job in
             JobFormView(
                 job: job,
-                workspaces: config.workspaces,
                 existingNames: otherJobNames(excluding: job.id)
             ) { updated in
                 if let idx = config.jobs.firstIndex(where: { $0.id == updated.id }) {
@@ -339,7 +337,7 @@ public struct SettingsView: View {
 
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(job.name).fontWeight(.medium)
-                                Text("\(job.workspace)/\(job.repo) · \(scheduleSummary(job.schedule))")
+                                Text("\(job.repo) · \(scheduleSummary(job.schedule))")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                                 Text("\(lastRunText(job)) · \(nextRunText(job))")
@@ -379,18 +377,11 @@ public struct SettingsView: View {
                             .font(.caption)
                     }
                     .buttonStyle(.borderless)
-                    .disabled(config.workspaces.isEmpty)
                 }
             } footer: {
-                if config.workspaces.isEmpty {
-                    Text("Add a workspace first — jobs are scoped to a repo in a workspace.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text("Scheduled prompt sets. When a job fires, Crow creates a worktree + session in the scoped repo and runs its prompts.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                Text("Scheduled prompt sets. When a job fires, Crow creates a worktree + session in the scoped repo and runs its prompts.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -85,7 +85,9 @@ public struct SettingsView: View {
         }
         .sheet(isPresented: $isAddingJob) {
             JobFormView(
-                existingNames: otherJobNames()
+                workspaces: config.workspaces,
+                existingNames: otherJobNames(),
+                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? [] }
             ) { job in
                 config.jobs.append(job)
                 save()
@@ -94,7 +96,9 @@ public struct SettingsView: View {
         .sheet(item: $editingJob) { job in
             JobFormView(
                 job: job,
-                existingNames: otherJobNames(excluding: job.id)
+                workspaces: config.workspaces,
+                existingNames: otherJobNames(excluding: job.id),
+                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? [] }
             ) { updated in
                 if let idx = config.jobs.firstIndex(where: { $0.id == updated.id }) {
                     config.jobs[idx] = updated
@@ -337,7 +341,7 @@ public struct SettingsView: View {
 
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(job.name).fontWeight(.medium)
-                                Text("\(job.repo) · \(scheduleSummary(job.schedule))")
+                                Text("\(jobScope(job)) · \(scheduleSummary(job.schedule))")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                                 Text("\(lastRunText(job)) · \(nextRunText(job))")
@@ -377,14 +381,27 @@ public struct SettingsView: View {
                             .font(.caption)
                     }
                     .buttonStyle(.borderless)
+                    .disabled(config.workspaces.isEmpty)
                 }
             } footer: {
-                Text("Scheduled prompt sets. When a job fires, Crow creates a worktree + session in the scoped repo and runs its prompts.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if config.workspaces.isEmpty {
+                    Text("Add a workspace first — jobs are scoped to a repo in a workspace.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Scheduled prompt sets. When a job fires, Crow creates a worktree + session in the scoped repo and runs its prompts.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .formStyle(.grouped)
+    }
+
+    /// "workspace/repo" for a job, or just the repo when no workspace is stored
+    /// (jobs persisted before the workspace field returned).
+    private func jobScope(_ job: JobConfig) -> String {
+        job.workspace.isEmpty ? job.repo : "\(job.workspace)/\(job.repo)"
     }
 
     /// Human-readable summary of a job's schedule (e.g. "every 4 hours", "Mon,Wed at 09:00").

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -398,10 +398,12 @@ public struct SettingsView: View {
         .formStyle(.grouped)
     }
 
-    /// "workspace/repo" for a job, or just the repo when no workspace is stored
-    /// (jobs persisted before the workspace field returned).
+    /// How a job's repo is shown. `repo` is already an `owner/repo` slug, so we
+    /// show it as-is (avoiding a redundant "workspace/owner/repo"); the
+    /// workspace is prefixed only for legacy bare-name jobs that lack an owner.
     private func jobScope(_ job: JobConfig) -> String {
-        job.workspace.isEmpty ? job.repo : "\(job.workspace)/\(job.repo)"
+        if job.repo.contains("/") { return job.repo }
+        return job.workspace.isEmpty ? job.repo : "\(job.workspace)/\(job.repo)"
     }
 
     /// Human-readable summary of a job's schedule (e.g. "every 4 hours", "Mon,Wed at 09:00").

--- a/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
@@ -71,7 +71,7 @@ public struct WorkspaceFormView: View {
 
                 TextField("Always Include Repos", text: $alwaysIncludeText)
                     .textFieldStyle(.roundedBorder)
-                Text("Comma-separated list of repos to always show in the workspace prompt.")
+                Text("Comma-separated repo specs: owner/* lists all of an org's repos, or owner/repo for a single repo. Populates the Jobs repo picker.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -647,7 +647,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSLog("[AppDelegate] Workspace '\(ws.name)': unknown provider '\(ws.provider)', defaulting to GitHub")
                 provider = .github
             }
-            let key = "\(ws.name)\u{1}\(ws.alwaysInclude.joined(separator: ","))"
+            // Key includes provider + host so flipping a workspace's provider
+            // (or GitLab host) without changing its specs doesn't return stale,
+            // wrong-provider slugs within the TTL window.
+            let key = [
+                ws.name, ws.provider, ws.host ?? "", ws.alwaysInclude.joined(separator: ","),
+            ].joined(separator: "\u{1}")
             if let cached = self.workspaceRepoCache[key],
                Date().timeIntervalSince(cached.fetchedAt) < self.workspaceRepoCacheTTL {
                 return cached.repos

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 import CrowCore
 import CrowGit
+import CrowProvider
 import CrowUI
 import CrowPersistence
 import CrowTerminal
@@ -624,6 +625,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         appState.onPromoteToGlobal = { [weak allowList] patterns in
             allowList?.promoteToGlobal(patterns: patterns)
+        }
+
+        // Jobs repo picker: expand a workspace's alwaysInclude specs (owner/*,
+        // owner/repo) into the repos available from its provider.
+        appState.onListWorkspaceRepos = { ws in
+            let provider = Provider(rawValue: ws.provider) ?? .github
+            return await ProviderManager().reposForSpecs(
+                ws.alwaysInclude, provider: provider, host: ws.host
+            )
         }
 
         // Hydrate mute state from config and wire toggle

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -28,6 +28,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var devRoot: String?
     private var appConfig: AppConfig?
 
+    /// Reused for the Jobs repo picker (avoids a fresh instance per form open).
+    private let providerManager = ProviderManager()
+    /// Cache of expanded `alwaysInclude` repo lists, keyed by workspace name +
+    /// its specs, with a short TTL so repeated form opens don't re-hit the
+    /// provider CLI.
+    private var workspaceRepoCache: [String: (fetchedAt: Date, repos: [String])] = [:]
+    private let workspaceRepoCacheTTL: TimeInterval = 300
+
     /// Tail of the serial review-kickoff queue. Each call to
     /// `enqueueReviewKickoff` awaits the previous tail before doing any work,
     /// so all `createReviewSession` runs are strictly sequential across both
@@ -628,12 +636,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Jobs repo picker: expand a workspace's alwaysInclude specs (owner/*,
-        // owner/repo) into the repos available from its provider.
-        appState.onListWorkspaceRepos = { ws in
-            let provider = Provider(rawValue: ws.provider) ?? .github
-            return await ProviderManager().reposForSpecs(
+        // owner/repo) into the repos available from its provider. Results are
+        // cached per (workspace, specs) with a short TTL.
+        appState.onListWorkspaceRepos = { [weak self] ws in
+            guard let self else { return [] }
+            let provider: Provider
+            if let p = Provider(rawValue: ws.provider) {
+                provider = p
+            } else {
+                NSLog("[AppDelegate] Workspace '\(ws.name)': unknown provider '\(ws.provider)', defaulting to GitHub")
+                provider = .github
+            }
+            let key = "\(ws.name)\u{1}\(ws.alwaysInclude.joined(separator: ","))"
+            if let cached = self.workspaceRepoCache[key],
+               Date().timeIntervalSince(cached.fetchedAt) < self.workspaceRepoCacheTTL {
+                return cached.repos
+            }
+            let repos = await self.providerManager.reposForSpecs(
                 ws.alwaysInclude, provider: provider, host: ws.host
             )
+            self.workspaceRepoCache[key] = (Date(), repos)
+            return repos
         }
 
         // Hydrate mute state from config and wire toggle

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1256,13 +1256,20 @@ final class SessionService {
             return nil
         }
 
-        let workspacePath = (devRoot as NSString).appendingPathComponent(job.workspace)
-        let repoPath = (workspacePath as NSString).appendingPathComponent(job.repo)
-        let gitDir = (repoPath as NSString).appendingPathComponent(".git")
-        guard FileManager.default.fileExists(atPath: gitDir) else {
-            NSLog("[SessionService] Job '\(job.name)': repo not found at \(repoPath)")
+        // Resolve the repo by folder name among the checkouts under the dev root.
+        // The repo's workspace is implied by its location, so jobs only store a
+        // repo name (CROW-327). First match wins if a name is duplicated.
+        let gitManager = GitManager(config: WorkspaceConfig(
+            devRoot: devRoot, workspaces: [:], defaults: WorkspaceDefaults()
+        ))
+        let repos = (try? await gitManager.discoverRepos()) ?? []
+        guard let repoInfo = repos.first(where: { $0.name == job.repo }) else {
+            NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' not found under devRoot")
             return nil
         }
+        let repoPath = repoInfo.path
+        // Worktree is a sibling of the repo checkout (matches the naming rule).
+        let workspacePath = (repoPath as NSString).deletingLastPathComponent
 
         let slug = Self.slugify(job.name)
         let stamp = Self.runStamp()
@@ -1271,9 +1278,6 @@ final class SessionService {
             .appendingPathComponent("\(job.repo)-job-\(slug)-\(stamp)")
 
         // Create the worktree on disk (fetch + new branch off default + retry).
-        let gitManager = GitManager(config: WorkspaceConfig(
-            devRoot: devRoot, workspaces: [:], defaults: WorkspaceDefaults()
-        ))
         do {
             try await gitManager.createWorktree(
                 repoPath: repoPath, worktreePath: worktreePath, branch: branch

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1256,26 +1256,46 @@ final class SessionService {
             return nil
         }
 
-        // Resolve the repo by folder name among the checkouts under the dev root.
-        // The repo's workspace is implied by its location, so jobs only store a
-        // repo name (CROW-327). First match wins if a name is duplicated.
         let gitManager = GitManager(config: WorkspaceConfig(
             devRoot: devRoot, workspaces: [:], defaults: WorkspaceDefaults()
         ))
-        let repos = (try? await gitManager.discoverRepos()) ?? []
-        guard let repoInfo = repos.first(where: { $0.name == job.repo }) else {
-            NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' not found under devRoot")
-            return nil
+
+        // Resolve the repo to a local checkout. The job carries a workspace and
+        // an `owner/repo` slug (CROW-327): the checkout lives at
+        // `{devRoot}/{workspace}/{repoFolder}` where repoFolder is the slug's
+        // last component. Clone it on demand if it isn't on disk yet.
+        let repoFolder = job.repo.contains("/")
+            ? (job.repo as NSString).lastPathComponent
+            : job.repo
+        let repoPath: String
+        let workspacePath: String
+
+        if !job.workspace.isEmpty {
+            workspacePath = (devRoot as NSString).appendingPathComponent(job.workspace)
+            repoPath = (workspacePath as NSString).appendingPathComponent(repoFolder)
+            if !FileManager.default.fileExists(atPath: (repoPath as NSString).appendingPathComponent(".git")) {
+                guard await cloneJobRepo(job: job, devRoot: devRoot, into: repoPath) else {
+                    NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' is not cloned and clone-on-demand failed")
+                    return nil
+                }
+            }
+        } else {
+            // Back-compat: jobs saved before the workspace field returned store a
+            // bare repo name. Resolve by folder name among local checkouts.
+            let repos = (try? await gitManager.discoverRepos()) ?? []
+            guard let repoInfo = repos.first(where: { $0.name == job.repo }) else {
+                NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' not found under devRoot")
+                return nil
+            }
+            repoPath = repoInfo.path
+            workspacePath = (repoPath as NSString).deletingLastPathComponent
         }
-        let repoPath = repoInfo.path
-        // Worktree is a sibling of the repo checkout (matches the naming rule).
-        let workspacePath = (repoPath as NSString).deletingLastPathComponent
 
         let slug = Self.slugify(job.name)
         let stamp = Self.runStamp()
         let branch = "feature/job-\(slug)-\(stamp)"
         let worktreePath = (workspacePath as NSString)
-            .appendingPathComponent("\(job.repo)-job-\(slug)-\(stamp)")
+            .appendingPathComponent("\(repoFolder)-job-\(slug)-\(stamp)")
 
         // Create the worktree on disk (fetch + new branch off default + retry).
         do {
@@ -1297,7 +1317,7 @@ final class SessionService {
         )
         let worktree = SessionWorktree(
             sessionID: session.id,
-            repoName: job.repo,
+            repoName: repoFolder,
             repoPath: repoPath,
             worktreePath: worktreePath,
             branch: branch,
@@ -1327,6 +1347,36 @@ final class SessionService {
 
         NSLog("[SessionService] Job '\(job.name)': created session '\(session.name)' at \(worktreePath)")
         return (session.id, preparedTerminal.id)
+    }
+
+    /// Clone a job's repo into `destination` on demand (the provider list can
+    /// include repos not yet checked out). Needs an `owner/repo` slug; the
+    /// workspace supplies the provider and (for GitLab) the host. Returns
+    /// whether a `.git` checkout exists at `destination` afterward.
+    private func cloneJobRepo(job: JobConfig, devRoot: String, into destination: String) async -> Bool {
+        guard job.repo.contains("/") else {
+            NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' is not an owner/repo slug; cannot clone")
+            return false
+        }
+        let workspace = ConfigStore.loadConfig(devRoot: devRoot)?
+            .workspaces.first { $0.name == job.workspace }
+        let provider = workspace?.provider ?? "github"
+
+        NSLog("[SessionService] Job '\(job.name)': cloning \(job.repo) into \(destination)")
+        do {
+            if provider == "gitlab" {
+                if let host = workspace?.host, !host.isEmpty {
+                    _ = try await shell("GITLAB_HOST=\(host)", "glab", "repo", "clone", job.repo, destination)
+                } else {
+                    _ = try await shell("glab", "repo", "clone", job.repo, destination)
+                }
+            } else {
+                _ = try await shell("gh", "repo", "clone", job.repo, destination)
+            }
+        } catch {
+            NSLog("[SessionService] Job '\(job.name)': clone failed: \(error.localizedDescription)")
+        }
+        return FileManager.default.fileExists(atPath: (destination as NSString).appendingPathComponent(".git"))
     }
 
     /// A filesystem/branch-safe slug derived from a job name.

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1386,6 +1386,13 @@ final class SessionService {
             .workspaces.first { $0.name == job.workspace }
         let provider = workspace?.provider ?? "github"
 
+        // Ensure the workspace parent exists — a brand-new workspace may have no
+        // checkouts on disk yet, and git won't create leading directories.
+        try? FileManager.default.createDirectory(
+            atPath: (destination as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+
         NSLog("[SessionService] Job '\(job.name)': cloning \(job.repo) into \(destination)")
         do {
             if provider == "gitlab" {

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -701,13 +701,15 @@ final class SessionService {
     // MARK: - Worktree Safety Checks
     // Protected branch and main-checkout detection are centralized on SessionWorktree in CrowCore.
 
-    private func shell(_ args: String...) async throws -> String {
+    private func shell(env: [String: String] = [:], _ args: String...) async throws -> String {
         let process = Process()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = args
-        process.environment = ShellEnvironment.shared.env
+        process.environment = env.isEmpty
+            ? ShellEnvironment.shared.env
+            : ShellEnvironment.shared.merging(env)
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
         try process.run()
@@ -1264,15 +1266,16 @@ final class SessionService {
         // an `owner/repo` slug (CROW-327): the checkout lives at
         // `{devRoot}/{workspace}/{repoFolder}` where repoFolder is the slug's
         // last component. Clone it on demand if it isn't on disk yet.
-        let repoFolder = job.repo.contains("/")
-            ? (job.repo as NSString).lastPathComponent
-            : job.repo
+        let repoFolder = Self.jobRepoFolder(for: job.repo)
         let repoPath: String
         let workspacePath: String
 
         if !job.workspace.isEmpty {
-            workspacePath = (devRoot as NSString).appendingPathComponent(job.workspace)
-            repoPath = (workspacePath as NSString).appendingPathComponent(repoFolder)
+            let layout = Self.jobWorktreeLayout(
+                devRoot: devRoot, workspace: job.workspace, repo: job.repo
+            )
+            workspacePath = layout.workspacePath
+            repoPath = layout.repoPath
             if !FileManager.default.fileExists(atPath: (repoPath as NSString).appendingPathComponent(".git")) {
                 guard await cloneJobRepo(job: job, devRoot: devRoot, into: repoPath) else {
                     NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' is not cloned and clone-on-demand failed")
@@ -1281,8 +1284,10 @@ final class SessionService {
             }
         } else {
             // Back-compat: jobs saved before the workspace field returned store a
-            // bare repo name. Resolve by folder name among local checkouts.
-            let repos = (try? await gitManager.discoverRepos()) ?? []
+            // bare repo name. Resolve by folder name among local checkouts. Sort
+            // first so a duplicated name binds deterministically across runs.
+            let repos = ((try? await gitManager.discoverRepos()) ?? [])
+                .sorted { $0.path < $1.path }
             guard let repoInfo = repos.first(where: { $0.name == job.repo }) else {
                 NSLog("[SessionService] Job '\(job.name)': repo '\(job.repo)' not found under devRoot")
                 return nil
@@ -1349,6 +1354,25 @@ final class SessionService {
         return (session.id, preparedTerminal.id)
     }
 
+    /// The local folder name for a job's repo: the slug's last component
+    /// (`radiusmethod/api` → `api`, GitLab `group/sub/proj` → `proj`), or the
+    /// value verbatim when it isn't a slug (legacy bare-name jobs).
+    nonisolated static func jobRepoFolder(for repo: String) -> String {
+        repo.contains("/") ? (repo as NSString).lastPathComponent : repo
+    }
+
+    /// Where a workspace-scoped job's checkout and worktree parent live:
+    /// `{devRoot}/{workspace}/{repoFolder}`. Pure path math (no filesystem),
+    /// so it's unit-testable independent of clone/worktree side effects.
+    nonisolated static func jobWorktreeLayout(
+        devRoot: String, workspace: String, repo: String
+    ) -> (workspacePath: String, repoPath: String, repoFolder: String) {
+        let repoFolder = jobRepoFolder(for: repo)
+        let workspacePath = (devRoot as NSString).appendingPathComponent(workspace)
+        let repoPath = (workspacePath as NSString).appendingPathComponent(repoFolder)
+        return (workspacePath, repoPath, repoFolder)
+    }
+
     /// Clone a job's repo into `destination` on demand (the provider list can
     /// include repos not yet checked out). Needs an `owner/repo` slug; the
     /// workspace supplies the provider and (for GitLab) the host. Returns
@@ -1365,11 +1389,9 @@ final class SessionService {
         NSLog("[SessionService] Job '\(job.name)': cloning \(job.repo) into \(destination)")
         do {
             if provider == "gitlab" {
-                if let host = workspace?.host, !host.isEmpty {
-                    _ = try await shell("GITLAB_HOST=\(host)", "glab", "repo", "clone", job.repo, destination)
-                } else {
-                    _ = try await shell("glab", "repo", "clone", job.repo, destination)
-                }
+                var env: [String: String] = [:]
+                if let host = workspace?.host, !host.isEmpty { env["GITLAB_HOST"] = host }
+                _ = try await shell(env: env, "glab", "repo", "clone", job.repo, destination)
             } else {
                 _ = try await shell("gh", "repo", "clone", job.repo, destination)
             }

--- a/Tests/CrowTests/JobRepoResolutionTests.swift
+++ b/Tests/CrowTests/JobRepoResolutionTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import Crow
+
+/// Resolution logic for where a job's repo lives on disk (CROW-327). A job's
+/// `repo` is an `owner/repo` slug; the checkout is the slug's last component
+/// under `{devRoot}/{workspace}/`. Legacy jobs store a bare repo name and a
+/// blank workspace, which `runJob` instead resolves by folder name.
+@Suite("Job repo resolution")
+struct JobRepoResolutionTests {
+
+    @Test func repoFolderTakesSlugLastComponent() {
+        #expect(SessionService.jobRepoFolder(for: "radiusmethod/api") == "api")
+    }
+
+    @Test func repoFolderHandlesNestedGitLabGroups() {
+        #expect(SessionService.jobRepoFolder(for: "group/sub/project") == "project")
+    }
+
+    @Test func repoFolderPassesBareNameThrough() {
+        // Legacy bare-name jobs (no owner) keep their value verbatim.
+        #expect(SessionService.jobRepoFolder(for: "api") == "api")
+    }
+
+    @Test func worktreeLayoutComposesWorkspaceScopedPath() {
+        let layout = SessionService.jobWorktreeLayout(
+            devRoot: "/dev", workspace: "RadiusMethod", repo: "radiusmethod/api"
+        )
+        #expect(layout.workspacePath == "/dev/RadiusMethod")
+        #expect(layout.repoPath == "/dev/RadiusMethod/api")
+        #expect(layout.repoFolder == "api")
+    }
+
+    @Test func worktreeLayoutUsesSlugLastComponentForNestedGroup() {
+        let layout = SessionService.jobWorktreeLayout(
+            devRoot: "/dev", workspace: "Corp", repo: "group/sub/project"
+        )
+        #expect(layout.repoPath == "/dev/Corp/project")
+        #expect(layout.repoFolder == "project")
+    }
+}


### PR DESCRIPTION
Closes #327

## Summary
The Jobs form scopes a job to a **workspace + a repo chosen from that workspace's provider** (GitHub/GitLab). The repo list is built by expanding the workspace's **"Always Include Repos"** specs — `owner/*` org globs and explicit `owner/repo` slugs — against the provider. Repos not yet checked out are **cloned on demand** when the job fires.

> Note: the branch's first commit (`df1b2c8`) implemented a free-form repo field and dropped the workspace; that direction was **superseded** by maintainer feedback. The net diff is the workspace + provider-sourced picker described here.

## Changes
- **`ProviderManager`** (net-new): `listRepos(owner:provider:host:)` shells out (`gh repo list` / `glab api`); `reposForSpecs(_:provider:host:)` expands `alwaysInclude` specs (globs + explicit slugs) into a de-duplicated, sorted slug list; `classifySpec` is a `nonisolated static` helper with unit tests.
- **`AppState`**: new `onListWorkspaceRepos` hook (async, returns slugs).
- **`AppDelegate`**: wires the hook to a **reused** `ProviderManager`, caches results per `(workspace, specs)` with a 5-min TTL, and logs unknown-provider fallback to GitHub.
- **`JobConfig`**: `workspace` field restored; `repo` now holds an `owner/repo` slug. Decoding stays forward/back-compatible — legacy `{workspace, repo}` jobs **and** the transient free-form `repo`-only jobs both decode.
- **`JobFormView`**: workspace `Picker` + a provider-loaded repo `Picker` (spinner while loading; stale loads cancelled via a generation token; generic empty-state hint).
- **`SessionService.runJob`**: resolves `{devRoot}/{workspace}/{repoFolder}` (pure `jobRepoFolder` / `jobWorktreeLayout` helpers) and **clones on demand** (gh/glab, `GITLAB_HOST` via an `env:` dict on `shell`) when the repo isn't checked out. Blank-workspace (legacy) jobs fall back to a sorted discover-by-name.
- **`SettingsView`** (workspace/repo row + add-a-workspace-first guard) and **`WorkspaceFormView`** help text updated for the new spec format.

## Testing
arm64 `swift build` succeeds. Suites pass: **CrowCore 180**, **CrowProvider 33** (incl. `classifySpec`/`reposForSpecs` tests), **CrowUI 31**, root **122** (incl. new `JobRepoResolutionTests`).

## Known limitation
Duplicate repo folder names across workspaces resolve to the first match (now sorted, so deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)