### PR TITLE
Rename non-primary Manager sessions from the UI

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -297,6 +297,9 @@ public final class AppState {
     /// Called to rename a terminal tab.
     public var onRenameTerminal: ((UUID, UUID, String) -> Void)?  // receives (sessionID, terminalID, newName)
 
+    /// Called to rename a session (used for non-primary Manager rows).
+    public var onRenameSession: ((UUID, String) -> Void)?  // receives (sessionID, newName)
+
     // MARK: - Closures wired by AppDelegate
 
     /// Called to delete a session and clean up its worktrees.

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -6,6 +6,7 @@ public struct SessionListView: View {
     @Bindable var appState: AppState
     @State private var searchText = ""
     @State private var sessionToDelete: Session?
+    @State private var editingManagerID: UUID?
     @State private var isSelectionMode = false
     @State private var selectedSessionIDs: Set<UUID> = []
     @State private var showBulkDeleteConfirm = false
@@ -85,11 +86,16 @@ public struct SessionListView: View {
             // Additional (non-primary) Manager sessions, each deletable.
             let extraManagers = appState.managerSessions.filter { $0.id != AppState.managerSessionID }
             ForEach(extraManagers) { session in
-                ManagerSessionRow(session: session, appState: appState)
+                ManagerSessionRow(session: session, appState: appState, editingSessionID: $editingManagerID)
                     .tag(session.id)
                     .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
                     .contextMenu {
+                        Button {
+                            editingManagerID = session.id
+                        } label: {
+                            Label("Rename", systemImage: "pencil")
+                        }
                         Button(role: .destructive) {
                             sessionToDelete = session
                         } label: {
@@ -469,9 +475,14 @@ struct ManagerSidebarRow: View {
 struct ManagerSessionRow: View {
     let session: Session
     @Bindable var appState: AppState
+    @Binding var editingSessionID: UUID?
+
+    @State private var editingName: String = ""
+    @FocusState private var isEditing: Bool
 
     private var isActive: Bool { appState.selectedSessionID == session.id }
     private var isDeleting: Bool { appState.isDeletingSession[session.id] == true }
+    private var isEditingThis: Bool { editingSessionID == session.id }
 
     var body: some View {
         Button {
@@ -480,9 +491,21 @@ struct ManagerSessionRow: View {
             HStack(spacing: 6) {
                 Image(systemName: "person.2.fill")
                     .font(.system(size: 11))
-                Text(session.name)
-                    .font(.system(size: 12, weight: .bold))
-                    .lineLimit(1)
+                if isEditingThis {
+                    TextField("Name", text: $editingName)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 12, weight: .bold))
+                        .focused($isEditing)
+                        .onSubmit { commitRename() }
+                        .onExitCommand { editingSessionID = nil }
+                        .onChange(of: isEditing) { _, nowEditing in
+                            if !nowEditing, isEditingThis { commitRename() }
+                        }
+                } else {
+                    Text(session.name)
+                        .font(.system(size: 12, weight: .bold))
+                        .lineLimit(1)
+                }
                 Spacer()
                 if isDeleting {
                     ProgressView().controlSize(.small)
@@ -512,6 +535,20 @@ struct ManagerSessionRow: View {
         }
         .buttonStyle(.plain)
         .padding(.vertical, 2)
+        .onChange(of: editingSessionID) { _, newValue in
+            if newValue == session.id {
+                editingName = session.name
+                isEditing = true
+            }
+        }
+    }
+
+    private func commitRename() {
+        let trimmed = editingName.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            appState.onRenameSession?(session.id, trimmed)
+        }
+        editingSessionID = nil
     }
 }
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -418,6 +418,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.onRenameTerminal = { [weak service] sessionID, terminalID, name in
             service?.renameTerminal(sessionID: sessionID, terminalID: terminalID, name: name)
         }
+        appState.onRenameSession = { [weak service] sessionID, name in
+            service?.renameSession(sessionID: sessionID, name: name)
+        }
 
         // Detect VS Code CLI and wire open action
         service.detectVSCode()

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1030,6 +1030,20 @@ final class SessionService {
         return true
     }
 
+    /// Rename a session. Returns `false` if the session was not found or the name is invalid.
+    @discardableResult
+    func renameSession(sessionID: UUID, name: String) -> Bool {
+        guard Validation.isValidSessionName(name),
+              let idx = appState.sessions.firstIndex(where: { $0.id == sessionID }) else { return false }
+        appState.sessions[idx].name = name
+        store.mutate { data in
+            if let i = data.sessions.firstIndex(where: { $0.id == sessionID }) {
+                data.sessions[i].name = name
+            }
+        }
+        return true
+    }
+
     // MARK: - Global Terminal Management
 
 


### PR DESCRIPTION
Closes #347

## Summary

Non-primary Manager sessions in the sidebar (the `extraManagers` rows rendered by `ManagerSessionRow`) previously had **no way to be renamed in-app** — they were auto-named "Manager 2", "Manager 3", … and the only way to rename them was the `crow rename-session` CLI. This adds a **Rename** affordance to those rows.

The rename backend already existed and was unrestricted (the `rename-session` RPC handler + CLI command rename any session by ID); this change is purely UI + callback plumbing.

## Changes

Mirrors the existing **terminal-tab rename** plumbing end-to-end:

- **`AppState.onRenameSession`** — new callback `((UUID, String) -> Void)?`, next to `onRenameTerminal`.
- **`SessionService.renameSession`** — validates via `Validation.isValidSessionName`, updates `appState.sessions`, and persists via `store.mutate`.
- **`AppDelegate`** — wires the callback alongside `onRenameTerminal`.
- **`SessionListView` / `ManagerSessionRow`** — adds a **"Rename"** button to the `extraManagers` context menu (above the destructive "Delete") and an inline `TextField` edit in the row, reusing the `TerminalTabBar` pattern. A lifted `editingManagerID` binding (mirroring the existing `sessionToDelete` state) bridges the parent context menu to the child row's edit state; commit on Enter/focus-loss, discard empty/whitespace names.

The primary "Manager" row (`ManagerSidebarRow`) is intentionally unchanged.

## Verification

- `make ghostty` + `swift build --arch arm64` → **Build complete.**
- Right-click a "Manager N" row → **Rename** → field becomes editable; Enter commits the new name.
- Empty/whitespace names are rejected (row keeps prior name).
- New name persists via the store (survives relaunch).
- Primary "Manager" row shows no rename affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)