### PR TITLE
fix: keep UI responsive when concurrent PR reviews arrive (#304)

### DIFF
--- a/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
@@ -37,6 +37,15 @@ public final class JSONStore: Sendable {
     private let fileURL: URL
     private let lock = NSLock()
     private nonisolated(unsafe) var _data: StoreData
+    /// Monotonic mutation counter, bumped under `lock` for every `mutate`.
+    /// Each snapshot carries the sequence it was taken at so the write path
+    /// can drop stale snapshots (see `mutate`).
+    private nonisolated(unsafe) var writeSeq: UInt64 = 0
+    /// Serializes disk writes independently of `lock`, so the in-memory data
+    /// lock is never held across the (potentially slow) encode + atomic write.
+    private let writeLock = NSLock()
+    /// Highest sequence already persisted, guarded by `writeLock`.
+    private nonisolated(unsafe) var lastWrittenSeq: UInt64 = 0
 
     public var data: StoreData {
         lock.lock()
@@ -70,10 +79,28 @@ public final class JSONStore: Sendable {
     }
 
     public func mutate(_ transform: (inout StoreData) -> Void) {
+        // Apply the mutation and snapshot under `lock`, then release it before
+        // touching disk. Holding `lock` across the encode + atomic write blocks
+        // every reader (`data`) and other mutators for the full duration of the
+        // I/O — exactly the contention that froze the UI when many sessions
+        // updated at once (#304).
         lock.lock()
-        defer { lock.unlock() }
         transform(&_data)
-        Self.save(_data, to: fileURL)
+        writeSeq &+= 1
+        let mySeq = writeSeq
+        let snapshot = _data
+        lock.unlock()
+
+        // Serialize writes on a separate lock so disk order matches mutation
+        // order. Each save carries its sequence; a snapshot that is already
+        // stale (a newer one has been written) is dropped. Because the
+        // highest-sequence snapshot reflects every mutation up to that point,
+        // coalescing redundant writes can never drop data.
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        guard mySeq > lastWrittenSeq else { return }
+        lastWrittenSeq = mySeq
+        Self.save(snapshot, to: fileURL)
     }
 
     private static func save(_ data: StoreData, to url: URL) {

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
@@ -59,6 +59,63 @@ import Testing
     #expect(reloaded.data.sessions.count == iterations)
 }
 
+// Guards the lock-scope + write-coalescing change (#304): the in-memory data
+// lock is released before the disk write, but writes must still land in
+// mutation order and the newest snapshot must win. A stale snapshot winning
+// would leave the on-disk state internally inconsistent across fields.
+@Test func concurrentMutatesAcrossFieldsAreConsistent() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let store = JSONStore(directory: dir)
+    let iterations = 100
+
+    let group = DispatchGroup()
+    for i in 0..<iterations {
+        group.enter()
+        DispatchQueue.global().async {
+            // Each mutate appends to two different arrays. The newest snapshot
+            // always reflects every prior mutation, so the final on-disk state
+            // must carry equal counts for both — never a torn write where one
+            // array advanced but the other did not.
+            store.mutate { data in
+                data.sessions.append(Session(name: "s-\(i)"))
+                data.links.append(SessionLink(
+                    sessionID: UUID(), label: "l-\(i)",
+                    url: "https://example.com/\(i)", linkType: .pr
+                ))
+            }
+            group.leave()
+        }
+    }
+    group.wait()
+
+    #expect(store.data.sessions.count == iterations)
+    #expect(store.data.links.count == iterations)
+
+    let reloaded = JSONStore(directory: dir)
+    #expect(reloaded.data.sessions.count == iterations)
+    #expect(reloaded.data.links.count == iterations)
+}
+
+// The final mutation in a rapid burst must always be the one persisted —
+// write coalescing may drop intermediate snapshots but never the latest (#304).
+@Test func lastMutationInBurstIsPersisted() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let store = JSONStore(directory: dir)
+    for i in 0..<200 {
+        store.mutate { data in
+            data.sessions.append(Session(name: "burst-\(i)"))
+        }
+    }
+
+    let reloaded = JSONStore(directory: dir)
+    #expect(reloaded.data.sessions.count == 200)
+    #expect(reloaded.data.sessions.last?.name == "burst-199")
+}
+
 @Test func corruptFileCreatesBackup() throws {
     let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     defer { try? FileManager.default.removeItem(at: dir) }

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -488,7 +488,7 @@ final class IssueTracker {
 
     // MARK: - Consolidated GraphQL Query
 
-    private struct ConsolidatedGitHubResponse {
+    private struct ConsolidatedGitHubResponse: Sendable {
         let openIssues: [AssignedIssue]
         let closedIssues: [AssignedIssue]
         let viewerPRs: [ViewerPR]
@@ -681,7 +681,9 @@ final class IssueTracker {
         }
 
         clearScopeWarning()
-        return parseConsolidatedResponse(result.stdout)
+        // Parse off the main actor — only the Sendable result hops back (#304).
+        let output = result.stdout
+        return await Task.detached { self.parseConsolidatedResponse(output) }.value
     }
 
     private func retryWithoutProjectItems(openQuery: String, closedQuery: String, reviewQuery: String) async -> ConsolidatedGitHubResponse? {
@@ -711,7 +713,9 @@ final class IssueTracker {
             print("[IssueTracker] GraphQL retry (no projectItems) failed (exit \(result.exitCode)): \(result.stderr.prefix(300))")
             return nil
         }
-        return parseConsolidatedResponse(result.stdout)
+        // Parse off the main actor — only the Sendable result hops back (#304).
+        let output = result.stdout
+        return await Task.detached { self.parseConsolidatedResponse(output) }.value
     }
 
     // MARK: - Stale PR Follow-up
@@ -1007,7 +1011,13 @@ final class IssueTracker {
         return prs
     }
 
-    private func parseConsolidatedResponse(_ output: String) -> ConsolidatedGitHubResponse? {
+    // `nonisolated` so the JSON parsing — the heaviest CPU work in a refresh
+    // (up to ~50 PRs + ~50 review requests + ~150 issues with nested
+    // label/check/review traversal) — can run off the main actor via
+    // `Task.detached`. These helpers touch no instance/`appState` state, only
+    // their arguments and a local date formatter, so they are safe off-actor.
+    // Only the resulting (Sendable) value hops back to the main actor (#304).
+    nonisolated private func parseConsolidatedResponse(_ output: String) -> ConsolidatedGitHubResponse? {
         guard let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataObj = json["data"] as? [String: Any] else {
@@ -1047,7 +1057,7 @@ final class IssueTracker {
         )
     }
 
-    private func parseIssueNodes(
+    nonisolated private func parseIssueNodes(
         _ searchObj: [String: Any]?,
         defaultState: String,
         dateFormatter: ISO8601DateFormatter,
@@ -1101,7 +1111,7 @@ final class IssueTracker {
         }
     }
 
-    private func parseViewerPRs(_ viewerObj: [String: Any]?) -> [ViewerPR] {
+    nonisolated private func parseViewerPRs(_ viewerObj: [String: Any]?) -> [ViewerPR] {
         guard let pullRequests = viewerObj?["pullRequests"] as? [String: Any],
               let nodes = pullRequests["nodes"] as? [[String: Any]] else { return [] }
 
@@ -1171,7 +1181,7 @@ final class IssueTracker {
         }
     }
 
-    private func parseReviewRequests(
+    nonisolated private func parseReviewRequests(
         _ searchObj: [String: Any]?,
         dateFormatter: ISO8601DateFormatter,
         viewerLogin: String?
@@ -1244,7 +1254,7 @@ final class IssueTracker {
         return requests.sorted { ($0.requestedAt ?? .distantPast) > ($1.requestedAt ?? .distantPast) }
     }
 
-    private func parseRateLimit(_ obj: [String: Any]?) -> GitHubRateLimit? {
+    nonisolated private func parseRateLimit(_ obj: [String: Any]?) -> GitHubRateLimit? {
         guard let obj,
               let remaining = obj["remaining"] as? Int,
               let limit = obj["limit"] as? Int,
@@ -1286,7 +1296,11 @@ final class IssueTracker {
             }
         }
 
-        let store = JSONStore()
+        // Accumulate new links and persist them in a single store write below.
+        // Writing per-session inside the loop meant N full-store encode + atomic
+        // disk writes when a burst of PRs got linked at once — the dominant
+        // main-thread stall behind the concurrent-review freeze (#304).
+        var newLinks: [SessionLink] = []
 
         for session in appState.sessions {
             guard session.id != AppState.managerSessionID else { continue }
@@ -1311,9 +1325,12 @@ final class IssueTracker {
                 linkType: .pr
             )
             appState.links[session.id, default: []].append(link)
-            store.mutate { data in
-                data.links.append(link)
-            }
+            newLinks.append(link)
+        }
+
+        guard !newLinks.isEmpty else { return }
+        JSONStore().mutate { data in
+            data.links.append(contentsOf: newLinks)
         }
     }
 
@@ -1590,7 +1607,8 @@ final class IssueTracker {
     /// (identified by URL match) wins without leaving a duplicate row.
     private func applyReconciledPRLinks(_ picks: [ReconcileBranchMatch]) {
         guard !picks.isEmpty else { return }
-        let store = JSONStore()
+        // Accumulate then persist once — see `applySessionPRLinks` (#304).
+        var newLinks: [SessionLink] = []
         for pick in picks {
             let existing = appState.links(for: pick.sessionID)
             if existing.contains(where: { $0.linkType == .pr || $0.url == pick.url }) { continue }
@@ -1601,9 +1619,12 @@ final class IssueTracker {
                 linkType: .pr
             )
             appState.links[pick.sessionID, default: []].append(link)
-            store.mutate { data in
-                data.links.append(link)
-            }
+            newLinks.append(link)
+        }
+
+        guard !newLinks.isEmpty else { return }
+        JSONStore().mutate { data in
+            data.links.append(contentsOf: newLinks)
         }
     }
 


### PR DESCRIPTION
Closes #304

## Problem

When several inbound PR reviews / status changes landed at roughly the same time, the Crow UI froze and stopped responding to input. The cause is `IssueTracker.refresh()` — it runs on `@MainActor` and performed CPU- and IO-heavy work on the main thread.

## Fixes

1. **Parsing off the main actor.** The consolidated GitHub-response parse helpers (`parseConsolidatedResponse` + the issue/PR/review/rate-limit parsers) are now `nonisolated` and run via `Task.detached`; `ConsolidatedGitHubResponse` is `Sendable`, so only the result hops back to the main actor. Parsing ~50 PRs + ~50 review requests + ~150 issues (with nested label/check/review traversal) no longer blocks the UI thread.

2. **Batched store writes.** `applySessionPRLinks` and `applyReconciledPRLinks` accumulated new links and wrote them one-per-session inside the loop — each call was a full-store JSON encode + atomic disk write. They now accumulate and persist with a single `JSONStore.mutate`, so a burst of N newly-linked review PRs is **1** write instead of N.

3. **JSONStore lock scope.** `mutate()` now applies the transform and snapshots under the data lock, then writes to disk **outside** it. Writes are serialized by a separate write lock keyed on a monotonic sequence, so disk order matches mutation order and stale snapshots are coalesced (never dropping data). Readers and other mutators no longer block for the full encode + atomic-write duration.

These keep writes synchronous and ordered, preserving the read-after-write semantics the fresh-per-call `JSONStore()` pattern depends on.

## Testing

- `CrowPersistence`: all 26 tests pass, including two new ones — cross-field concurrent consistency and last-write-wins coalescing — plus the existing concurrency guard.
- Root `Crow` package builds and links cleanly (Swift 6, arm64), and all 117 root tests across 13 suites pass (including the 5 `IssueTracker*` suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)