### PR TITLE
Sync Remote Control name on session rename (#354)

### DIFF
--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1041,7 +1041,36 @@ final class SessionService {
                 data.sessions[i].name = name
             }
         }
+        syncRemoteControlName(sessionID: sessionID, newName: name)
         return true
+    }
+
+    /// Terminals to push a Remote-Control `/rename` into for a session: those
+    /// launched with `--rc` (tracked in `remoteControlActiveTerminals`). That's
+    /// the Claude Code instance whose claude.ai panel label is fixed at launch.
+    /// Manager terminals qualify even though they aren't flagged `isManaged`.
+    /// Pure/`nonisolated` so it can be unit-tested without a live app.
+    nonisolated static func remoteControlRenameTargets(
+        terminals: [SessionTerminal],
+        rcActiveTerminals: Set<UUID>
+    ) -> [SessionTerminal] {
+        terminals.filter { rcActiveTerminals.contains($0.id) }
+    }
+
+    /// After an in-app rename, push the new name to the running Claude Code via
+    /// its `/rename` slash command so claude.ai's Remote Control panel label
+    /// (fixed at launch via `--name`) stays in sync. No-op when the session has
+    /// no `--rc` terminal, or when a terminal's surface isn't ready to receive.
+    /// The name is already validated (no control characters) by the caller, so
+    /// the trailing newline is the only Enter keypress sent.
+    private func syncRemoteControlName(sessionID: UUID, newName: String) {
+        let targets = Self.remoteControlRenameTargets(
+            terminals: appState.terminals(for: sessionID),
+            rcActiveTerminals: appState.remoteControlActiveTerminals
+        )
+        for terminal in targets where TerminalRouter.canSend(terminal) {
+            TerminalRouter.send(terminal, text: "/rename \(newName)\n")
+        }
     }
 
     // MARK: - Global Terminal Management

--- a/Tests/CrowTests/RemoteControlRenameTargetTests.swift
+++ b/Tests/CrowTests/RemoteControlRenameTargetTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+/// Locks down which terminals receive a `/rename` slash command when a session
+/// is renamed (#354). The selection is driven by `remoteControlActiveTerminals`
+/// — the set of terminals launched with `--rc` — and NOT by `isManaged`, since
+/// Manager terminals are RC-active without carrying the `isManaged` flag.
+@Suite("SessionService.remoteControlRenameTargets")
+struct RemoteControlRenameTargetTests {
+
+    private func terminal(_ id: UUID, isManaged: Bool = false) -> SessionTerminal {
+        SessionTerminal(id: id, sessionID: UUID(), cwd: "/tmp", isManaged: isManaged)
+    }
+
+    @Test
+    func returnsRemoteControlTerminal() {
+        let rc = UUID()
+        let terminals = [terminal(rc)]
+        let targets = SessionService.remoteControlRenameTargets(
+            terminals: terminals, rcActiveTerminals: [rc]
+        )
+        #expect(targets.map(\.id) == [rc])
+    }
+
+    @Test
+    func returnsEmptyWhenNoRemoteControlTerminal() {
+        let terminals = [terminal(UUID()), terminal(UUID())]
+        let targets = SessionService.remoteControlRenameTargets(
+            terminals: terminals, rcActiveTerminals: []
+        )
+        #expect(targets.isEmpty)
+    }
+
+    /// Manager terminals run Claude with `--rc` but are created without the
+    /// `isManaged` flag — they must still be selected, otherwise renaming a
+    /// non-primary Manager session (#354's primary case) wouldn't sync.
+    @Test
+    func selectsRemoteControlTerminalEvenWhenNotManaged() {
+        let rc = UUID()
+        let terminals = [terminal(rc, isManaged: false)]
+        let targets = SessionService.remoteControlRenameTargets(
+            terminals: terminals, rcActiveTerminals: [rc]
+        )
+        #expect(targets.map(\.id) == [rc])
+    }
+
+    @Test
+    func filtersToOnlyRemoteControlTerminals() {
+        let rc = UUID()
+        let plainShell = UUID()
+        let terminals = [terminal(plainShell), terminal(rc)]
+        let targets = SessionService.remoteControlRenameTargets(
+            terminals: terminals, rcActiveTerminals: [rc]
+        )
+        #expect(targets.map(\.id) == [rc])
+    }
+}


### PR DESCRIPTION
Closes #354

## Problem

When a session is launched with remote control, Crow starts Claude Code with `--rc --name <sessionName>`. That `--name` label is fixed **at launch time**, so the in-app rename added in #350 (PR #350) only updated Crow's own session name + store — claude.ai's **Remote Control** panel kept showing the old name, and the two drifted out of sync.

## Change

`SessionService.renameSession` now pushes the new name into the running Claude Code by sending the `/rename <name>` slash command to any of the session's terminals that were launched with `--rc`.

Key detail: the target terminals are gated on membership in `remoteControlActiveTerminals` (the set of terminals actually launched with `--rc`), **not** the `isManaged` flag. Manager terminals run Claude with `--rc` but are created without `isManaged`, so gating on `isManaged` would miss the non-primary Manager sessions this ticket targets. A `TerminalRouter.canSend` guard fails soft when a terminal surface isn't ready, and the already-enforced session-name validation (no control characters) means the trailing newline is the only Enter keypress sent.

A pure, `nonisolated` `remoteControlRenameTargets` helper isolates the selection logic so it's unit-testable without a live app.

## Scope

Sidebar rename path only (`onRenameSession` → `SessionService.renameSession`). The `crow rename-session` CLI RPC is intentionally unchanged.

## Acceptance criteria

- ✅ Renaming a remote-control session in the sidebar updates the claude.ai Remote Control panel label.
- ✅ Renaming a non-remote-control session does nothing extra (no stray `/rename` typed into a terminal).

## Tests

- New `RemoteControlRenameTargetTests` (4 cases): selects the `--rc` terminal; returns empty when none is RC-active; selects an RC-active terminal even when not flagged `isManaged`; filters to only RC-active terminals.
- Full `CrowTests` suite passes (139 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)