### PR TITLE
feat: "Changes" on Manager sidebar row + user-selectable summary repos

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -261,6 +261,10 @@ public final class AppState {
     /// per-repo commit digest for the given window (git date strings).
     public var onGenerateSummary: ((_ since: String, _ until: String?) async -> [RepoCommitSummary])?
 
+    /// Lists discovered repos (as "workspace/name" keys) for the
+    /// Changes-summary scope picker in Settings.
+    public var onListSummaryRepos: (() async -> [String])?
+
     /// Called to launch Claude in a terminal that just became ready.
     public var onLaunchClaude: ((UUID) -> Void)?  // receives terminal ID
 

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -224,6 +224,9 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
     public var excludeReviewRepos: [String]
     public var excludeTicketRepos: [String]
     public var ignoreReviewLabels: [String]
+    /// Repos (as "workspace/name" keys) the Changes board summarizes. Empty
+    /// means nothing is summarized — the user opts in explicitly.
+    public var summaryRepos: [String]
 
     /// Characters that are invalid in git ref names (see `git check-ref-format`).
     private static let invalidBranchChars = CharacterSet(charactersIn: " ~^:?*[\\")
@@ -250,7 +253,8 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         excludeDirs: [String] = ["node_modules", ".git", "vendor", "dist", "build", "target"],
         excludeReviewRepos: [String] = [],
         excludeTicketRepos: [String] = [],
-        ignoreReviewLabels: [String] = []
+        ignoreReviewLabels: [String] = [],
+        summaryRepos: [String] = []
     ) {
         self.provider = provider
         self.cli = cli
@@ -259,6 +263,7 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         self.excludeReviewRepos = excludeReviewRepos
         self.excludeTicketRepos = excludeTicketRepos
         self.ignoreReviewLabels = ignoreReviewLabels
+        self.summaryRepos = summaryRepos
     }
 
     public init(from decoder: Decoder) throws {
@@ -270,10 +275,11 @@ public struct ConfigDefaults: Codable, Sendable, Equatable {
         excludeReviewRepos = try container.decodeIfPresent([String].self, forKey: .excludeReviewRepos) ?? []
         excludeTicketRepos = try container.decodeIfPresent([String].self, forKey: .excludeTicketRepos) ?? []
         ignoreReviewLabels = try container.decodeIfPresent([String].self, forKey: .ignoreReviewLabels) ?? []
+        summaryRepos = try container.decodeIfPresent([String].self, forKey: .summaryRepos) ?? []
     }
 
     private enum CodingKeys: String, CodingKey {
-        case provider, cli, branchPrefix, excludeDirs, excludeReviewRepos, excludeTicketRepos, ignoreReviewLabels
+        case provider, cli, branchPrefix, excludeDirs, excludeReviewRepos, excludeTicketRepos, ignoreReviewLabels, summaryRepos
     }
 }
 

--- a/Packages/CrowGit/Sources/CrowGit/GitManager.swift
+++ b/Packages/CrowGit/Sources/CrowGit/GitManager.swift
@@ -231,11 +231,14 @@ public actor GitManager {
         }
     }
 
-    /// Collect commits across every discovered repo within a time window and
-    /// group them by repo. Deterministic digest — no LLM.
+    /// Collect commits across discovered repos within a time window and group
+    /// them by repo. Deterministic digest — no LLM.
     ///
     /// - `since`/`until` are passed straight to git, which parses flexible date
     ///   strings ("1 week ago", "2026-05-01"); `until` defaults to now when nil.
+    /// - `includeRepos`, when non-nil, scopes the scan to repos whose
+    ///   "workspace/name" key is in the set (an empty set yields nothing); `nil`
+    ///   includes every discovered repo.
     /// - `--all` picks up commits on every branch (worktree feature branches
     ///   share the main checkout's object store), `--no-merges` keeps diffstats
     ///   from double-counting merge commits.
