### PR TITLE
Persist tmux backend server across Crow restarts (#330)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -115,33 +115,52 @@ public final class TmuxBackend {
 
     // MARK: - Lifecycle
 
-    /// Whether the cockpit session has been started this app launch.
+    /// Whether the cockpit session is live. Note this may be true on a fresh
+    /// app launch (before this process has created anything) when a prior Crow
+    /// quit left the server running at the stable socket — see #330.
     public var isRunning: Bool { controller?.hasSession() ?? false }
 
-    /// Tear down the tmux server (used by the crash-watchdog in PROD #5,
-    /// and by app quit). Resets internal state.
-    public func shutdown() {
+    /// Detach this Crow process from the tmux backend, resetting in-memory
+    /// state. Used by app quit and by the crash-watchdog (PROD #5).
+    ///
+    /// `killServer` controls whether the underlying tmux server is torn down:
+    ///   - `false` (clean app quit, #330): leave the server — and all its
+    ///     sessions/windows — running so the next launch can re-attach via
+    ///     `adoptTerminal`. The sentinel and wrapper-log files are *kept* on
+    ///     disk for the same reason: `adoptTerminal` re-fires `.shellReady`
+    ///     off the surviving sentinel.
+    ///   - `true` (default — crash-watchdog "Restart tmux server"): run
+    ///     `kill-server` and unlink the per-terminal scratch files.
+    public func shutdown(killServer: Bool = true) {
         if controller != nil {
-            NSLog("[CrowTelemetry tmux:server_shutdown bindings=\(bindings.count)]")
+            NSLog("[CrowTelemetry tmux:\(killServer ? "server_killed" : "server_detach") bindings=\(bindings.count)]")
         }
-        controller?.killServer()
+        if killServer {
+            controller?.killServer()
+        }
         sharedSurface?.destroy()
         sharedSurface = nil
         controller = nil
         bindings.removeAll()
         activeTerminalID = nil
         // Cancel any in-flight readiness watches so they don't keep polling
-        // (sentinel files are about to be unlinked) after server teardown.
-        // Mirrors the `destroyTerminal` cleanup (#282).
+        // after we let go of the backend. Mirrors the `destroyTerminal`
+        // cleanup (#282).
         for tasks in readinessTasks.values { tasks.forEach { $0.cancel() } }
         readinessTasks.removeAll()
-        for path in sentinels.values {
-            try? FileManager.default.removeItem(atPath: path)
+        // Only unlink the per-terminal scratch files when we're actually
+        // killing the server. On a clean quit that leaves the server running
+        // they must survive so the next launch's `adoptTerminal` can detect
+        // the already-ready shell from the existing sentinel (#330).
+        if killServer {
+            for path in sentinels.values {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+            for path in wrapperLogs.values {
+                try? FileManager.default.removeItem(atPath: path)
+            }
         }
         sentinels.removeAll()
-        for path in wrapperLogs.values {
-            try? FileManager.default.removeItem(atPath: path)
-        }
         wrapperLogs.removeAll()
     }
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -104,8 +104,11 @@ public final class TmuxBackend {
     /// Must be called before any other method.
     public private(set) var tmuxBinary: String = ""
 
-    /// Persistent socket path — Crow uses one explicit socket per app
-    /// instance so it never collides with a user's own tmux.
+    /// Persistent socket path. Crow uses one explicit, per-user socket
+    /// (`$TMPDIR/crow-tmux.sock`) so it never collides with a user's own tmux.
+    /// Since #330 it is stable across app instances: the server outlives a
+    /// clean quit and a relaunch re-attaches to it (single-instance guard in
+    /// AppDelegate guarantees only one owner).
     public private(set) var socketPath: String = ""
 
     public func configure(tmuxBinary: String, socketPath: String) {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxOrphanReaper.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxOrphanReaper.swift
@@ -1,25 +1,29 @@
 import Foundation
 
-/// Reaps orphaned tmux servers left behind by previous Crow instances that
-/// exited ungracefully (Force Quit, crash, SIGKILL — anything that bypasses
-/// `applicationWillTerminate` and therefore the shutdown fix from PR #229).
-/// Called once at app launch, BEFORE the new instance configures its own
-/// tmux server.
+/// Reaps orphaned, *legacy PID-keyed* tmux sockets left behind by pre-#330
+/// Crow builds. Called once at app launch, BEFORE the new instance configures
+/// its tmux server.
 ///
-/// Each Crow instance creates a socket at `$TMPDIR/crow-tmux-<pid>.sock`.
-/// On a clean ⌘Q, `TmuxBackend.shutdown()` runs and reaps the server. On
-/// an ungraceful exit the server lives on as an orphan, accumulating ~10-20
-/// MB of RSS per stuck instance and a stale socket file each. Without this
-/// reaper, dev iteration that involves Force Quit (or `pkill`) leaks one
-/// tmux server per cycle.
+/// Since #330 the running instance uses a single stable socket
+/// (`$TMPDIR/crow-tmux.sock`) that deliberately *outlives* the app process so
+/// a relaunch can re-attach to the still-running sessions. That stable socket
+/// is intentionally NEVER reaped — the regex below only matches the old
+/// `$TMPDIR/crow-tmux-<pid>.sock` naming, so `crow-tmux.sock` (no PID) falls
+/// through untouched, and a healthy persistent server is preserved.
+///
+/// What's left for this reaper is one-time cleanup of orphans from the old
+/// per-PID design: a `crow-tmux-<pid>.sock` whose owning CrowApp is gone leaks
+/// ~10-20 MB of RSS plus a stale socket file. (These self-heal on the app side
+/// too — a persisted binding pointing at a dead PID socket mismatches the
+/// stable socket and falls back to a fresh window — but reaping reclaims the
+/// leaked server.)
 ///
 /// The reaper is idempotent and best-effort. It enumerates
-/// `$TMPDIR/crow-tmux-*.sock`, extracts the PID encoded in each filename,
+/// `$TMPDIR/crow-tmux-<pid>.sock`, extracts the PID encoded in each filename,
 /// and:
 ///   - Skips the current process's own socket (we're about to bind it).
 ///   - Skips sockets whose PID is still bound to a live `CrowApp` process
-///     (the rare "two Crow instances running concurrently" case — must not
-///     reap a peer's server out from under it).
+///     (defensive — must not reap a peer's server out from under it).
 ///   - Otherwise: runs `tmux -S <socket> kill-server` (no-op if already
 ///     dead), then unlinks the socket file.
 public enum TmuxOrphanReaper {

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -12,12 +12,41 @@ import Testing
 struct TmuxBackendTests {
 
     private func makeBackend() -> TmuxBackend {
-        let id = UUID().uuidString.prefix(8).lowercased()
-        let socket = (NSTemporaryDirectory() as NSString)
-            .appendingPathComponent("crow-test-backend-\(id).sock")
+        makeBackend(socket: sharedSocketPath())
+    }
+
+    /// Configure a backend on a caller-chosen socket. The persistence tests
+    /// (#330) need two distinct backend instances pointed at the *same* socket
+    /// to model a quit/relaunch where the server outlived the app.
+    private func makeBackend(socket: String) -> TmuxBackend {
         let backend = TmuxBackend()
         backend.configure(tmuxBinary: discoveredTmuxBinary!, socketPath: socket)
         return backend
+    }
+
+    private func sharedSocketPath() -> String {
+        let id = UUID().uuidString.prefix(8).lowercased()
+        return (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("crow-test-backend-\(id).sock")
+    }
+
+    /// Mirrors `TmuxBackend.sentinelPath(for:)` (which is private). Kept in sync
+    /// by the sentinel-survival test — if the format drifts, that test's
+    /// killServer assertion fails loudly.
+    private func sentinelPath(for id: UUID) -> String {
+        let dir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp/"
+        return (dir as NSString)
+            .appendingPathComponent("crow-ready-\(id.uuidString).sentinel")
+    }
+
+    /// Best-effort kill of a server left running by a `killServer: false`
+    /// shutdown in a test, so we don't leak tmux servers across the suite.
+    private func killLeftoverServer(socket: String) {
+        TmuxController(
+            tmuxBinary: discoveredTmuxBinary!,
+            socketPath: socket,
+            sessionName: TmuxBackend.cockpitSessionName
+        ).killServer()
     }
 
     @Test func registerTerminalCreatesWindowAndBinding() throws {
@@ -227,5 +256,118 @@ struct TmuxBackendTests {
 
         #expect(received.contains(.timedOut))
         #expect(!received.contains(.shellReady))
+    }
+
+    // MARK: - #330 persistence: server survives quit, relaunch re-attaches
+
+    /// A `killServer: false` shutdown (clean app quit) leaves the server and
+    /// its windows running. A fresh backend pointed at the same socket — i.e.
+    /// the relaunched app — re-binds the existing window via `adoptTerminal`
+    /// instead of spawning a new one.
+    @Test func serverSurvivesDetachAndIsAdoptedOnRelaunch() throws {
+        let socket = sharedSocketPath()
+        let backendA = makeBackend(socket: socket)
+        let id = UUID()
+        let binding = try backendA.registerTerminal(
+            id: id, name: "persist", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+
+        // Clean quit — detach, don't kill.
+        backendA.shutdown(killServer: false)
+
+        // Relaunch: a brand-new backend on the SAME socket finds the live
+        // session and adopts the window. backendB.shutdown() (killServer:true)
+        // tears the shared server down so nothing leaks.
+        let backendB = makeBackend(socket: socket)
+        defer { backendB.shutdown() }
+        try backendB.adoptTerminal(id: id, binding: binding, trackReadiness: false)
+        #expect(backendB.isRegistered(id: id))
+        #expect(backendB.isRunning)
+    }
+
+    /// A `killServer: true` shutdown tears the server down. The next backend on
+    /// the same socket cold-starts a fresh cockpit session (anchor window
+    /// only), so the prior window index is gone and adoption fails — the
+    /// post-reboot clean-slate path.
+    @Test func killServerShutdownTearsDownServer() throws {
+        let socket = sharedSocketPath()
+        let backendA = makeBackend(socket: socket)
+        let id = UUID()
+        let binding = try backendA.registerTerminal(
+            id: id, name: "ephemeral", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        backendA.shutdown(killServer: true)
+
+        let backendB = makeBackend(socket: socket)
+        defer { backendB.shutdown() }
+        #expect(throws: TmuxBackendError.self) {
+            try backendB.adoptTerminal(id: id, binding: binding, trackReadiness: false)
+        }
+    }
+
+    /// The sentinel file is KEPT across a `killServer: false` shutdown (so the
+    /// next launch's `adoptTerminal` can detect the already-ready shell) and
+    /// UNLINKED across a `killServer: true` shutdown (legacy cleanup).
+    @Test func sentinelKeptOnDetachRemovedOnKill() throws {
+        let id = UUID()
+        let sentinel = sentinelPath(for: id)
+
+        // killServer:false → sentinel survives.
+        let detachSocket = sharedSocketPath()
+        let detached = makeBackend(socket: detachSocket)
+        _ = try detached.registerTerminal(
+            id: id, name: "s", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        FileManager.default.createFile(atPath: sentinel, contents: nil)
+        detached.shutdown(killServer: false)
+        #expect(FileManager.default.fileExists(atPath: sentinel))
+        killLeftoverServer(socket: detachSocket)
+
+        // killServer:true → sentinel removed.
+        let killSocket = sharedSocketPath()
+        let killed = makeBackend(socket: killSocket)
+        _ = try killed.registerTerminal(
+            id: id, name: "s", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        FileManager.default.createFile(atPath: sentinel, contents: nil)
+        killed.shutdown(killServer: true)
+        #expect(!FileManager.default.fileExists(atPath: sentinel))
+
+        try? FileManager.default.removeItem(atPath: sentinel)
+    }
+
+    /// Adopting with `trackReadiness: false` must NOT fire `.shellReady`, even
+    /// when the sentinel still exists from before the quit. This is what stops
+    /// SessionService from pasting a second `claude --continue` into a pane
+    /// where Claude is already running on relaunch (#330).
+    @Test func adoptWithoutReadinessDoesNotEmitShellReady() async throws {
+        let socket = sharedSocketPath()
+        let backendA = makeBackend(socket: socket)
+        let id = UUID()
+        let binding = try backendA.registerTerminal(
+            id: id, name: "ready-test", cwd: NSHomeDirectory(),
+            command: nil, trackReadiness: false
+        )
+        // Simulate the wrapper having marked the shell ready before the quit.
+        let sentinel = sentinelPath(for: id)
+        FileManager.default.createFile(atPath: sentinel, contents: nil)
+        backendA.shutdown(killServer: false)
+
+        let backendB = makeBackend(socket: socket)
+        defer { backendB.shutdown() }  // killServer:true also unlinks the sentinel
+
+        var received: [TerminalReadiness] = []
+        backendB.onReadinessChanged = { reportedID, state in
+            guard reportedID == id else { return }
+            received.append(state)
+        }
+        try backendB.adoptTerminal(id: id, binding: binding, trackReadiness: false)
+        // Give any erroneous MainActor callback hop a chance to land.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(received.isEmpty)
     }
 }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -311,33 +311,36 @@ struct TmuxBackendTests {
     /// next launch's `adoptTerminal` can detect the already-ready shell) and
     /// UNLINKED across a `killServer: true` shutdown (legacy cleanup).
     @Test func sentinelKeptOnDetachRemovedOnKill() throws {
-        let id = UUID()
-        let sentinel = sentinelPath(for: id)
-
-        // killServer:false → sentinel survives.
+        // killServer:false → sentinel survives. Independent id/socket per half
+        // so the two assertions don't share any state.
+        let keptID = UUID()
+        let keptSentinel = sentinelPath(for: keptID)
         let detachSocket = sharedSocketPath()
         let detached = makeBackend(socket: detachSocket)
         _ = try detached.registerTerminal(
-            id: id, name: "s", cwd: NSHomeDirectory(),
+            id: keptID, name: "s", cwd: NSHomeDirectory(),
             command: nil, trackReadiness: false
         )
-        FileManager.default.createFile(atPath: sentinel, contents: nil)
+        FileManager.default.createFile(atPath: keptSentinel, contents: nil)
         detached.shutdown(killServer: false)
-        #expect(FileManager.default.fileExists(atPath: sentinel))
+        #expect(FileManager.default.fileExists(atPath: keptSentinel))
         killLeftoverServer(socket: detachSocket)
+        try? FileManager.default.removeItem(atPath: keptSentinel)
 
         // killServer:true → sentinel removed.
+        let killedID = UUID()
+        let killedSentinel = sentinelPath(for: killedID)
         let killSocket = sharedSocketPath()
         let killed = makeBackend(socket: killSocket)
         _ = try killed.registerTerminal(
-            id: id, name: "s", cwd: NSHomeDirectory(),
+            id: killedID, name: "s", cwd: NSHomeDirectory(),
             command: nil, trackReadiness: false
         )
-        FileManager.default.createFile(atPath: sentinel, contents: nil)
+        FileManager.default.createFile(atPath: killedSentinel, contents: nil)
         killed.shutdown(killServer: true)
-        #expect(!FileManager.default.fileExists(atPath: sentinel))
+        #expect(!FileManager.default.fileExists(atPath: killedSentinel))
 
-        try? FileManager.default.removeItem(atPath: sentinel)
+        try? FileManager.default.removeItem(atPath: killedSentinel)
     }
 
     /// Adopting with `trackReadiness: false` must NOT fire `.shellReady`, even

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -94,10 +94,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func acquireSingleInstanceLock() -> Bool {
         let tmpdir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
         let lockPath = (tmpdir as NSString).appendingPathComponent("crow-instance.lock")
-        let fd = open(lockPath, O_CREAT | O_RDWR, 0o600)
+        // O_CLOEXEC so the lock fd is NOT inherited across exec by the
+        // subprocesses Crow spawns (Process/posix_spawn defaults to inheriting
+        // fds). A `flock` is released only when *every* descriptor on its
+        // open-file-description is closed across all processes — if the
+        // persistent tmux daemon (#330) inherited and held this fd, a relaunch
+        // would fail to re-acquire the lock even with no Crow alive. Don't rely
+        // on the child's own fd cleanup; close on exec unconditionally.
+        let fd = open(lockPath, O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
         guard fd >= 0 else {
             // Can't create the lock file — fail open rather than blocking launch.
-            NSLog("[Crow] single-instance lock open() failed (errno=\(errno)); proceeding")
+            NSLog("[CrowTelemetry instance_lock:open_failed errno=\(errno)] proceeding without single-instance guard")
             return true
         }
         guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
@@ -112,6 +119,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// supports one instance per user because the persistent tmux backend is a
     /// single shared server (#330).
     private func presentAlreadyRunningAlert() {
+        let tmpdir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
+        let lockPath = (tmpdir as NSString).appendingPathComponent("crow-instance.lock")
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Crow is already running"
@@ -119,6 +128,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Another Crow instance is already connected to the terminal backend. \
             Only one Crow instance can run at a time — switch to the existing \
             window instead.
+
+            If no Crow is actually running, remove the stale lock file:
+            \(lockPath)
             """
         alert.addButton(withTitle: "Quit")
         alert.runModal()
@@ -1683,17 +1695,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             _ = semaphore.wait(timeout: .now() + 2)
         }
         socketServer?.stop()
+        // Release the single-instance lock as early as possible so a fast
+        // quit→relaunch doesn't hit a spurious "Crow is already running" while
+        // the slower Ghostty/tmux teardown below finishes (flock would release
+        // on exit anyway; explicit + early is best).
+        if instanceLockFD >= 0 {
+            close(instanceLockFD)
+            instanceLockFD = -1
+        }
         // Leave the tmux server running so the next launch re-attaches to the
         // existing sessions (#330). The crash-watchdog's "Restart tmux server"
         // path still tears it down via the default `shutdown()`.
         TmuxBackend.shared.shutdown(killServer: false)
         GhosttyApp.shared.shutdown()
-        // Release the single-instance lock last so the next Crow launch can
-        // acquire it (flock would release on exit anyway; explicit is clearer).
-        if instanceLockFD >= 0 {
-            close(instanceLockFD)
-            instanceLockFD = -1
-        }
         NSLog("[Crow] Cleanup complete")
     }
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -29,6 +29,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var devRoot: String?
     private var appConfig: AppConfig?
 
+    /// File descriptor holding the single-instance advisory lock
+    /// (`$TMPDIR/crow-instance.lock`). Held open for the whole process so the
+    /// `flock` is released only on exit/crash. -1 until acquired. See #330:
+    /// the tmux backend now uses a stable socket and outlives the app, so the
+    /// sole running instance must be the unambiguous owner of that server.
+    private var instanceLockFD: Int32 = -1
+
     /// Reused for the Jobs repo picker (avoids a fresh instance per form open).
     private let providerManager = ProviderManager()
     /// Cache of expanded `alwaysInclude` repo lists, keyed by workspace name +
@@ -52,6 +59,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // launched from Finder.
         CrashReporter.install()
 
+        // Enforce a single Crow instance per user (#330). The tmux backend now
+        // uses a stable socket that outlives the app, so a second instance
+        // would otherwise attach to (and fight over) the same persistent
+        // server. Bail out with an alert before touching any shared state.
+        guard acquireSingleInstanceLock() else {
+            presentAlreadyRunningAlert()
+            NSApp.terminate(nil)
+            return
+        }
+
         // Surface the prior launch's crash (if any) once the app is up.
         // Deferred via async so it doesn't block first-paint.
         if let priorCrashLog = CrashReporter.unseenPriorCrashLog() {
@@ -67,6 +84,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             showSetupWizard()
         }
+    }
+
+    /// Acquire the process-lifetime single-instance lock (#330). Returns true
+    /// if we got it (we're the only / owning instance), false if another live
+    /// Crow already holds it. The fd is stored in `instanceLockFD` and kept
+    /// open for the life of the process; `flock` releases automatically on
+    /// exit or crash, so a relaunch always reclaims it.
+    private func acquireSingleInstanceLock() -> Bool {
+        let tmpdir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
+        let lockPath = (tmpdir as NSString).appendingPathComponent("crow-instance.lock")
+        let fd = open(lockPath, O_CREAT | O_RDWR, 0o600)
+        guard fd >= 0 else {
+            // Can't create the lock file — fail open rather than blocking launch.
+            NSLog("[Crow] single-instance lock open() failed (errno=\(errno)); proceeding")
+            return true
+        }
+        guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
+            close(fd)
+            return false
+        }
+        instanceLockFD = fd
+        return true
+    }
+
+    /// Native alert shown when a second Crow instance is launched. Crow only
+    /// supports one instance per user because the persistent tmux backend is a
+    /// single shared server (#330).
+    private func presentAlreadyRunningAlert() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Crow is already running"
+        alert.informativeText = """
+            Another Crow instance is already connected to the terminal backend. \
+            Only one Crow instance can run at a time — switch to the existing \
+            window instead.
+            """
+        alert.addButton(withTitle: "Quit")
+        alert.runModal()
     }
 
     /// Show an alert pointing the user at the prior launch's crash log.
@@ -268,24 +323,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // onboarding sheet — there is no longer a per-terminal Ghostty
         // fallback, so terminals won't render until tmux is installed.
         //
-        // First reap any orphan tmux servers from past Crow runs that exited
-        // ungracefully (Force Quit / crash bypasses applicationWillTerminate
-        // and therefore the shutdown fix). Reaping is keyed on
-        // $TMPDIR/crow-tmux-<pid>.sock files whose PID is no longer a live
-        // CrowApp process. Costs ~50ms when there's nothing to do; idempotent.
+        // First reap any *legacy* per-PID tmux sockets left by pre-#330 builds
+        // (`$TMPDIR/crow-tmux-<pid>.sock` whose owning CrowApp is gone). The
+        // reaper deliberately does NOT match the stable socket below, so a
+        // healthy persistent server is preserved across this launch. Costs
+        // ~50ms when there's nothing to do; idempotent.
         let discoveredTmuxBinary = TmuxDiscovery.discover()
         if let tmuxBinary = discoveredTmuxBinary {
             TmuxOrphanReaper.reap(
                 tmuxBinary: tmuxBinary,
                 currentPID: ProcessInfo.processInfo.processIdentifier
             )
-            // Per-app socket in $TMPDIR. v1 of the rollout kills the tmux
-            // server on app quit, so restart-survival isn't a requirement;
-            // ~/Library/Application Support is reserved for that future work
-            // (spec §12).
+            // Stable, non-PID socket in $TMPDIR (#330). The tmux server now
+            // outlives the app: a clean quit leaves it running (see
+            // `applicationWillTerminate`) and this launch re-attaches to it,
+            // rebinding the existing sessions via `adoptTerminal`. Keeping the
+            // socket under $TMPDIR preserves the "reboot clears everything"
+            // property (macOS wipes /var/folders on reboot) — surviving a
+            // reboot is an explicit non-goal. The single-instance lock acquired
+            // in applicationDidFinishLaunching guarantees we're the sole owner.
             let tmpdir = ProcessInfo.processInfo.environment["TMPDIR"] ?? "/tmp"
             let socketPath = (tmpdir as NSString)
-                .appendingPathComponent("crow-tmux-\(ProcessInfo.processInfo.processIdentifier).sock")
+                .appendingPathComponent("crow-tmux.sock")
             TmuxBackend.shared.configure(tmuxBinary: tmuxBinary, socketPath: socketPath)
             TmuxBackend.shared.onUnresponsive = { [weak self] error in
                 Task { @MainActor in self?.handleTmuxUnresponsive(error: error) }
@@ -1624,8 +1683,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             _ = semaphore.wait(timeout: .now() + 2)
         }
         socketServer?.stop()
-        TmuxBackend.shared.shutdown()
+        // Leave the tmux server running so the next launch re-attaches to the
+        // existing sessions (#330). The crash-watchdog's "Restart tmux server"
+        // path still tears it down via the default `shutdown()`.
+        TmuxBackend.shared.shutdown(killServer: false)
         GhosttyApp.shared.shutdown()
+        // Release the single-instance lock last so the next Crow launch can
+        // acquire it (flock would release on exit anyway; explicit is clearer).
+        if instanceLockFD >= 0 {
+            close(instanceLockFD)
+            instanceLockFD = -1
+        }
         NSLog("[Crow] Cleanup complete")
     }
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -141,10 +141,12 @@ final class SessionService {
         // tmux sentinel's .shellReady event is never lost.
         wireTerminalReadiness()
 
-        // Re-hydrate every persisted terminal by re-registering it with a
-        // freshly-started tmux server (v1 doesn't keep the server alive across
-        // launches; spec §12). If re-registration fails (e.g. tmux uninstalled)
-        // the row is left as-is and simply won't render this launch.
+        // Re-hydrate every persisted terminal. Since #330 the tmux server
+        // outlives the app, so rehydrateTerminalSurface adopts the persisted
+        // window when it's still live and only re-registers a fresh one as a
+        // fallback (post-reboot, closed window, or a legacy socket). If both
+        // fail (e.g. tmux uninstalled) the row is left as-is and simply won't
+        // render this launch.
         //
         // Each per-terminal rehydration is dispatched as its own @MainActor
         // task so the run loop can service AppKit/SwiftUI between them.

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -196,6 +196,35 @@ final class SessionService {
             NSLog("[SessionService] tmux not configured this run — terminal \(terminal.id) will not render")
             return terminal
         }
+
+        // #330: the tmux server now outlives the app, so on relaunch the
+        // window from last time is (usually) still live with its Claude TUI
+        // running. Re-attach to it rather than spawning a fresh window.
+        if let binding = terminal.tmuxBinding {
+            do {
+                // trackReadiness:false so adoptTerminal does NOT re-fire the
+                // sentinel's `.shellReady` — otherwise wireTerminalReadiness
+                // would drive launchClaude and paste a *second* `claude
+                // --continue` into a pane where Claude is already running.
+                try TmuxBackend.shared.adoptTerminal(id: terminal.id, binding: binding, trackReadiness: false)
+                // The window survived the prior quit → Claude is already up.
+                // Belt-and-suspenders against any other readiness path: drop
+                // the terminal from autoLaunchTerminals (also stops the
+                // didBecomeActive re-arm) and mark readiness terminal so
+                // launchClaude's `== .shellReady` guard can never fire.
+                appState.autoLaunchTerminals.remove(terminal.id)
+                if appState.terminalReadiness[terminal.id] != nil {
+                    appState.terminalReadiness[terminal.id] = .claudeLaunched
+                }
+                return terminal  // binding unchanged → no redundant persist
+            } catch {
+                NSLog("[SessionService] tmux adopt failed (\(error)) for \(terminal.id); creating a fresh window")
+            }
+        }
+
+        // No prior binding, or adoption failed (post-reboot clean slate, the
+        // window was closed, or a legacy per-PID socketPath that no longer
+        // matches the stable socket). Create a fresh window as before.
         do {
             let binding = try TmuxBackend.shared.registerTerminal(
                 id: terminal.id,


### PR DESCRIPTION
Closes #330

## What & why

When Crow quit and relaunched, the embedded tmux server was torn down and a fresh one started, so every terminal session (scrollback + running Claude process) was lost. Three mechanisms each prevented persistence: a PID-keyed socket, `tmux kill-server` on clean quit, and the launch-time orphan reaper.

This makes the tmux server **outlive the app process**: quitting leaves it running, and relaunching re-attaches and rebinds the existing sessions into the UI. A reboot still clears everything (the socket lives in `$TMPDIR`, wiped by macOS on reboot) — surviving a reboot is an explicit non-goal.

## Changes

- **Stable socket** — `$TMPDIR/crow-tmux.sock` (no PID) so a relaunched process can find the prior server (`AppDelegate.swift`).
- **`TmuxBackend.shutdown(killServer:)`** — a clean quit (`applicationWillTerminate`) detaches and leaves the server *and its sentinel files* alive; the crash-watchdog's "Restart tmux server" still tears it down via the default.
- **Adopt on relaunch** — `SessionService.rehydrateTerminalSurface` now calls `adoptTerminal` for a persisted binding instead of always creating a fresh window. It adopts with `trackReadiness: false` and marks the terminal `.claudeLaunched` / drops it from `autoLaunchTerminals`, so the readiness→`launchClaude` path can't paste a **second** `claude --continue` into a pane where Claude is already running. Falls back to `registerTerminal` when the binding is stale (post-reboot, closed window, or a legacy PID socket).
- **Single instance per user** — an `flock` advisory lock (`$TMPDIR/crow-instance.lock`) acquired at launch; a second Crow launch shows an "already running" alert and exits, making the sole instance the unambiguous owner of the shared persistent server (acceptance criterion 5).
- **Reaper** — doc-only: its `crow-tmux-<pid>.sock` regex never matches the stable `crow-tmux.sock`, so a healthy server is never reaped; it now only cleans up legacy per-PID orphans.

## Tests

New `TmuxBackend` integration tests: attach-to-existing-server after a non-killing shutdown, sentinel kept-on-detach / removed-on-kill, kill-server tears the server down, and adopt-with-`trackReadiness:false` does not fire `.shellReady`. All CrowTerminal + 135 root tests pass (`arch -arm64 swift test`).

## Known edge case

If a persisted terminal's Claude process exited *while Crow was quit*, adopt re-binds a window whose child is now a dead shell (adopt validates the window index is live, not what's running in it). Acceptable for v1 — the user can restart claude in-pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)