### PR TITLE
feat: cross-repo commit digest over a time period

### DIFF
--- a/Packages/CrowCLI/Sources/CrowCLILib/Commands/SummaryCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/Commands/SummaryCommand.swift
@@ -1,0 +1,66 @@
+import ArgumentParser
+import CrowIPC
+import Foundation
+
+/// Print a cross-repo commit digest for a time window.
+///
+/// Calls the `get-summary` RPC, which scans every repo under the dev root and
+/// groups commits by repo. Text output mirrors a changelog; `--json` emits the
+/// raw structured result.
+public struct Summary: ParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "summary",
+        abstract: "Cross-repo commit digest over a time period"
+    )
+
+    @Option(name: .long, help: "Start of window (git date: '1 week ago', '2026-05-01').")
+    var since: String = "1 week ago"
+
+    @Option(name: .long, help: "End of window (git date). Defaults to now.")
+    var until: String?
+
+    @Flag(name: .long, help: "Emit raw JSON instead of formatted text.")
+    var json = false
+
+    public init() {}
+
+    public func run() throws {
+        var params: [String: JSONValue] = ["since": .string(since)]
+        if let until { params["until"] = .string(until) }
+        let result = try rpc("get-summary", params: params)
+        if json {
+            printJSON(result)
+        } else {
+            printDigest(result)
+        }
+    }
+
+    /// Render the `repos` array as a grouped, per-repo changelog.
+    private func printDigest(_ result: [String: JSONValue]) {
+        let repos = result["repos"]?.arrayValue ?? []
+        let totalCommits = repos.reduce(0) { acc, repo in
+            acc + (repo.objectValue?["commits"]?.arrayValue?.count ?? 0)
+        }
+        let window = until.map { "\(since) until \($0)" } ?? since
+        print("## Since \(window) · \(totalCommits) commit\(totalCommits == 1 ? "" : "s") · \(repos.count) repo\(repos.count == 1 ? "" : "s")")
+
+        for repo in repos {
+            guard let obj = repo.objectValue else { continue }
+            let name = obj["repo"]?.stringValue ?? "(unknown)"
+            let commits = obj["commits"]?.arrayValue ?? []
+            let ins = obj["totalInsertions"]?.intValue ?? 0
+            let del = obj["totalDeletions"]?.intValue ?? 0
+            let files = obj["totalFilesChanged"]?.intValue ?? commits.reduce(0) {
+                $0 + ($1.objectValue?["filesChanged"]?.intValue ?? 0)
+            }
+
+            print("")
+            print("### \(name) (\(commits.count))")
+            for commit in commits {
+                let subject = commit.objectValue?["subject"]?.stringValue ?? ""
+                print("- \(subject)")
+            }
+            print("  \(files) file\(files == 1 ? "" : "s"), +\(ins) / -\(del)")
+        }
+    }
+}

--- a/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
+++ b/Packages/CrowCLI/Sources/CrowCLILib/CrowCommand.swift
@@ -29,6 +29,7 @@ public struct CrowCommand: ParsableCommand {
             AddLink.self,
             ListLinks.self,
             HookEventCmd.self,
+            Summary.self,
         ]
     )
 

