### PR TITLE
Attribute Crow-created tickets to Crow

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -5,4 +5,7 @@ public enum CrowAttribution {
 
     public static let reviewMarkdownLink =
         "[🐦‍⬛ Reviewed by Crow via Claude Code](\(repoURL))"
+
+    public static let ticketMarkdownLink =
+        "[🐦‍⬛ Created with Crow via Claude Code](\(repoURL))"
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -19,3 +19,17 @@ import Testing
     #expect(!CrowAttribution.reviewMarkdownLink.contains("nicholasgasior"))
     #expect(!CrowAttribution.reviewMarkdownLink.lowercased().contains("corveil"))
 }
+
+@Test func crowAttributionTicketLinkIsCanonical() {
+    #expect(CrowAttribution.ticketMarkdownLink ==
+            "[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)")
+}
+
+@Test func crowAttributionTicketLinkEmbedsRepoURL() {
+    #expect(CrowAttribution.ticketMarkdownLink.contains(CrowAttribution.repoURL))
+}
+
+@Test func crowAttributionTicketLinkContainsNoForkReferences() {
+    #expect(!CrowAttribution.ticketMarkdownLink.contains("nicholasgasior"))
+    #expect(!CrowAttribution.ticketMarkdownLink.lowercased().contains("corveil"))
+}

--- a/Resources/crow-create-ticket-SKILL.md.template
+++ b/Resources/crow-create-ticket-SKILL.md.template
@@ -62,9 +62,11 @@ All `gh`/`glab`/`git` commands below require `dangerouslyDisableSandbox: true`.
 Extract the title (required) and optional body from `$ARGUMENTS` per the **Arguments**
 rules above. If there is no usable title, ask the user for one and stop until provided.
 
-**Keep the body footer-free.** Do NOT append any Crow attribution, "Generated with"
-footer, or co-author trailer — those belong on PRs, not issues. The body is exactly
-what the user provided (or empty).
+The body is the text the user provided (or empty). It MUST end with the Crow
+attribution footer (see **Step 4b**): a blank line, then exactly
+`[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)`.
+Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
+trailer. The Crow attribution is the only footer.
 
 ### Step 2: Determine the target repo and provider
 
@@ -98,26 +100,47 @@ GITLAB_HOST={host} glab api user --jq '.username'
 
 ### Step 4: Create the issue (assigned + labeled `crow:auto`)
 
+In both commands below, `BODY` is the user-provided body followed by the required
+attribution footer from **Step 4b** (a blank line, then the canonical link).
+
 **GitHub:**
 ```bash
 gh issue create --repo OWNER/REPO \
   --title "TITLE" \
-  --body "BODY" \
+  --body "BODY
+
+[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
-- If the body is empty, still pass `--body ""` so `gh` does not open an interactive
-  editor.
+- If the user-provided body is empty, the body is just the attribution footer — never
+  pass `--body ""`, or `gh` would open an interactive editor.
 
 **GitLab (non-default host):**
 ```bash
 GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
