### PR TITLE
fix: Changes-summary board — dedupe PR clones, fetch remote main, scrollbar, dropdown (#348)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -173,6 +173,10 @@ public final class AppState {
     public var lastSummary: [RepoCommitSummary] = []
     public var isLoadingSummary: Bool = false
 
+    /// The configured Changes-summary scope (from config.defaults.summaryRepos),
+    /// surfaced in the board's repo dropdown. Synced from AppConfig.
+    public var summaryRepoScope: [String] = []
+
     /// LLM narrative of the current digest (item 4). Transient.
     public var llmNarrative: String = ""
     public var isSummarizingLLM: Bool = false

--- a/Packages/CrowGit/Sources/CrowGit/GitManager.swift
+++ b/Packages/CrowGit/Sources/CrowGit/GitManager.swift
@@ -29,6 +29,10 @@ public actor GitManager {
             var isDir: ObjCBool = false
             guard fm.fileExists(atPath: wsPath, isDirectory: &isDir), isDir.boolValue else { continue }
             guard !config.defaults.excludeDirs.contains(wsDir) else { continue }
+            // crow-reviews holds transient PR-review clones (full clones that
+            // resolve to the same org/repo slug as the canonical checkout); never
+            // discover them or they'd duplicate the real repo in the summary scan.
+            guard wsDir != "crow-reviews" else { continue }
 
             let wsConfig = config.workspaces[wsDir]
             let provider = wsConfig?.provider ?? config.defaults.provider
@@ -242,9 +246,14 @@ public actor GitManager {
     ///   discovered repo. Bare names are ambiguous across orgs, so the scope key
     ///   is the full slug; a repo with no parseable remote can't match a scoped
     ///   set and is dropped.
-    /// - `--all` picks up commits on every branch (worktree feature branches
-    ///   share the main checkout's object store), `--no-merges` keeps diffstats
-    ///   from double-counting merge commits.
+    /// - Before scanning each repo we `git fetch --no-tags origin <defaultBranch>`
+    ///   and base the digest on `origin/<defaultBranch>` (the latest remote
+    ///   default branch) so it reflects what landed on the remote regardless of
+    ///   local state. The default branch is resolved from `origin/HEAD`; if that
+    ///   can't be resolved we fall back to `--all` (commits on every branch).
+    ///   `--no-merges` keeps diffstats from double-counting merge commits.
+    /// - Repos sharing an `org/repo` slug are deduped (first seen wins) so each
+    ///   configured repo appears at most once.
     /// - Repos with zero commits in the window are omitted; a repo whose
     ///   `git log` errors (empty/detached) is skipped rather than failing the
     ///   whole scan.
@@ -257,6 +266,7 @@ public actor GitManager {
         // since git hosts treat org/repo case-insensitively. nil = include all.
         let wantedSlugs = includeRepos.map { Set($0.map { $0.lowercased() }) }
         var summaries: [RepoCommitSummary] = []
+        var seenSlugs = Set<String>()
         for repo in repos {
             // Derive org/repo + the hosted-commit-page prefix from the remote.
             // When scoping, skip repos that don't match (or have no remote).
@@ -264,8 +274,19 @@ public actor GitManager {
             if let wantedSlugs {
                 guard let slug = remote?.slug, wantedSlugs.contains(slug.lowercased()) else { continue }
             }
+            // Dedupe by slug so a repo checked out in two workspaces appears once.
+            if let slug = remote?.slug.lowercased() {
+                guard seenSlugs.insert(slug).inserted else { continue }
+            }
+            // Base the digest on the latest remote default branch: fetch it, then
+            // log `origin/<default>`. Fall back to `--all` if it can't be resolved.
+            let defaultBranch = try? await resolveDefaultBranch(repoPath: repo.path)
+            if let defaultBranch {
+                _ = try? await run(["git", "-C", repo.path, "fetch", "--no-tags", "origin", defaultBranch])
+            }
+            let logRange = defaultBranch.map { "origin/\($0)" } ?? "--all"
             var args = [
-                "git", "-C", repo.path, "log", "--all", "--no-merges",
+                "git", "-C", repo.path, "log", logRange, "--no-merges",
                 "--since=\(since)",
             ]
             if let until { args.append("--until=\(until)") }

--- a/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
+++ b/Packages/CrowGit/Tests/CrowGitTests/GitManagerTests.swift
@@ -91,6 +91,19 @@ private func makeConfig(
     #expect(repos.isEmpty)
 }
 
+@Test func discoverReposSkipsCrowReviewsClones() async throws {
+    let root = makeTempDevRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // crow-reviews holds transient PR-review clones that resolve to the same
+    // org/repo slug as the canonical checkout; they must never be discovered.
+    createFakeRepo(at: root, workspace: "crow-reviews", repo: "crow-pr-346")
+    let config = makeConfig(devRoot: root.path)
+    let repos = try await GitManager(config: config).discoverRepos()
+
+    #expect(repos.isEmpty)
+}
+
 @Test func discoverReposSkipsWorktrees() async throws {
     let root = makeTempDevRoot()
     defer { try? FileManager.default.removeItem(at: root) }

--- a/Packages/CrowUI/Sources/CrowUI/SummaryBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SummaryBoardView.swift
@@ -57,6 +57,8 @@ public struct SummaryBoardView: View {
                     .controlSize(.small)
             }
 
+            scopeMenu
+
             Spacer()
 
             if !appState.lastSummary.isEmpty {
@@ -68,6 +70,30 @@ public struct SummaryBoardView: View {
         .padding(.horizontal)
         .padding(.vertical, 10)
         .background(CorveilTheme.bgSurface)
+    }
+
+    /// Dropdown listing the configured Changes-summary scope so it's clear which
+    /// repos' commits are shown. Reflects `config.defaults.summaryRepos` (synced
+    /// into `appState.summaryRepoScope`); edited in Settings, not here.
+    private var scopeMenu: some View {
+        Menu {
+            if appState.summaryRepoScope.isEmpty {
+                Text("No repos configured")
+            } else {
+                ForEach(appState.summaryRepoScope, id: \.self) { Text($0) }
+            }
+            Divider()
+            Text("Edit in Settings → General → Changes Summary")
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                Text("\(appState.summaryRepoScope.count) repo\(appState.summaryRepoScope.count == 1 ? "" : "s")")
+            }
+            .font(.caption)
+            .foregroundStyle(CorveilTheme.textSecondary)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
     }
 
     // MARK: Controls
@@ -86,7 +112,7 @@ public struct SummaryBoardView: View {
                         Image(systemName: "sparkles")
                             .font(.system(size: 10))
                     }
-                    Text("LLM Summarize")
+                    Text("Summarize")
                         .font(.system(size: 13, weight: .semibold))
                 }
                 .foregroundStyle(CorveilTheme.gold)
@@ -101,7 +127,7 @@ public struct SummaryBoardView: View {
             .disabled(appState.lastSummary.isEmpty || appState.isLoadingSummary || appState.isSummarizingLLM || !claudeAvailable)
             .help(claudeAvailable
                   ? "Summarize the digest with Claude"
-                  : "Install the `claude` CLI to use LLM Summarize")
+                  : "Install the `claude` CLI to use Summarize")
 
             Button(action: generate) {
                 HStack(spacing: 4) {
@@ -211,6 +237,7 @@ public struct SummaryBoardView: View {
                 }
             }
             .listStyle(.inset)
+            .scrollIndicators(.visible)
         }
     }
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -317,6 +317,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
+        appState.summaryRepoScope = config.defaults.summaryRepos
 
         // Create session service and hydrate state
         let service = SessionService(store: store, appState: appState, telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil)
@@ -916,6 +917,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
+        appState.summaryRepoScope = config.defaults.summaryRepos
     }
 
     /// Record a job's run time in the canonical `appConfig` and persist it, so


### PR DESCRIPTION
Closes #348

Follow-up to #345 / #346 — fixes five rough edges on the Changes-summary board.

## Changes

1. **Dedupe PR-review clones** (`GitManager.discoverRepos` / `summarizeCommits`) — the `crow-reviews` workspace dir (full clones at `<devRoot>/crow-reviews/<repo>-pr-<n>`) is skipped during discovery, and the scan dedupes by `org/repo` slug. Each configured repo now appears at most once; transient `*-pr-<n>` clones never show.
2. **Fetch the remote default branch** (`GitManager.summarizeCommits`) — before scanning each in-scope repo we `git fetch --no-tags origin <defaultBranch>` (resolved from `origin/HEAD`) and base the digest on `origin/<defaultBranch>` instead of `--all` local branches. Falls back to `--all` when the default branch can't be resolved, and the fetch is best-effort so an offline machine still produces a (stale) digest.
3. **Rename button** — the `sparkles` button label "LLM Summarize" now reads "Summarize" (`ClaudeSummarizer` behavior unchanged).
4. **Visible scrollbar** — the per-repo results `List` gets `.scrollIndicators(.visible)` so it scrolls with a persistent scroller on overflow.
5. **In-scope repo dropdown** — a header `Menu` lists the configured scope (`config.defaults.summaryRepos`, synced into `AppState.summaryRepoScope`), making it clear which repos' commits are shown.

## Verification
- `swift build --arch arm64` — app builds.
- `swift test` (CrowGit package) — 30/30 pass, including a new `discoverReposSkipsCrowReviewsClones` test and the existing `summarizeCommits` suite (exercises the `--all` fallback for remote-less local repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)