### PR TITLE
Add refresh button to Tickets sidebar row

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -608,6 +608,9 @@ public struct TicketBoardSidebarRow: View {
                 }
                 Spacer()
             }
+            .overlay(alignment: .trailing) {
+                refreshButton
+            }
             HStack(spacing: 8) {
                 Spacer(minLength: 0)
                 StatusCount(icon: "tray", color: CorveilTheme.textMuted, count: appState.issueCount(for: .backlog))
@@ -628,6 +631,32 @@ public struct TicketBoardSidebarRow: View {
                         .strokeBorder(CorveilTheme.borderSubtle, lineWidth: 1)
                 )
         )
+    }
+
+    /// Refreshes the ticket board without leaving the sidebar — same action as
+    /// the board toolbar's refresh (`onManualRefresh`). `.plain` style keeps the
+    /// tap on the button rather than selecting the enclosing list row.
+    private var refreshButton: some View {
+        Button {
+            appState.onManualRefresh?()
+        } label: {
+            Image(systemName: "arrow.clockwise")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(CorveilTheme.textSecondary)
+                .padding(5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(CorveilTheme.bgCard)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(CorveilTheme.borderSubtle, lineWidth: 1)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(appState.isLoadingIssues)
+        .help("Refresh")
+        .accessibilityLabel("Refresh tickets")
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a refresh button to the **Tickets** section in the left sidebar (`TicketBoardSidebarRow`). Previously the sidebar row showed live status counts but had no way to refresh — you had to open the full ticket board to hit its toolbar refresh.

The new button is wired to the same `appState.onManualRefresh` action the board toolbar uses, so the ticket pipeline can be re-polled directly from the sidebar.

## Details

- Placed as a trailing overlay on the "Tickets" title row, keeping the title centered.
- Uses `.buttonStyle(.plain)` so the tap is captured by the button rather than selecting the enclosing list row.
- Disabled while a refresh is already in flight (`appState.isLoadingIssues`), matching the board toolbar button.
- Matches the existing refresh-button styling (`arrow.clockwise`, card background, subtle border).

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)