--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -82,6 +82,9 @@ public final class AppState {
     /// Fixed UUID for the global terminals page.
     nonisolated public static let globalTerminalSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
 
+    /// Fixed UUID for the changes-summary board tab.
+    nonisolated public static let summaryBoardSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+
     /// The primary (back-compat) Manager session identified by the well-known UUID.
     public var managerSession: Session? {
         sessions.first { $0.id == Self.managerSessionID }
@@ -156,6 +159,12 @@ public final class AppState {
     public var excludeReviewRepos: [String] = []
     public var excludeTicketRepos: [String] = []
     public var ignoreReviewLabels: [String] = []
+
+    // MARK: - Changes Summary
+
+    /// Last generated cross-repo commit digest (transient; not persisted).
+    public var lastSummary: [RepoCommitSummary] = []
+    public var isLoadingSummary: Bool = false
 
     public var filteredReviewRequests: [ReviewRequest] {
         var result = reviewRequests
@@ -241,6 +250,10 @@ public final class AppState {
     /// Called when user clicks "Start Review" for multiple selected PR review requests (batch mode).
     public var onBatchStartReview: (([String]) -> Void)?  // receives array of PR URLs
 
+    /// Called when the user generates a changes summary. Returns the grouped
+    /// per-repo commit digest for the given window (git date strings).
+    public var onGenerateSummary: ((_ since: String, _ until: String?) async -> [RepoCommitSummary])?
+
     /// Called to launch Claude in a terminal that just became ready.
     public var onLaunchClaude: ((UUID) -> Void)?  // receives terminal ID
 
@@ -324,7 +337,8 @@ public final class AppState {
         guard selectedSessionID != Self.ticketBoardSessionID,
               selectedSessionID != Self.allowListSessionID,
               selectedSessionID != Self.reviewBoardSessionID,
-              selectedSessionID != Self.globalTerminalSessionID else { return nil }
+              selectedSessionID != Self.globalTerminalSessionID,
+              selectedSessionID != Self.summaryBoardSessionID else { return nil }
         return sessions.first { $0.id == selectedSessionID }
     }
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/CommitSummary.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/CommitSummary.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// A single commit's metadata plus its diffstat, as collected by
+/// `GitManager.summarizeCommits`. Lives in CrowCore so CrowGit (which produces
+/// it), CrowCLI, and CrowUI can all share one type.
+public struct CommitInfo: Codable, Sendable, Identifiable {
+    public var id: String { hash }
+    public let hash: String
+    public let shortHash: String
+    public let authorName: String
+    public let authorEmail: String
+    public let date: Date            // ISO author date (git %aI)
+    public let subject: String
+    public let filesChanged: Int
+    public let insertions: Int
+    public let deletions: Int
+
+    public init(
+        hash: String,
+        shortHash: String,
+        authorName: String,
+        authorEmail: String,
+        date: Date,
+        subject: String,
+        filesChanged: Int,
+        insertions: Int,
+        deletions: Int
+    ) {
+        self.hash = hash
+        self.shortHash = shortHash
+        self.authorName = authorName
+        self.authorEmail = authorEmail
+        self.date = date
+        self.subject = subject
+        self.filesChanged = filesChanged
+        self.insertions = insertions
+        self.deletions = deletions
+    }
+}
+
+/// All commits in the requested window for a single repo, grouped under the
+/// repo's discovered path. Identified by `path` (unique per checkout).
+public struct RepoCommitSummary: Codable, Sendable, Identifiable {
+    public var id: String { path }
+    public let repo: String
+    public let path: String
+    public let workspace: String
+    public let commits: [CommitInfo]
+
+    public var totalInsertions: Int { commits.reduce(0) { $0 + $1.insertions } }
+    public var totalDeletions: Int { commits.reduce(0) { $0 + $1.deletions } }
+    public var totalFilesChanged: Int { commits.reduce(0) { $0 + $1.filesChanged } }
+
+    public init(repo: String, path: String, workspace: String, commits: [CommitInfo]) {
+        self.repo = repo
+        self.path = path
+        self.workspace = workspace
+        self.commits = commits
+    }
+}

--- a/Packages/CrowGit/Sources/CrowGit/GitManager.swift
+++ b/Packages/CrowGit/Sources/CrowGit/GitManager.swift
@@ -231,6 +231,94 @@ public actor GitManager {
         }
     }
 
+    /// Collect commits across every discovered repo within a time window and
+    /// group them by repo. Deterministic digest — no LLM.
+    ///
+    /// - `since`/`until` are passed straight to git, which parses flexible date
+    ///   strings ("1 week ago", "2026-05-01"); `until` defaults to now when nil.
+    /// - `--all` picks up commits on every branch (worktree feature branches
+    ///   share the main checkout's object store), `--no-merges` keeps diffstats
+    ///   from double-counting merge commits.
+    /// - Repos with zero commits in the window are omitted; a repo whose
+    ///   `git log` errors (empty/detached) is skipped rather than failing the
+    ///   whole scan.
+    ///
+    /// Runs sequentially: `run` is actor-isolated and blocks on
+    /// `waitUntilExit`, so a task group would serialize on the actor anyway.
+    public func summarizeCommits(since: String, until: String?) async throws -> [RepoCommitSummary] {
+        let repos = try await discoverRepos()
+        var summaries: [RepoCommitSummary] = []
+        for repo in repos {
+            var args = [
+                "git", "-C", repo.path, "log", "--all", "--no-merges",
+                "--since=\(since)",
+            ]
+            if let until { args.append("--until=\(until)") }
+            args.append(contentsOf: [
+                "--date=iso-strict",
+                "--pretty=format:%x1e%H%x1f%h%x1f%an%x1f%ae%x1f%aI%x1f%s",
+                "--numstat",
+            ])
+
+            let output: String
+            do {
+                output = try await run(args)
+            } catch {
+                // Empty repo, detached HEAD, etc. — skip, don't abort the scan.
+                continue
+            }
+
+            let commits = Self.parseCommitLog(output)
+            if !commits.isEmpty {
+                summaries.append(RepoCommitSummary(
+                    repo: repo.name, path: repo.path, workspace: repo.workspace, commits: commits
+                ))
+            }
+        }
+        return summaries
+    }
+
+    /// Parse the `--pretty`/`--numstat` output of the `summarizeCommits` git
+    /// command. Records are delimited by RS (`\u{1e}`), header fields by US
+    /// (`\u{1f}`); numstat lines (`<ins>\t<del>\t<path>`) follow each header.
+    static func parseCommitLog(_ output: String) -> [CommitInfo] {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        var commits: [CommitInfo] = []
+
+        for record in output.components(separatedBy: "\u{1e}") {
+            let trimmed = record.trimmingCharacters(in: .newlines)
+            guard !trimmed.isEmpty else { continue }
+
+            let lines = trimmed.components(separatedBy: "\n")
+            let fields = lines[0].components(separatedBy: "\u{1f}")
+            guard fields.count >= 6 else { continue }
+
+            var files = 0, insertions = 0, deletions = 0
+            for line in lines.dropFirst() where !line.isEmpty {
+                let cols = line.components(separatedBy: "\t")
+                guard cols.count >= 3 else { continue }
+                files += 1
+                // Binary files report "-" for ins/del; treat as 0.
+                insertions += Int(cols[0]) ?? 0
+                deletions += Int(cols[1]) ?? 0
+            }
+
+            commits.append(CommitInfo(
+                hash: fields[0],
+                shortHash: fields[1],
+                authorName: fields[2],
+                authorEmail: fields[3],
+                date: formatter.date(from: fields[4]) ?? Date(timeIntervalSince1970: 0),
+                subject: fields[5],
+                filesChanged: files,
+                insertions: insertions,
+                deletions: deletions
+            ))
+        }
+        return commits
+    }
+
     /// Run a git command, returning stdout on success.
     private func run(_ args: [String]) async throws -> String {
         let process = Process()

--- a/Packages/CrowGit/Tests/CrowGitTests/CommitSummaryTests.swift
+++ b/Packages/CrowGit/Tests/CrowGitTests/CommitSummaryTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import CrowGit
+import CrowCore
+
+/// Integration tests for `GitManager.summarizeCommits`. Builds a real repo
+/// under a temp dev-root (devRoot/<workspace>/<repo>/.git), makes commits with
+/// controlled dates and known diffstats, then asserts the digest. Skipped
+/// automatically if `git` isn't on PATH.
+@Suite("GitManager.summarizeCommits")
+struct CommitSummaryTests {
+
+    // MARK: - Harness
+
+    /// Run a git command in `dir`, optionally pinning the commit timestamp via
+    /// `date` (sets both author and committer date — `git log --since/--until`
+    /// filters on committer date). Returns (exitCode, stdout).
+    @discardableResult
+    private func git(_ args: [String], in dir: String? = nil, date: String? = nil) -> (code: Int32, out: String) {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        var full = ["git"]
+        if let dir { full += ["-C", dir] }
+        full += args
+        p.arguments = full
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_AUTHOR_NAME"] = "Test"; env["GIT_AUTHOR_EMAIL"] = "test@example.com"
+        env["GIT_COMMITTER_NAME"] = "Test"; env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+        env["GIT_CONFIG_GLOBAL"] = "/dev/null"; env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+        if let date { env["GIT_AUTHOR_DATE"] = date; env["GIT_COMMITTER_DATE"] = date }
+        p.environment = env
+        let outPipe = Pipe()
+        p.standardOutput = outPipe
+        p.standardError = outPipe
+        try? p.run()
+        p.waitUntilExit()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        return (p.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+    }
+
+    private func gitAvailable() -> Bool {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        p.arguments = ["git", "--version"]
+        p.standardOutput = Pipe(); p.standardError = Pipe()
+        do { try p.run() } catch { return false }
+        p.waitUntilExit()
+        return p.terminationStatus == 0
+    }
+
+    private func write(_ path: String, _ contents: String) {
+        try? contents.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    /// Build devRoot/ws/repo with:
+    ///  - "base" commit dated 2020 (outside any 2026 window)
+    ///  - "recent feature" on main dated 2026-05-20, +3 lines / 1 file
+    ///  - "branch only commit" on a non-checked-out branch dated 2026-05-21,
+    ///    +2 lines / 1 file (exercises `--all`)
+    /// Returns the dev-root path.
+    private func makeDevRoot() -> String? {
+        let devRoot = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("summary-test-\(UUID().uuidString)")
+        let wsPath = (devRoot as NSString).appendingPathComponent("ws")
+        let repo = (wsPath as NSString).appendingPathComponent("repo")
+        try? FileManager.default.createDirectory(atPath: repo, withIntermediateDirectories: true)
+
+        guard git(["init", "-b", "main", repo]).code == 0 else { return nil }
+
+        write((repo as NSString).appendingPathComponent("base.txt"), "base\n")
+        git(["add", "."], in: repo)
+        guard git(["commit", "-m", "base"], in: repo, date: "2020-01-01T00:00:00").code == 0 else { return nil }
+
+        write((repo as NSString).appendingPathComponent("feature.txt"), "a\nb\nc\n")
+        git(["add", "."], in: repo)
+        guard git(["commit", "-m", "recent feature"], in: repo, date: "2026-05-20T12:00:00").code == 0 else { return nil }
+
+        // Commit only reachable from a branch we don't leave checked out.
+        guard git(["switch", "-c", "sidebranch"], in: repo).code == 0 else { return nil }
+        write((repo as NSString).appendingPathComponent("branch.txt"), "x\ny\n")
+        git(["add", "."], in: repo)
+        guard git(["commit", "-m", "branch only commit"], in: repo, date: "2026-05-21T12:00:00").code == 0 else { return nil }
+        git(["switch", "main"], in: repo)
+
+        return devRoot
+    }
+
+    private func manager(devRoot: String) -> GitManager {
+        GitManager(config: WorkspaceConfig(devRoot: devRoot, workspaces: [:], defaults: WorkspaceDefaults()))
+    }
+
+    // MARK: - Tests
+
+    @Test func collectsCommitsWithSubjectsAndDiffstat() async throws {
+        try #require(gitAvailable())
+        let devRoot = try #require(makeDevRoot())
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        let summaries = try await manager(devRoot: devRoot)
+            .summarizeCommits(since: "2026-05-01", until: "2026-12-31")
+
+        #expect(summaries.count == 1)
+        let repo = try #require(summaries.first)
+        #expect(repo.repo == "repo")
+        #expect(repo.workspace == "ws")
+
+        // 2026 commits only: the 2020 "base" commit is outside the window.
+        #expect(repo.commits.count == 2)
+        let subjects = Set(repo.commits.map(\.subject))
+        #expect(subjects.contains("recent feature"))
+        #expect(subjects.contains("branch only commit")) // --all picked up the side branch
+        #expect(!subjects.contains("base"))
+
+        // feature.txt (+3) + branch.txt (+2), no deletions, two files.
+        #expect(repo.totalInsertions == 5)
+        #expect(repo.totalDeletions == 0)
+        #expect(repo.totalFilesChanged == 2)
+    }
+
+    @Test func excludesReposWithNoCommitsInWindow() async throws {
+        try #require(gitAvailable())
+        let devRoot = try #require(makeDevRoot())
+        defer { try? FileManager.default.removeItem(atPath: devRoot) }
+
+        // A window with no commits → the repo is omitted entirely.
+        let summaries = try await manager(devRoot: devRoot)
+            .summarizeCommits(since: "2019-01-01", until: "2019-12-31")
+        #expect(summaries.isEmpty)
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
@@ -22,6 +22,8 @@ public struct MainContentView: View {
                 ReviewBoardView(appState: appState)
             } else if appState.selectedSessionID == AppState.globalTerminalSessionID {
                 GlobalTerminalView(appState: appState)
+            } else if appState.selectedSessionID == AppState.summaryBoardSessionID {
+                SummaryBoardView(appState: appState)
             } else if let session = appState.selectedSession {
                 SessionDetailView(session: session, appState: appState)
             } else {

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -77,6 +77,11 @@ public struct SessionListView: View {
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
 
+            // Changes Summary row
+            SummaryBoardSidebarRow(appState: appState)
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+
             // Manager + Allow List row
             if appState.managerSession != nil {
                 ManagerAllowListRow(appState: appState)
@@ -449,6 +454,50 @@ struct ManagerAllowListRow: View {
                 )
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Summary Board Row
+
+/// Full-width sidebar button that selects the changes-summary board tab.
+struct SummaryBoardSidebarRow: View {
+    @Bindable var appState: AppState
+
+    private var isActive: Bool { appState.selectedSessionID == AppState.summaryBoardSessionID }
+
+    var body: some View {
+        Button {
+            appState.selectedSessionID = AppState.summaryBoardSessionID
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "chart.bar.doc.horizontal")
+                    .font(.system(size: 11))
+                Text("Changes Summary")
+                    .font(.system(size: 12, weight: .bold))
+                    .lineLimit(1)
+                Spacer()
+                if appState.isLoadingSummary {
+                    ProgressView().controlSize(.mini)
+                }
+            }
+            .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(
+                                isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
+                                lineWidth: 1
+                            )
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 2)
     }
 }
 

--- a/Packages/CrowUI/Sources/CrowUI/SummaryBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SummaryBoardView.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+import CrowCore
+
+// MARK: - Changes Summary Board
+
+/// Full-pane changes-summary board. Lets the user pick a time window, hit
+/// Generate, and see a deterministic cross-repo commit digest grouped by repo
+/// — the in-app counterpart to the `crow summary` CLI. Both converge on
+/// `GitManager.summarizeCommits` via `appState.onGenerateSummary`.
+public struct SummaryBoardView: View {
+    @Bindable var appState: AppState
+
+    /// Preset windows. `.custom` reveals two date pickers.
+    private enum Period: String, CaseIterable, Identifiable {
+        case today = "Today"
+        case week = "7 days"
+        case month = "30 days"
+        case custom = "Custom"
+        var id: String { rawValue }
+    }
+
+    @State private var period: Period = .week
+    @State private var customStart = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+    @State private var customEnd = Date()
+
+    public init(appState: AppState) {
+        self.appState = appState
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            header
+            SectionHelpBanner(
+                description: "A deterministic digest of every commit across all repos under your dev root for the chosen window, grouped by repo. Same data as `crow summary`.",
+                storageKey: "helpDismissed_summary"
+            )
+            controls
+            Divider()
+            resultsList
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.background)
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack {
+            Text("Changes Summary")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(CorveilTheme.gold)
+
+            if appState.isLoadingSummary {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Spacer()
+
+            if !appState.lastSummary.isEmpty {
+                Text("\(totalCommits) commit\(totalCommits == 1 ? "" : "s") · \(appState.lastSummary.count) repo\(appState.lastSummary.count == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(CorveilTheme.bgSurface)
+    }
+
+    // MARK: Controls
+
+    private var controls: some View {
+        VStack(spacing: 10) {
+            Picker("Period", selection: $period) {
+                ForEach(Period.allCases) { p in
+                    Text(p.rawValue).tag(p)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            if period == .custom {
+                HStack(spacing: 12) {
+                    DatePicker("From", selection: $customStart, displayedComponents: .date)
+                    DatePicker("To", selection: $customEnd, displayedComponents: .date)
+                }
+                .font(.caption)
+            }
+
+            HStack {
+                Spacer()
+                Button(action: generate) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .font(.system(size: 10))
+                        Text("Generate")
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 6)
+                    .background(CorveilTheme.gold)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+                .disabled(appState.isLoadingSummary)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(CorveilTheme.bgSurface)
+    }
+
+    // MARK: Results
+
+    @ViewBuilder
+    private var resultsList: some View {
+        if appState.lastSummary.isEmpty {
+            VStack {
+                Spacer().frame(height: 40)
+                Image(systemName: "chart.bar.doc.horizontal")
+                    .font(.system(size: 32))
+                    .foregroundStyle(CorveilTheme.textMuted)
+                Text(appState.isLoadingSummary ? "Generating…" : "No Summary Yet")
+                    .font(.headline)
+                    .foregroundStyle(CorveilTheme.textSecondary)
+                    .padding(.top, 8)
+                Text("Pick a window and hit Generate to see what changed across every repo.")
+                    .font(.caption)
+                    .foregroundStyle(CorveilTheme.textMuted)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            List {
+                ForEach(appState.lastSummary) { repo in
+                    Section {
+                        ForEach(repo.commits) { commit in
+                            commitRow(commit)
+                        }
+                    } header: {
+                        repoHeader(repo)
+                    }
+                }
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    private func repoHeader(_ repo: RepoCommitSummary) -> some View {
+        HStack {
+            Text(repo.repo)
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(CorveilTheme.gold)
+            Text("(\(repo.commits.count))")
+                .font(.caption)
+                .foregroundStyle(CorveilTheme.textSecondary)
+            Spacer()
+            Text("\(repo.totalFilesChanged) file\(repo.totalFilesChanged == 1 ? "" : "s"), +\(repo.totalInsertions) / -\(repo.totalDeletions)")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(CorveilTheme.textMuted)
+        }
+    }
+
+    private func commitRow(_ commit: CommitInfo) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(commit.shortHash)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(CorveilTheme.goldDark)
+            Text(commit.subject)
+                .font(.system(size: 12))
+                .foregroundStyle(CorveilTheme.textPrimary)
+            Spacer()
+            Text("+\(commit.insertions) / -\(commit.deletions)")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(CorveilTheme.textMuted)
+        }
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+    }
+
+    // MARK: Actions
+
+    private var totalCommits: Int {
+        appState.lastSummary.reduce(0) { $0 + $1.commits.count }
+    }
+
+    /// Map the selected period to git date strings and generate.
+    private func generate() {
+        let since: String
+        let until: String?
+        switch period {
+        case .today:
+            since = "midnight"
+            until = nil
+        case .week:
+            since = "7 days ago"
+            until = nil
+        case .month:
+            since = "30 days ago"
+            until = nil
+        case .custom:
+            let fmt = DateFormatter()
+            fmt.dateFormat = "yyyy-MM-dd"
+            since = fmt.string(from: customStart)
+            until = fmt.string(from: customEnd)
+        }
+
+        guard let onGenerate = appState.onGenerateSummary else { return }
+        appState.isLoadingSummary = true
+        Task {
+            let result = await onGenerate(since, until)
+            appState.lastSummary = result
+            appState.isLoadingSummary = false
+        }
+    }
+}

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import CrowCore
+import CrowGit
 import CrowUI
 import CrowPersistence
 import CrowTerminal
@@ -355,6 +356,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         appState.onCompleteSession = { [weak service] id in
             service?.completeSession(id: id)
+        }
+        // In-app Summary view calls GitManager directly (no socket round-trip);
+        // the CLI path goes through the "get-summary" RPC handler. Both converge
+        // on summarizeCommits.
+        appState.onGenerateSummary = { [weak self] since, until in
+            guard let self, let devRoot = self.devRoot else { return [] }
+            let excludeDirs = self.appConfig?.defaults.excludeDirs ?? WorkspaceDefaults().excludeDirs
+            let gm = GitManager(config: WorkspaceConfig(
+                devRoot: devRoot,
+                workspaces: [:],
+                defaults: WorkspaceDefaults(excludeDirs: excludeDirs)
+            ))
+            return (try? await gm.summarizeCommits(since: since, until: until)) ?? []
         }
         appState.onSetSessionInReview = { [weak service] id in
             service?.setSessionInReview(id: id)
@@ -898,6 +912,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let capturedService = sessionService
         let capturedTelemetryPort = sessionService.telemetryPort
         let hookDebug = ProcessInfo.processInfo.environment["CROW_HOOK_DEBUG"] == "1"
+        // Handler closures capture locals (not `self`); snapshot what the
+        // get-summary handler needs to build a GitManager.
+        let capturedDevRoot = devRoot
+        let capturedExcludeDirs = appConfig?.defaults.excludeDirs ?? WorkspaceDefaults().excludeDirs
 
         let router = CommandRouter(handlers: [
             "new-session": { @Sendable params in
@@ -1486,6 +1504,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         "event_name": .string(eventName),
                     ]
                 }
+            },
+            "get-summary": { @Sendable params in
+                let since = params["since"]?.stringValue ?? "1 week ago"
+                let until = params["until"]?.stringValue
+                let gm = GitManager(config: WorkspaceConfig(
+                    devRoot: capturedDevRoot,
+                    workspaces: [:],
+                    defaults: WorkspaceDefaults(excludeDirs: capturedExcludeDirs)
+                ))
+                let summaries = try await gm.summarizeCommits(since: since, until: until)
+                let fmt = ISO8601DateFormatter()
+                let repos: [JSONValue] = summaries.map { s in
+                    .object([
+                        "repo": .string(s.repo),
+                        "path": .string(s.path),
+                        "workspace": .string(s.workspace),
+                        "totalFilesChanged": .int(s.totalFilesChanged),
+                        "totalInsertions": .int(s.totalInsertions),
+                        "totalDeletions": .int(s.totalDeletions),
+                        "commits": .array(s.commits.map { c in
+                            .object([
+                                "hash": .string(c.hash),
+                                "shortHash": .string(c.shortHash),
+                                "authorName": .string(c.authorName),
+                                "authorEmail": .string(c.authorEmail),
+                                "date": .string(fmt.string(from: c.date)),
+                                "subject": .string(c.subject),
+                                "filesChanged": .int(c.filesChanged),
+                                "insertions": .int(c.insertions),
+                                "deletions": .int(c.deletions),
+                            ])
+                        }),
+                    ])
+                }
+                return ["repos": .array(repos)]
             },
         ])
 


### PR DESCRIPTION
Closes #335

## What

Adds a deterministic **Changes Summary** digest: given a time window, scan every repo under the dev root, collect commits, and render them grouped by repo with subjects + diffstat (files changed, +/− lines) — like a changelog. No LLM.

One backend method powers two front-ends:

```
GitManager.summarizeCommits(since:until:)   ← new, in CrowGit (reuses discoverRepos + run)
        ├── crow summary CLI  → rpc("get-summary") → AppDelegate handler ──┐
        └── SummaryBoardView (in-app) → appState.onGenerateSummary ─────────┤
                                                                            └─► same method
```

## Changes

- **CrowCore**: new shared models `CommitInfo` / `RepoCommitSummary` (`Models/CommitSummary.swift`); `AppState` gains `summaryBoardSessionID`, `onGenerateSummary`, and transient `lastSummary`/`isLoadingSummary`.
- **CrowGit**: `summarizeCommits(since:until:)` reuses `discoverRepos()` + `run()`, runs `git log --all --no-merges --numstat` per repo and parses an RS/US-delimited pretty format. Repos with no commits in the window are omitted; repos whose `git log` errors are skipped. `--all` picks up commits on every branch/worktree; `--no-merges` keeps diffstats clean. Runs sequentially (the actor's `run` blocks on `waitUntilExit`, so a task group would serialize anyway).
- **CrowCLI**: `crow summary` (`--since` / `--until` / `--json`) over a new `get-summary` RPC handler.
- **CrowUI**: `SummaryBoardView` (period presets Today / 7 days / 30 days / Custom range, Generate button), a "Changes Summary" sidebar entry, and detail-pane routing. The in-app path calls `GitManager` directly (no socket round-trip).

## Testing

- `swift test --package-path Packages/CrowGit` — new `CommitSummaryTests` (over a temp git repo) assert commit count, subjects, ins/del totals, window exclusion, and `--all` non-checked-out branch inclusion. **All 20 CrowGit tests pass.**
- CrowCLI builds; full app compiles & links.

> **Build note:** this dev host is x86_64, but `scripts/build-ghostty.sh` produces an arm64-only `GhosttyKit.xcframework`, so the app was verified via `swift build --arch arm64` (compiles & links cleanly). The native x86_64 `make build` fails at `import GhosttyKit` in the untouched `CrowTerminal` module — a pre-existing Intel-host limitation, unrelated to this change.

## Out of scope (per ticket)

LLM prose summary, scheduling/recurring digests, and an author filter remain deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)