### PR TITLE
Default left sidebar to maximum width on fresh launch

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/MainContentView.swift
@@ -12,7 +12,7 @@ public struct MainContentView: View {
     public var body: some View {
         NavigationSplitView {
             SessionListView(appState: appState)
-                .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 350)
+                .navigationSplitViewColumnWidth(min: 220, ideal: 350, max: 350)
         } detail: {
             if appState.selectedSessionID == AppState.ticketBoardSessionID {
                 TicketBoardView(appState: appState)


### PR DESCRIPTION
## Summary

The left sidebar now comes up at its **maximum width** on a fresh launch instead of the narrower default, so users no longer have to drag the divider out to get more room.

The sidebar is the column of a `NavigationSplitView` in `MainContentView`. Its width was configured as `min: 220, ideal: 260, max: 350`. SwiftUI uses the `ideal` value only when no width has been persisted (i.e. a fresh launch); thereafter macOS restores the user's chosen width. Setting `ideal` to `350` (equal to `max`) makes a fresh launch open fully expanded.

```swift
.navigationSplitViewColumnWidth(min: 220, ideal: 350, max: 350)
```

- `min: 220` unchanged — the user can still drag the sidebar smaller.
- `ideal: 350` (was `260`) — fresh launch starts at maximum width.
- `max: 350` unchanged.

## Acceptance criteria

- [x] A fresh launch shows the left sidebar at its maximum width without the user having to drag the divider.
- [x] The user can still resize it smaller manually; macOS persistence of the chosen width is preserved.

## Testing

- `make ghostty && swift build --arch arm64` — builds clean.

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)