### PR TITLE
feat: add "Jobs" sidebar section above Active

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -359,6 +359,10 @@ public final class AppState {
         sessions.filter { $0.status == .active && $0.kind == .work }
     }
 
+    public var jobSessions: [Session] {
+        sessions.filter { $0.status == .active && $0.kind == .job }
+    }
+
     public var inReviewSessions: [Session] {
         sessions.filter { $0.status == .inReview && !$0.isManager }
     }

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -99,6 +99,30 @@ public struct SessionListView: View {
                     }
             }
 
+            // Job sessions
+            if !appState.jobSessions.isEmpty {
+                SectionDivider(
+                    title: "Jobs",
+                    isSelectionMode: isSelectionMode,
+                    sectionIDs: Set(filteredSessions(appState.jobSessions).map(\.id)),
+                    selectedSessionIDs: $selectedSessionIDs
+                )
+                ForEach(filteredSessions(appState.jobSessions)) { session in
+                    SessionRow(
+                        session: session,
+                        appState: appState,
+                        isSelectionMode: isSelectionMode,
+                        selectedSessionIDs: $selectedSessionIDs
+                    )
+                    .tag(session.id)
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+                    .contextMenu {
+                        sessionContextMenu(session)
+                    }
+                }
+            }
+
             // Active sessions
             if !appState.activeSessions.isEmpty {
                 SectionDivider(


### PR DESCRIPTION
## Summary

Scheduled jobs create sessions with `kind == .job` and `status == .active`, but no sidebar section's filter matched them — the "Active" section requires `kind == .work`. As a result, a freshly-spun job session was invisible in the left sidebar.

This adds a dedicated **"Jobs"** section above "Active" that surfaces active job sessions. Once a job session transitions to In Review or Completed, the existing status-based filters (`inReviewSessions`, `completedSessions`, which are not kind-restricted) pick it up automatically.

## Changes

- **`AppState.swift`** — new `jobSessions` computed property filtering `status == .active && kind == .job`, alongside `activeSessions`.
- **`SessionListView.swift`** — new "Jobs" section block inserted before the "Active" block (List renders in declaration order, so it appears above Active). Reuses the existing `SectionDivider`, `SessionRow`, `filteredSessions(_:)`, and `sessionContextMenu(_:)` — no new components.

## Verification

- `swift build --arch arm64` succeeds.
- A triggered job now appears under a "Jobs" header at the top of the sidebar, selectable and opening its terminal like any other session.
- Regular work sessions still appear only under "Active".
- Moving a job session to In Review / Completed removes it from Jobs and surfaces it under the corresponding existing section.

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)