### PR TITLE
Add "Restart tmux Server" menu item to recycle the cockpit backend

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -283,6 +283,11 @@ public final class AppState {
     /// preserving the Manager session identity. Wired to `SessionService.restartManager`.
     public var onRestartManager: (() -> Void)?
 
+    /// Called from the "Restart tmux Server" menu item (after confirmation) to
+    /// kill the tmux server and rebuild every terminal surface. Wired to
+    /// `SessionService.restartTmuxServer`.
+    public var onRestartTmuxServer: (() -> Void)?
+
     /// Called when the user clicks "Retry" on a terminal whose tmux readiness
     /// watch timed out before the shell signaled it was interactive.
     public var onRetryReadiness: ((UUID) -> Void)?  // receives terminal ID

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -467,6 +467,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             service?.restartManager(devRoot: devRoot)
         }
 
+        appState.onRestartTmuxServer = { [weak service] in
+            service?.restartTmuxServer()
+        }
+
         appState.onRetryReadiness = { [weak service] terminalID in
             service?.retryReadiness(terminalID: terminalID)
         }
@@ -871,6 +875,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let restartManagerItem = NSMenuItem(title: "Restart Manager", action: #selector(restartManager), keyEquivalent: "")
         restartManagerItem.target = self
         appMenu.addItem(restartManagerItem)
+        // No keyEquivalent — recycling the tmux server kills every pane's claude,
+        // so keep it menu-only to avoid accidental fires (#375).
+        let restartTmuxItem = NSMenuItem(title: "Restart tmux Server", action: #selector(restartTmuxServer), keyEquivalent: "")
+        restartTmuxItem.target = self
+        appMenu.addItem(restartTmuxItem)
         appMenu.addItem(NSMenuItem.separator())
         appMenu.addItem(withTitle: "Hide Crow", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h")
         let hideOthersItem = NSMenuItem(title: "Hide Others", action: #selector(NSApplication.hideOtherApplications(_:)), keyEquivalent: "h")
@@ -887,6 +896,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func restartManager() {
         appState.onRestartManager?()
+    }
+
+    @objc private func restartTmuxServer() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Restart tmux server?"
+        alert.informativeText = """
+            This kills the tmux server and every terminal it hosts — including \
+            all running Claude sessions — then rebuilds a fresh window for each \
+            and relaunches Claude. Use it to recover a stuck or corrupted cockpit.
+
+            Unsaved work in any terminal will be lost.
+            """
+        alert.addButton(withTitle: "Restart tmux Server")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            appState.onRestartTmuxServer?()
+        }
     }
 
     @objc private func showAbout() {

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -152,35 +152,65 @@ final class SessionService {
             }
         }
 
-        // Wire the readiness callback BEFORE re-registering terminals so the
-        // tmux sentinel's .shellReady event is never lost.
+        // Wire the readiness callback and re-hydrate every persisted terminal.
+        // Since #330 the tmux server outlives the app, so on launch
+        // rehydrateTerminalSurface adopts the persisted window when it's still
+        // live and only re-registers a fresh one as a fallback (post-reboot,
+        // closed window, or a legacy socket). `forceRegister: false` keeps that
+        // adopt-first behavior; the manual "Restart tmux Server" path passes
+        // true. If both adopt and register fail (e.g. tmux uninstalled) the row
+        // is left as-is and simply won't render this launch.
+        rebuildAllSurfaces(forceRegister: false)
+    }
+
+    /// Wire the tmux readiness callback, then re-register a tmux window and
+    /// relaunch claude for every persisted terminal across all sessions. Shared
+    /// by `hydrateState` (launch) and `restartTmuxServer` (manual recycle).
+    ///
+    /// `forceRegister: true` drops each terminal's persisted `tmuxBinding` so
+    /// `rehydrateTerminalSurface` always takes the `registerTerminal` path —
+    /// used after the server was killed, when every binding is dead — and
+    /// re-arms the managed work terminals' readiness/auto-launch state so the
+    /// fresh shell's `.shellReady` fire drives `launchClaude`. On launch the
+    /// pre-seed already happened in `hydrateState`, so `forceRegister: false`
+    /// skips it and preserves the adopt-first behavior.
+    ///
+    /// Each per-terminal rehydration is dispatched as its own @MainActor task
+    /// so the run loop can service AppKit/SwiftUI between them. Running the loop
+    /// synchronously pinned the main actor for seconds on profiles with many
+    /// persisted rows (each `registerTerminal` spawns a subprocess) — #293.
+    @MainActor
+    func rebuildAllSurfaces(forceRegister: Bool = false) {
+        // Wire BEFORE re-registering so the sentinel's .shellReady is never lost.
         wireTerminalReadiness()
 
-        // Re-hydrate every persisted terminal. Since #330 the tmux server
-        // outlives the app, so rehydrateTerminalSurface adopts the persisted
-        // window when it's still live and only re-registers a fresh one as a
-        // fallback (post-reboot, closed window, or a legacy socket). If both
-        // fail (e.g. tmux uninstalled) the row is left as-is and simply won't
-        // render this launch.
-        //
-        // Each per-terminal rehydration is dispatched as its own @MainActor
-        // task so the run loop can service AppKit/SwiftUI between them.
-        // Previously this loop ran synchronously and pinned the main actor
-        // for seconds on profiles with many persisted .tmux rows (each
-        // call to TmuxBackend.registerTerminal spawns a subprocess) — #293.
         for session in appState.sessions {
             guard let terminals = appState.terminals[session.id] else { continue }
             let isManagerSession = session.isManager
             let sid = session.id
+
+            if forceRegister, !isManagerSession {
+                // The previous adopt (#367) / launchClaude cleared these; re-arm
+                // so the fresh shell's .shellReady relaunches claude --continue.
+                for terminal in terminals where terminal.isManaged {
+                    appState.terminalReadiness[terminal.id] = .uninitialized
+                    appState.autoLaunchTerminals.insert(terminal.id)
+                }
+            }
+
             for original in terminals {
                 let trackReadiness = !isManagerSession && original.isManaged
+                // Server was just killed → binding is dead. Drop it so
+                // rehydrateTerminalSurface skips adopt and registers a fresh
+                // window (and persists the new windowIndex).
+                var seed = original
+                if forceRegister { seed.tmuxBinding = nil }
                 Task { @MainActor in
-                    let updated = self.rehydrateTerminalSurface(original, trackReadiness: trackReadiness)
-                    self.applyRehydrationResult(sessionID: sid, original: original, updated: updated)
+                    let updated = self.rehydrateTerminalSurface(seed, trackReadiness: trackReadiness)
+                    self.applyRehydrationResult(sessionID: sid, original: seed, updated: updated)
                 }
             }
         }
-
     }
 
     /// Commit the result of a per-terminal rehydration task back to
@@ -522,6 +552,33 @@ final class SessionService {
 
         // Session row still exists, so this only recreates the terminal.
         ensureManagerSession(devRoot: resolvedDevRoot)
+    }
+
+    /// Tear down the tmux server and rebuild every terminal surface from
+    /// scratch. Manual recovery for a wedged/leaked cockpit session (#375):
+    /// kills the server — every pane's claude included — then re-registers a
+    /// fresh window and relaunches claude for every persisted terminal across
+    /// all sessions (Manager via its stored command, work sessions via
+    /// `claude --continue`). The destructive teardown is guarded by a
+    /// confirmation alert in `AppDelegate.restartTmuxServer`.
+    @MainActor
+    func restartTmuxServer() {
+        NSLog("[CrowTelemetry tmux:server_restart_by_user]")
+        let savedSelection = appState.selectedSessionID
+        let savedActive = appState.activeTerminalID
+
+        // kill-server + unlink scratch/sentinel files. The first registerTerminal
+        // in rebuildAllSurfaces lazily recreates the controller + cockpit session
+        // via ensureRunningServer, so no explicit reconfigure is needed.
+        TmuxBackend.shared.shutdown(killServer: true)
+
+        rebuildAllSurfaces(forceRegister: true)
+
+        // Re-assign selection (even to the same values) to force a SwiftUI
+        // re-render so TerminalSurfaceView re-creates the destroyed cockpit
+        // surface and re-attaches a fresh tmux client; preserves focus.
+        appState.selectedSessionID = savedSelection
+        appState.activeTerminalID = savedActive
     }
 
     /// Build the claude shell command for a Manager terminal, reflecting the


### PR DESCRIPTION
Closes #375

## What

Adds an app-menu item **"Restart tmux Server"** (next to "Restart Manager") that, after a confirmation alert, tears down the persistent `crow-tmux` backend and rebuilds every session's terminal window from scratch.

## Why

Since #330 the tmux server deliberately outlives the app (`$TMPDIR/crow-tmux.sock`), so a normal quit/relaunch does **not** clear a corrupted cockpit session — orphaned/leaked windows (#374), a wedged server, or stale windows after a tmux upgrade. The only previous recoveries were quitting Crow (which leaves the bad server running) or killing the socket from a shell. This adds an in-app, supported way to recycle the server.

## How

- **AppState**: new `onRestartTmuxServer` callback.
- **AppDelegate**: menu item (menu-only — no key equivalent — to avoid accidental fires); `@objc restartTmuxServer()` with an `NSAlert` confirmation mirroring the existing unresponsive-server alert; callback wiring.
- **SessionService**: factored the `hydrateState` tail into a reusable `rebuildAllSurfaces(forceRegister:)`, shared by launch and the new `restartTmuxServer()`.
  - `restartTmuxServer()` calls `TmuxBackend.shutdown(killServer: true)` then `rebuildAllSurfaces(forceRegister: true)`.
  - With `forceRegister: true`, each terminal's now-dead `tmuxBinding` is dropped so rehydration always takes the `registerTerminal` path (which lazily recreates the controller + cockpit session via `ensureRunningServer`), and managed work terminals' readiness/auto-launch state is re-armed so `claude --continue` relaunches. The Manager relaunches via its stored command.
  - Selection is re-applied to force a SwiftUI re-render that re-attaches a fresh cockpit surface and preserves focus.
  - The launch path is behaviorally unchanged (`forceRegister: false`).

## Testing

- `make ghostty` + `swift build --arch arm64` — clean build.
- `swift test --arch arm64` — 143 tests / 16 suites pass; `CrowCore` package tests — 189 tests / 5 suites pass.
- The rebuild touches `TmuxBackend.shared` / libghostty, so end-to-end behavior (kill server → fresh window per terminal with Claude relaunched, no orphans, focus preserved) is verified interactively per the ticket's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)