### PR TITLE
Default adopted terminals to .done so resumed sessions show green (#367)

### DIFF
--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -256,6 +256,17 @@ final class SessionService {
                     if appState.remoteControlEnabled {
                         appState.remoteControlActiveTerminals.insert(terminal.id)
                     }
+                    // Emulate the SessionStart(source: resume) hook that pre-#330
+                    // relaunch fired (via re-running `claude --continue`), which set
+                    // claudeState to .done — so an adopted, idle-at-the-prompt Claude
+                    // shows the "done" green card like it used to (#367). A persisted
+                    // in-progress state (working/waiting) was already restored in
+                    // hydrateState and is more specific, so only fill in .done when
+                    // nothing meaningful was restored (still the .idle default).
+                    let hookState = appState.hookState(for: terminal.sessionID)
+                    if hookState.claudeState == .idle {
+                        hookState.claudeState = .done
+                    }
                 }
                 return terminal  // binding unchanged → no redundant persist
             } catch {


### PR DESCRIPTION
Closes #371

Follow-up to #368 (issue #367).

## Problem

After #368, status colors restore correctly for sessions that had a `done`/`working` hook state persisted to disk. But sessions whose last `Stop` hook fired **before** the persistence feature shipped — notably already-**completed** issues — have no entry on disk, so on relaunch they restore to the `.idle` default and their cards never turn green.

## Why they used to be green

Pre-#330, relaunch re-ran `claude --continue`, which fired `SessionStart(source: resume)` → set `claudeState = .done` for **every** resumed session → green cards across the board right after relaunch. The #330 adopt path replaced the re-run (correctly, to avoid double-pasting `--continue`) but dropped that refresh side effect.

## Fix

In the adopt branch (gated on `trackReadiness`, i.e. managed work terminals — same scope as the hook-config/RemoteControl re-seeds from #368), emulate the skipped `SessionStart(resume)`: seed `claudeState = .done` when nothing meaningful was restored (state is still the `.idle` default).

A persisted in-progress state (`working`/`waiting`) is restored earlier in `hydrateState` and is more specific, so it still wins for a session quit mid-turn. No second `claude --continue` is pasted — the #330 guards are untouched.

## Effect

Adopted sessions with no persisted state (completed/idle issues) come up green again like pre-#330, while genuinely-in-progress sessions keep their accurate working/waiting indicator.

## Testing

- `swift build --arch arm64` — clean build.
- Manual: relaunch with completed sessions present → their cards come up green without interaction; a session quit mid-`working` still shows working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)