-  --description "BODY" \
+  --description "BODY
+
+[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
 ```
+
+### Step 4b: Attribution (REQUIRED)
+
+The body passed to `gh issue create --body` / `glab issue create --description` MUST
+end with a blank line followed by exactly this line:
+
+```
+[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)
+```
+
+- Do not modify the link text.
+- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
+- This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.
 
 ### Step 5: Missing-label fallback
 

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -15,6 +15,8 @@ struct AttributionSkillTests {
     private static let canonicalRepoURL = "https://github.com/radiusmethod/crow"
     private static let canonicalReviewLink =
         "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)"
+    private static let canonicalTicketLink =
+        "[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)"
 
     /// Walk up from this test source file until we find Package.swift.
     /// Returns the repo root URL.
@@ -41,6 +43,18 @@ struct AttributionSkillTests {
     private static func bundledTemplate() throws -> String {
         let url = repoRoot()
             .appendingPathComponent("Resources/crow-review-pr-SKILL.md.template")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func liveTicketSkill() throws -> String {
+        let url = repoRoot()
+            .appendingPathComponent("skills/crow-create-ticket/SKILL.md")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func bundledTicketTemplate() throws -> String {
+        let url = repoRoot()
+            .appendingPathComponent("Resources/crow-create-ticket-SKILL.md.template")
         return try String(contentsOf: url, encoding: .utf8)
     }
 
@@ -88,6 +102,39 @@ struct AttributionSkillTests {
             let url = String(content[r])
             #expect(url == Self.canonicalRepoURL,
                     "review skill contains non-canonical github.com link: \(url)")
+        }
+    }
+
+    @Test func liveTicketSkillContainsCanonicalAttributionLink() throws {
+        let content = try Self.liveTicketSkill()
+        #expect(content.contains(Self.canonicalTicketLink))
+    }
+
+    @Test func bundledTicketTemplateContainsCanonicalAttributionLink() throws {
+        let content = try Self.bundledTicketTemplate()
+        #expect(content.contains(Self.canonicalTicketLink))
+    }
+
+    @Test func liveTicketSkillAndBundledTemplateAreByteIdentical() throws {
+        let live = try Self.liveTicketSkill()
+        let bundled = try Self.bundledTicketTemplate()
+        #expect(live == bundled,
+                "skills/crow-create-ticket/SKILL.md and Resources/crow-create-ticket-SKILL.md.template must stay in sync — Scaffolder.bundledCreateTicketSkill() picks one or the other depending on build type.")
+    }
+
+    @Test func ticketSkillLinksOnlyToCanonicalRepo() throws {
+        // Any github.com link in the create-ticket skill must point at radiusmethod/crow.
+        let content = try Self.liveTicketSkill()
+        let pattern = #"https://github\.com/[A-Za-z0-9._/-]+"#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(content.startIndex..., in: content)
+        let matches = regex.matches(in: content, range: range)
+        #expect(!matches.isEmpty, "expected at least one github.com link (the attribution line) in the skill")
+        for match in matches {
+            guard let r = Range(match.range, in: content) else { continue }
+            let url = String(content[r])
+            #expect(url == Self.canonicalRepoURL,
+                    "create-ticket skill contains non-canonical github.com link: \(url)")
         }
     }
 }

--- a/skills/crow-create-ticket/SKILL.md
+++ b/skills/crow-create-ticket/SKILL.md
@@ -62,9 +62,11 @@ All `gh`/`glab`/`git` commands below require `dangerouslyDisableSandbox: true`.
 Extract the title (required) and optional body from `$ARGUMENTS` per the **Arguments**
 rules above. If there is no usable title, ask the user for one and stop until provided.
 
-**Keep the body footer-free.** Do NOT append any Crow attribution, "Generated with"
-footer, or co-author trailer — those belong on PRs, not issues. The body is exactly
-what the user provided (or empty).
+The body is the text the user provided (or empty). It MUST end with the Crow
+attribution footer (see **Step 4b**): a blank line, then exactly
+`[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)`.
+Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
+trailer. The Crow attribution is the only footer.
 
 ### Step 2: Determine the target repo and provider
 
@@ -98,26 +100,47 @@ GITLAB_HOST={host} glab api user --jq '.username'
 
 ### Step 4: Create the issue (assigned + labeled `crow:auto`)
 
+In both commands below, `BODY` is the user-provided body followed by the required
+attribution footer from **Step 4b** (a blank line, then the canonical link).
+
 **GitHub:**
 ```bash
 gh issue create --repo OWNER/REPO \
   --title "TITLE" \
-  --body "BODY" \
+  --body "BODY
+
+[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
-- If the body is empty, still pass `--body ""` so `gh` does not open an interactive
-  editor.
+- If the user-provided body is empty, the body is just the attribution footer — never
+  pass `--body ""`, or `gh` would open an interactive editor.
 
 **GitLab (non-default host):**
 ```bash
 GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
-  --description "BODY" \
+  --description "BODY
+
+[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
 ```
+
+### Step 4b: Attribution (REQUIRED)
+
+The body passed to `gh issue create --body` / `glab issue create --description` MUST
+end with a blank line followed by exactly this line:
+
+```
+[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)
+```
+
+- Do not modify the link text.
+- Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
+- Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
+- This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.
 
 ### Step 5: Missing-label fallback
 


### PR DESCRIPTION
Closes #372

## Problem

Tickets created via the `/crow-create-ticket` skill ended with a **"Created with Claude Code"** footer — auto-appended by Claude Code's default behavior — instead of the **Crow** attribution that the code-review path uses. The two flows were inconsistent.

There is no literal `"Created with Claude Code"` string in the repo; the skill previously tried to suppress the footer by telling the model to keep the body "footer-free", which neither worked reliably nor matched the desired outcome.

## Fix

Mirror the explicit, forceful pattern the code-review skill already uses (`crow-review-pr` → "Step 5b: Attribution (REQUIRED)" + `CrowAttribution.reviewMarkdownLink` + sync tests):

- Add `CrowAttribution.ticketMarkdownLink` = `[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)`.
- Flip `crow-create-ticket/SKILL.md` from "footer-free" to a **REQUIRED** Crow attribution footer (new **Step 4b**) and update the GitHub/GitLab `issue create` examples to append it.
- Keep `skills/crow-create-ticket/SKILL.md` and `Resources/crow-create-ticket-SKILL.md.template` byte-identical.
- Add unit tests (`CrowAttributionTests`) and snapshot/byte-identical tests (`AttributionSkillTests`) mirroring the review attribution tests.

No Swift wiring changes — `Scaffolder.bundledCreateTicketSkill()` already loads the skill and `gh issue create` is already pre-approved.

## Verification

- `swift test --filter CrowAttribution` (CrowCore) — 7 tests pass, including the 4 new ticket-attribution tests.
- `diff skills/crow-create-ticket/SKILL.md Resources/crow-create-ticket-SKILL.md.template` — identical.
- The new `AttributionSkillTests` cases run in the main target (requires the GhosttyKit framework build) and will be exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)