### PR TITLE
Preserve tmuxBinding across hydrate rebuild so Manager re-attaches (#374)

### DIFF
--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -83,12 +83,10 @@ final class SessionService {
                 if !hasManagedTerminal, let idx = terminals.firstIndex(where: {
                     $0.name == "Claude Code" || ($0.command?.contains("claude") ?? false)
                 }) {
-                    terminals[idx] = SessionTerminal(
-                        id: terminals[idx].id, sessionID: terminals[idx].sessionID,
-                        name: terminals[idx].name, cwd: terminals[idx].cwd,
-                        command: terminals[idx].command, isManaged: true,
-                        createdAt: terminals[idx].createdAt
-                    )
+                    // Mutate in place so tmuxBinding (and every other field) is
+                    // preserved — reconstructing via the memberwise init defaults
+                    // tmuxBinding to nil and breaks adopt-on-relaunch (#374).
+                    terminals[idx].isManaged = true
                 }
 
                 // For managed terminals, clear the claude command so they start as plain shells.
@@ -96,12 +94,8 @@ final class SessionService {
                 for i in terminals.indices {
                     if terminals[i].isManaged,
                        let cmd = terminals[i].command, cmd.contains("claude") {
-                        terminals[i] = SessionTerminal(
-                            id: terminals[i].id, sessionID: terminals[i].sessionID,
-                            name: terminals[i].name, cwd: terminals[i].cwd,
-                            command: nil, isManaged: true,
-                            createdAt: terminals[i].createdAt
-                        )
+                        // In-place so tmuxBinding survives the rebuild (#374).
+                        terminals[i].command = nil
                     }
                 }
             } else {
@@ -115,12 +109,11 @@ final class SessionService {
                 let rebuiltCommand = managerCommand(sessionName: session.name)
                 for i in terminals.indices {
                     if let cmd = terminals[i].command, cmd.contains("claude") {
-                        terminals[i] = SessionTerminal(
-                            id: terminals[i].id, sessionID: terminals[i].sessionID,
-                            name: terminals[i].name, cwd: terminals[i].cwd,
-                            command: rebuiltCommand, isManaged: terminals[i].isManaged,
-                            createdAt: terminals[i].createdAt
-                        )
+                        // Mutate in place rather than reconstructing the row:
+                        // the memberwise init drops tmuxBinding, which made the
+                        // Manager spawn a fresh window + claude every relaunch
+                        // instead of re-attaching to its live window (#374).
+                        terminals[i].command = rebuiltCommand
                         if appState.remoteControlEnabled {
                             appState.remoteControlActiveTerminals.insert(terminals[i].id)
                         }

--- a/Tests/CrowTests/ManagerMigrationTests.swift
+++ b/Tests/CrowTests/ManagerMigrationTests.swift
@@ -61,4 +61,74 @@ struct ManagerMigrationTests {
         #expect(cmd2.contains("--permission-mode auto"))
         #expect(cmd2.contains("--rc"))
     }
+
+    /// #374: hydrating the Manager rebuilds its claude `command` to refresh the
+    /// --rc/--name/--permission-mode flags. That rebuild must NOT drop the
+    /// terminal's `tmuxBinding` — if it does, `rehydrateTerminalSurface` can't
+    /// take the adopt path and spawns a fresh tmux window + claude every
+    /// relaunch, leaking the prior Manager window in `crow-cockpit`.
+    @MainActor
+    @Test
+    func hydratePreservesManagerTmuxBinding() {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-hydrate-mgr-\(UUID().uuidString)")
+        let store = JSONStore(directory: tmp)
+        let binding = TmuxBinding(socketPath: "/tmp/crow.sock", sessionName: "crow-cockpit", windowIndex: 5)
+        let terminalID = UUID()
+        store.mutate { data in
+            data.sessions = [Session(id: AppState.managerSessionID, name: "Manager", kind: .manager)]
+            data.terminals = [SessionTerminal(
+                id: terminalID, sessionID: AppState.managerSessionID,
+                name: "Manager", cwd: tmp.path,
+                command: "claude --rc --name 'Manager'", isManaged: false,
+                tmuxBinding: binding
+            )]
+        }
+
+        let appState = AppState()
+        appState.remoteControlEnabled = true  // so the rebuilt command carries --rc/--name
+        let service = SessionService(store: store, appState: appState)
+        service.hydrateState()
+
+        let row = appState.terminals[AppState.managerSessionID]?.first { $0.id == terminalID }
+        // Binding preserved → relaunch will adopt the live window, not register a new one.
+        #expect(row?.tmuxBinding == binding)
+        // Command was still rebuilt (proves we didn't just skip the rebuild).
+        #expect(row?.command?.contains("--name 'Manager'") == true)
+        // Rebuild also re-seeds the Remote Control active set for the row.
+        #expect(appState.remoteControlActiveTerminals.contains(terminalID))
+    }
+
+    /// Same in-place-mutation guarantee for the work-session hydration branch
+    /// that clears a managed terminal's claude command (#374). The command is
+    /// nilled (so the surface starts as a plain shell) but the `tmuxBinding`
+    /// must survive so the work terminal also re-adopts its window.
+    @MainActor
+    @Test
+    func hydratePreservesWorkTerminalTmuxBinding() {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crow-hydrate-work-\(UUID().uuidString)")
+        let store = JSONStore(directory: tmp)
+        let binding = TmuxBinding(socketPath: "/tmp/crow.sock", sessionName: "crow-cockpit", windowIndex: 9)
+        let sessionID = UUID()
+        let terminalID = UUID()
+        store.mutate { data in
+            data.sessions = [Session(id: sessionID, name: "feature", kind: .work)]
+            data.terminals = [SessionTerminal(
+                id: terminalID, sessionID: sessionID,
+                name: "Claude Code", cwd: tmp.path,
+                command: "claude --continue", isManaged: true,
+                tmuxBinding: binding
+            )]
+        }
+
+        let appState = AppState()
+        let service = SessionService(store: store, appState: appState)
+        service.hydrateState()
+
+        let row = appState.terminals[sessionID]?.first { $0.id == terminalID }
+        #expect(row?.tmuxBinding == binding)
+        // Managed work terminal's claude command is cleared so it starts as a shell.
+        #expect(row?.command == nil)
+    }
 }


### PR DESCRIPTION
Closes #374

## Problem
Since #330 the tmux server outlives the app, so terminals should re-attach to their existing windows on relaunch. But the **Manager** terminal spawned a brand-new tmux window and a fresh `claude` process on every relaunch, orphaning the prior window in `crow-cockpit` (~18 leaked `Manager` windows after a day of dev relaunches).

## Root cause
`SessionService.hydrateState()` rebuilt terminal rows via the memberwise `SessionTerminal.init` to refresh `command`/`isManaged`. That initializer defaults `tmuxBinding` to `nil`, so every rebuild **dropped the binding**. `rehydrateTerminalSurface` then failed its `if let binding = terminal.tmuxBinding` guard and fell through from `adoptTerminal` to registering a fresh window + fresh `claude`.

Only the Manager fired on current data (its rebuild is gated on `command.contains("claude")`, and it's the only terminal that persists its claude invocation in `command`), but the two work-terminal rebuild branches carried the same latent bug.

## Fix
Mutate the rows in place instead of reconstructing them. `command` and `isManaged` are `var`s, so in-place assignment refreshes them while preserving `tmuxBinding` (and `backend`). All three reconstruction sites in `hydrateState` are converted.

## Tests
- `hydratePreservesManagerTmuxBinding` — a Manager hydrate rebuild keeps the binding while still rebuilding the command (and re-seeds the Remote Control active set).
- `hydratePreservesWorkTerminalTmuxBinding` — a managed work terminal keeps its binding while its claude command is cleared (locks down the latent branch).

`swift build` and the root test suite (145 tests) pass. The one CrowTerminal failure (`retryReadinessEmitsTimedOutWhenSentinelMissing`) is a pre-existing timing-flaky tmux integration test, unrelated to this diff (passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)