### PR TITLE
feat: jobs — manual "Run now", scrolling prompt editor, wider "Every" labels

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -332,6 +332,9 @@ public final class AppState {
     /// Called when the sound mute toggle is changed.
     public var onSoundMutedChanged: ((Bool) -> Void)?
 
+    /// Fire a job immediately, ignoring its enabled flag and schedule (job ID).
+    public var onRunJob: ((UUID) -> Void)?
+
     // MARK: - Computed Properties
 
     public var selectedSession: Session? {

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -198,9 +198,21 @@ public struct JobFormView: View {
             Section {
                 ForEach(prompts.indices, id: \.self) { idx in
                     HStack(alignment: .top) {
-                        TextField("Prompt \(idx + 1)", text: $prompts[idx], axis: .vertical)
-                            .textFieldStyle(.roundedBorder)
-                            .lineLimit(1...6)
+                        TextEditor(text: $prompts[idx])
+                            .font(.body)
+                            .scrollContentBackground(.hidden)
+                            .frame(height: 90)
+                            .padding(4)
+                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.3)))
+                            .overlay(alignment: .topLeading) {
+                                if prompts[idx].isEmpty {
+                                    Text("Prompt \(idx + 1)")
+                                        .foregroundStyle(.secondary)
+                                        .padding(.horizontal, 9)
+                                        .padding(.vertical, 12)
+                                        .allowsHitTesting(false)
+                                }
+                            }
                         Button(role: .destructive) {
                             prompts.remove(at: idx)
                             if prompts.isEmpty { prompts = [""] }
@@ -229,17 +241,18 @@ public struct JobFormView: View {
             }
 
             Section("Schedule") {
-                Picker("Run", selection: $scheduleMode) {
+                Picker("", selection: $scheduleMode) {
                     Text("Every").tag(ScheduleMode.interval)
                     Text("Daily at").tag(ScheduleMode.daily)
                 }
                 .pickerStyle(.segmented)
+                .labelsHidden()
 
                 if scheduleMode == .interval {
                     HStack {
                         TextField("Every", value: $intervalValue, format: .number)
                             .textFieldStyle(.roundedBorder)
-                            .frame(width: 70)
+                            .frame(width: 90)
                         Picker("", selection: $intervalUnit) {
                             ForEach(IntervalUnit.allCases) { Text($0.label).tag($0) }
                         }

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -352,6 +352,14 @@ public struct SettingsView: View {
                             Spacer()
 
                             Button {
+                                appState.onRunJob?(job.id)
+                            } label: {
+                                Image(systemName: "play.fill")
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel("Run \(job.name) now")
+
+                            Button {
                                 editingJob = job
                             } label: {
                                 Image(systemName: "pencil")

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -593,6 +593,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         scheduler.start()
         self.jobScheduler = scheduler
 
+        // Manual "Run now" — fire a job immediately, regardless of enabled/schedule.
+        appState.onRunJob = { [weak self] jobID in
+            self?.jobScheduler?.runNow(jobID)
+        }
+
         appState.onMarkInReview = { [weak tracker] id in
             Task { await tracker?.markInReview(sessionID: id) }
         }

--- a/Sources/Crow/App/JobScheduler.swift
+++ b/Sources/Crow/App/JobScheduler.swift
@@ -67,16 +67,32 @@ final class JobScheduler {
             guard !inFlight.contains(job.id) else { continue }
             let baseline = job.lastRunAt ?? job.createdAt
             guard let next = job.nextRunDate(after: baseline), next <= now else { continue }
+            fire(job, devRoot: devRoot)
+        }
+    }
 
-            inFlight.insert(job.id)
-            let captured = job
-            Task { @MainActor in
-                defer { self.inFlight.remove(captured.id) }
-                if let result = await self.sessionService.runJob(captured, devRoot: devRoot) {
-                    // Persist run time first so the job isn't re-fired next tick.
-                    self.onJobRan(captured.id, Date())
-                    self.deliverRemainingPrompts(captured, terminalID: result.terminalID)
-                }
+    // MARK: - Manual run
+
+    /// Fire a job on demand, regardless of its enabled flag or schedule.
+    func runNow(_ jobID: UUID) {
+        guard let devRoot = devRootProvider() else { return }
+        guard let job = jobsProvider().first(where: { $0.id == jobID }) else { return }
+        fire(job, devRoot: devRoot)
+    }
+
+    /// Launch one job: guard against double-launch, spin up the worktree/session/
+    /// Claude terminal, persist the run time, then deliver any remaining prompts.
+    /// Shared by `tick()` (scheduled) and `runNow(_:)` (manual).
+    private func fire(_ job: JobConfig, devRoot: String) {
+        guard !inFlight.contains(job.id) else { return }
+        inFlight.insert(job.id)
+        let captured = job
+        Task { @MainActor in
+            defer { self.inFlight.remove(captured.id) }
+            if let result = await self.sessionService.runJob(captured, devRoot: devRoot) {
+                // Persist run time first so the job isn't re-fired next tick.
+                self.onJobRan(captured.id, Date())
+                self.deliverRemainingPrompts(captured, terminalID: result.terminalID)
             }
         }
     }


### PR DESCRIPTION
Closes #340

Three improvements to the Jobs settings feature (CROW-317).

## 1. Run now (even when disabled / unscheduled)
A ▶ button on every job row fires the job on demand, regardless of its `enabled` flag or schedule. `SessionService.runJob` already ignores those, so this exposes a manual trigger that reuses the existing launch path.

- `JobScheduler.tick()`'s fire-and-deliver logic is extracted into a shared `fire()` helper that owns the in-flight double-launch guard; a new `runNow(_:)` reuses it.
- Manual runs record `lastRunAt`, consistent with scheduled runs.
- Wired through a new `AppState.onRunJob` callback in `AppDelegate`.

## 2. Multiline scrolling prompt editor
Replaced the capped `TextField(axis: .vertical).lineLimit(1...6)` with a fixed-height `TextEditor` that scrolls internally, with a bordered look and a placeholder overlay shown only when empty.

## 3. Wider "Every" labels in the Schedule section
Dropped the redundant "Run" label so the segmented **Every / Daily at** toggle uses the full row width (no clipping), and widened the interval number field 70 → 90pt.

## Files
- `Packages/CrowCore/Sources/CrowCore/AppState.swift` — `onRunJob` callback
- `Sources/Crow/App/JobScheduler.swift` — extract `fire()`, add `runNow(_:)`
- `Sources/Crow/App/AppDelegate.swift` — wire `appState.onRunJob`
- `Packages/CrowUI/Sources/CrowUI/SettingsView.swift` — "Run now" ▶ button
- `Packages/CrowUI/Sources/CrowUI/JobFormView.swift` — `TextEditor` prompts + widened "Every"

## Verification
- `swift build --arch arm64` → build complete (arm64 required: this host's shell runs under Rosetta, and the GhosttyKit xcframework only ships an arm64 slice).
- `swift test` in `Packages/CrowCore` → 186 tests pass, including `JobConfigTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)