@@ -245,8 +248,13 @@ public actor GitManager {
     ///
     /// Runs sequentially: `run` is actor-isolated and blocks on
     /// `waitUntilExit`, so a task group would serialize on the actor anyway.
-    public func summarizeCommits(since: String, until: String?) async throws -> [RepoCommitSummary] {
-        let repos = try await discoverRepos()
+    public func summarizeCommits(since: String, until: String?, includeRepos: Set<String>? = nil) async throws -> [RepoCommitSummary] {
+        var repos = try await discoverRepos()
+        // When an include-set is provided, scope to repos whose "workspace/name"
+        // key is selected; an empty set yields nothing. `nil` keeps all repos.
+        if let includeRepos {
+            repos = repos.filter { includeRepos.contains("\($0.workspace)/\($0.name)") }
+        }
         var summaries: [RepoCommitSummary] = []
         for repo in repos {
             var args = [

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -77,17 +77,10 @@ public struct SessionListView: View {
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
 
-            // Changes Summary row
-            SummaryBoardSidebarRow(appState: appState)
+            // Changes + Manager + New Manager (+) row
+            ManagerSidebarRow(appState: appState)
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
-
-            // Manager + New Manager (+) row
-            if appState.managerSession != nil {
-                ManagerSidebarRow(appState: appState)
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-            }
 
             // Additional (non-primary) Manager sessions, each deletable.
             let extraManagers = appState.managerSessions.filter { $0.id != AppState.managerSessionID }
@@ -384,46 +377,63 @@ struct SectionDivider: View {
 
 // MARK: - Manager Row
 
-/// Primary Manager toggle button plus the "new Manager" (+) button, on their
-/// own sidebar row.
+/// Sidebar row holding the "Changes" board button followed by the primary
+/// Manager toggle and the "new Manager" (+) button. Changes is always visible;
+/// the Manager + (+) buttons appear once the primary Manager has loaded.
 struct ManagerSidebarRow: View {
     @Bindable var appState: AppState
 
     var body: some View {
         HStack(spacing: 6) {
             sidebarButton(
-                title: "Manager",
-                isActive: appState.selectedSessionID == AppState.managerSessionID
+                title: "Changes",
+                isActive: appState.selectedSessionID == AppState.summaryBoardSessionID
             ) {
-                appState.selectedSessionID = AppState.managerSessionID
+                appState.selectedSessionID = AppState.summaryBoardSessionID
             }
-            .overlay(alignment: .topTrailing) {
-                if appState.isRemoteControlActive(sessionID: AppState.managerSessionID) {
-                    RemoteControlBadge(compact: true)
-                        .padding(4)
+            .overlay(alignment: .trailing) {
+                if appState.isLoadingSummary {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .padding(.trailing, 8)
                 }
             }
 
-            Button {
-                appState.onCreateManager?()
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(CorveilTheme.goldDark)
-                    .frame(width: 28)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(CorveilTheme.bgSurface)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .strokeBorder(CorveilTheme.goldDark.opacity(0.3), lineWidth: 1)
-                            )
-                    )
+            if appState.managerSession != nil {
+                sidebarButton(
+                    title: "Manager",
+                    isActive: appState.selectedSessionID == AppState.managerSessionID
+                ) {
+                    appState.selectedSessionID = AppState.managerSessionID
+                }
+                .overlay(alignment: .topTrailing) {
+                    if appState.isRemoteControlActive(sessionID: AppState.managerSessionID) {
+                        RemoteControlBadge(compact: true)
+                            .padding(4)
+                    }
+                }
+
+                Button {
+                    appState.onCreateManager?()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(CorveilTheme.goldDark)
+                        .frame(width: 28)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(CorveilTheme.bgSurface)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .strokeBorder(CorveilTheme.goldDark.opacity(0.3), lineWidth: 1)
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .help("New Manager session")
+                .accessibilityLabel("New Manager session")
             }
-            .buttonStyle(.plain)
-            .help("New Manager session")
-            .accessibilityLabel("New Manager session")
         }
         .padding(.vertical, 2)
     }
@@ -448,50 +458,6 @@ struct ManagerSidebarRow: View {
                 )
         }
         .buttonStyle(.plain)
-    }
-}
-
-// MARK: - Summary Board Row
-
-/// Full-width sidebar button that selects the changes-summary board tab.
-struct SummaryBoardSidebarRow: View {
-    @Bindable var appState: AppState
-
-    private var isActive: Bool { appState.selectedSessionID == AppState.summaryBoardSessionID }
-
-    var body: some View {
-        Button {
-            appState.selectedSessionID = AppState.summaryBoardSessionID
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "chart.bar.doc.horizontal")
-                    .font(.system(size: 11))
-                Text("Changes Summary")
-                    .font(.system(size: 12, weight: .bold))
-                    .lineLimit(1)
-                Spacer()
-                if appState.isLoadingSummary {
-                    ProgressView().controlSize(.mini)
-                }
-            }
-            .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .strokeBorder(
-                                isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
-                                lineWidth: 1
-                            )
-                    )
-            )
-        }
-        .buttonStyle(.plain)
-        .padding(.vertical, 2)
     }
 }
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -231,6 +231,17 @@ public struct SettingsView: View {
                 .onChange(of: config.cleanup.retentionHours) { _, _ in save() }
                 .disabled(!config.cleanup.enabled)
             }
+
+            Section("Changes Summary") {
+                Text("Select which repositories the Changes board summarizes. Nothing is summarized until you pick at least one.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                SummaryReposPicker(
+                    selected: $config.defaults.summaryRepos,
+                    listRepos: { await appState.onListSummaryRepos?() ?? [] },
+                    onSave: { save() }
+                )
+            }
         }
         .formStyle(.grouped)
     }

--- a/Packages/CrowUI/Sources/CrowUI/SummaryBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SummaryBoardView.swift
@@ -31,7 +31,7 @@ public struct SummaryBoardView: View {
         VStack(spacing: 0) {
             header
             SectionHelpBanner(
-                description: "A deterministic digest of every commit across all repos under your dev root for the chosen window, grouped by repo. Same data as `crow summary`.",
+                description: "A deterministic digest of commits for the chosen window, grouped by repo. Scoped to the repos you select in Settings → General → Changes Summary — nothing is summarized until at least one is selected. Same data as `crow summary`.",
                 storageKey: "helpDismissed_summary"
             )
             controls
@@ -126,7 +126,7 @@ public struct SummaryBoardView: View {
                     .font(.headline)
                     .foregroundStyle(CorveilTheme.textSecondary)
                     .padding(.top, 8)
-                Text("Pick a window and hit Generate to see what changed across every repo.")
+                Text("Select repos in Settings → General → Changes Summary, pick a window, and hit Generate to see what changed.")
                     .font(.caption)
                     .foregroundStyle(CorveilTheme.textMuted)
                     .multilineTextAlignment(.center)

--- a/Packages/CrowUI/Sources/CrowUI/SummaryReposPicker.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SummaryReposPicker.swift
@@ -50,6 +50,8 @@ struct SummaryReposPicker: View {
         )
     }
 
+    // Loads once per view lifetime: a repo added to the dev root while Settings
+    // is open won't appear until the panel is closed and reopened.
     private func load() async {
         guard !didLoad else { return }
         isLoading = true

--- a/Packages/CrowUI/Sources/CrowUI/SummaryReposPicker.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SummaryReposPicker.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import CrowCore
+
+/// Checklist of repos discovered under the dev root, used in Settings to scope
+/// which repositories the Changes board summarizes. Selections are stored as
+/// "workspace/name" keys in `ConfigDefaults.summaryRepos`. Repos are loaded
+/// asynchronously once via the injected `listRepos` closure.
+struct SummaryReposPicker: View {
+    @Binding var selected: [String]
+    let listRepos: () async -> [String]
+    var onSave: (() -> Void)?
+
+    @State private var options: [String] = []
+    @State private var isLoading = false
+    @State private var didLoad = false
+
+    var body: some View {
+        Group {
+            if isLoading && options.isEmpty {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text("Discovering repos…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else if options.isEmpty {
+                Text("No repositories found under the dev root.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(options, id: \.self) { repo in
+                    Toggle(repo, isOn: binding(for: repo))
+                }
+            }
+        }
+        .task { await load() }
+    }
+
+    private func binding(for repo: String) -> Binding<Bool> {
+        Binding(
+            get: { selected.contains(repo) },
+            set: { isOn in
+                if isOn {
+                    if !selected.contains(repo) { selected.append(repo) }
+                } else {
+                    selected.removeAll { $0 == repo }
+                }
+                onSave?()
+            }
+        )
+    }
+
+    private func load() async {
+        guard !didLoad else { return }
+        isLoading = true
+        options = await listRepos().sorted()
+        isLoading = false
+        didLoad = true
+    }
+}

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -372,12 +372,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.onGenerateSummary = { [weak self] since, until in
             guard let self, let devRoot = self.devRoot else { return [] }
             let excludeDirs = self.appConfig?.defaults.excludeDirs ?? WorkspaceDefaults().excludeDirs
+            let include = Set(self.appConfig?.defaults.summaryRepos ?? [])
             let gm = GitManager(config: WorkspaceConfig(
                 devRoot: devRoot,
                 workspaces: [:],
                 defaults: WorkspaceDefaults(excludeDirs: excludeDirs)
             ))
-            return (try? await gm.summarizeCommits(since: since, until: until)) ?? []
+            return (try? await gm.summarizeCommits(since: since, until: until, includeRepos: include)) ?? []
+        }
+        // Lists every discovered repo (as "workspace/name") so the Settings
+        // picker can scope which repos the Changes board summarizes.
+        appState.onListSummaryRepos = { [weak self] in
+            guard let self, let devRoot = self.devRoot else { return [] }
+            let excludeDirs = self.appConfig?.defaults.excludeDirs ?? WorkspaceDefaults().excludeDirs
+            let gm = GitManager(config: WorkspaceConfig(
+                devRoot: devRoot,
+                workspaces: [:],
+                defaults: WorkspaceDefaults(excludeDirs: excludeDirs)
+            ))
+            let repos = (try? await gm.discoverRepos()) ?? []
+            return repos.map { "\($0.workspace)/\($0.name)" }.sorted()
         }
         appState.onSetSessionInReview = { [weak service] id in
             service?.setSessionInReview(id: id)
@@ -948,6 +962,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // get-summary handler needs to build a GitManager.
         let capturedDevRoot = devRoot
         let capturedExcludeDirs = appConfig?.defaults.excludeDirs ?? WorkspaceDefaults().excludeDirs
+        let capturedSummaryRepos = Set(appConfig?.defaults.summaryRepos ?? [])
 
         let router = CommandRouter(handlers: [
             "new-session": { @Sendable params in
@@ -1541,7 +1556,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     workspaces: [:],
                     defaults: WorkspaceDefaults(excludeDirs: capturedExcludeDirs)
                 ))
-                let summaries = try await gm.summarizeCommits(since: since, until: until)
+                let summaries = try await gm.summarizeCommits(since: since, until: until, includeRepos: capturedSummaryRepos)
                 let fmt = ISO8601DateFormatter()
                 let repos: [JSONValue] = summaries.map { s in
                     .object([

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -958,11 +958,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let capturedService = sessionService
         let capturedTelemetryPort = sessionService.telemetryPort
         let hookDebug = ProcessInfo.processInfo.environment["CROW_HOOK_DEBUG"] == "1"
-        // Handler closures capture locals (not `self`); snapshot what the
-        // get-summary handler needs to build a GitManager.
+        // Handler closures capture locals (not `self`). `devRoot` is fixed for
+        // the server's lifetime, so it's snapshotted; but the Changes-summary
+        // scope (`summaryRepos`) and `excludeDirs` are edited live in Settings,
+        // so the get-summary handler reads them per-call via providers that hop
+        // to the main actor — keeping `crow summary` in sync with the in-app
+        // board (which reads `appConfig` at call time too).
         let capturedDevRoot = devRoot
-        let capturedExcludeDirs = appConfig?.defaults.excludeDirs ?? WorkspaceDefaults().excludeDirs
-        let capturedSummaryRepos = Set(appConfig?.defaults.summaryRepos ?? [])
+        let summaryReposProvider: @Sendable () async -> Set<String> = { [weak self] in
+            await MainActor.run { Set(self?.appConfig?.defaults.summaryRepos ?? []) }
+        }
+        let excludeDirsProvider: @Sendable () async -> [String] = { [weak self] in
+            await MainActor.run { self?.appConfig?.defaults.excludeDirs ?? WorkspaceDefaults().excludeDirs }
+        }
 
         let router = CommandRouter(handlers: [
             "new-session": { @Sendable params in
@@ -1551,12 +1559,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "get-summary": { @Sendable params in
                 let since = params["since"]?.stringValue ?? "1 week ago"
                 let until = params["until"]?.stringValue
+                let excludeDirs = await excludeDirsProvider()
+                let include = await summaryReposProvider()
                 let gm = GitManager(config: WorkspaceConfig(
                     devRoot: capturedDevRoot,
                     workspaces: [:],
-                    defaults: WorkspaceDefaults(excludeDirs: capturedExcludeDirs)
+                    defaults: WorkspaceDefaults(excludeDirs: excludeDirs)
                 ))
-                let summaries = try await gm.summarizeCommits(since: since, until: until, includeRepos: capturedSummaryRepos)
+                let summaries = try await gm.summarizeCommits(since: since, until: until, includeRepos: include)
                 let fmt = ISO8601DateFormatter()
                 let repos: [JSONValue] = summaries.map { s in
                     .object([


### PR DESCRIPTION
Closes #339

## Part A — sidebar relabel/move (ticket #339)
Collapses the standalone "Changes Summary" sidebar row onto the Manager line, before Manager, renamed to **"Changes"**. Row layout is now `[ Changes ] [ Manager ] [ + ]`. "Changes" is always visible; the Manager and `+` buttons gate on the primary Manager having loaded. The now-unused `SummaryBoardSidebarRow` is removed.

## Part B — user-selectable summary repos
Previously the changes summary silently scanned **every** git repo under the dev root, with no way to control which. This adds a **persisted setting** — a checklist of discovered repos under **Settings → General → Changes Summary** — that scopes the summary. Per design, an **empty selection summarizes nothing** (explicit opt-in).

- `ConfigDefaults.summaryRepos: [String]` — selections stored as `"workspace/name"` keys in `config.json`.
- `GitManager.summarizeCommits` gains `includeRepos: Set<String>?` (nil = all repos, preserving prior behavior for callers that don't pass it; empty set = nothing).
- `AppState.onListSummaryRepos` lists discovered repos for the picker, wired in `AppDelegate` to `GitManager.discoverRepos`.
- Both `onGenerateSummary` (in-app board) and the `get-summary` RPC (`crow summary` CLI) pass the configured set, so both surfaces honor the same scope.
- New `SummaryReposPicker` checklist view; `SummaryBoardView` help/empty-state copy updated to point at the setting.

## Verification
- `swift build --arch arm64` for CrowCore, CrowGit, CrowUI, and the root Crow app — all compile/link cleanly.
- Existing `CommitSummaryTests` are unaffected (new param defaults to `nil`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)