### PR TITLE
Add a way to duplicate an existing job (#378)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/JobConfig.swift
@@ -79,6 +79,36 @@ public struct JobConfig: Identifiable, Codable, Sendable, Equatable {
         return nil
     }
 
+    /// A new job seeded from this one as the starting point for a duplicate:
+    /// fresh `id` + `createdAt`, cleared `lastRunAt`, and `enabled = false` so it
+    /// can't fire before the user reviews it. `workspace`, `repo`, `prompts`, and
+    /// `schedule` are copied verbatim. The name is made unique against
+    /// `existingNames` by appending " copy" (then " copy 2", " copy 3", …).
+    public func duplicated(existingNames: [String]) -> JobConfig {
+        JobConfig(
+            id: UUID(),
+            name: Self.uniqueCopyName(of: name, existingNames: existingNames),
+            workspace: workspace,
+            repo: repo,
+            prompts: prompts,
+            schedule: schedule,
+            enabled: false,
+            lastRunAt: nil,
+            createdAt: Date()
+        )
+    }
+
+    /// Builds a "<base> copy" name absent from `existingNames` (case-insensitive,
+    /// matching `validateName`), escalating to " copy 2", " copy 3", … on collision.
+    static func uniqueCopyName(of base: String, existingNames: [String]) -> String {
+        let taken = Set(existingNames.map { $0.lowercased() })
+        let first = "\(base) copy"
+        if !taken.contains(first.lowercased()) { return first }
+        var n = 2
+        while taken.contains("\(base) copy \(n)".lowercased()) { n += 1 }
+        return "\(base) copy \(n)"
+    }
+
     /// The next time this job should fire strictly after `reference`.
     ///
     /// The scheduler treats the job as due when

--- a/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JobConfigTests.swift
@@ -124,3 +124,32 @@ import Testing
     #expect(JobConfig.validateName("Audit", existingNames: ["audit"]) != nil) // case-insensitive dupe
     #expect(JobConfig.validateName("Audit", existingNames: ["Other"]) == nil)
 }
+
+@Test func jobConfigDuplicated() {
+    let src = JobConfig(
+        name: "Audit",
+        workspace: "ws",
+        repo: "o/r",
+        prompts: ["a", "b"],
+        schedule: .interval(seconds: 3600),
+        enabled: true,
+        lastRunAt: Date(),
+        createdAt: Date(timeIntervalSince1970: 0)
+    )
+    let copy = src.duplicated(existingNames: ["Audit"])
+
+    #expect(copy.id != src.id)              // fresh id
+    #expect(copy.name == "Audit copy")      // unique name
+    #expect(copy.enabled == false)          // disabled by default
+    #expect(copy.lastRunAt == nil)          // run state reset
+    #expect(copy.createdAt > src.createdAt) // fresh createdAt
+    #expect(copy.workspace == src.workspace) // copied verbatim
+    #expect(copy.repo == src.repo)
+    #expect(copy.prompts == src.prompts)
+    #expect(copy.schedule == src.schedule)
+
+    // escalates when " copy" is already taken (case-insensitive)
+    #expect(src.duplicated(existingNames: ["Audit", "audit copy"]).name == "Audit copy 2")
+    // the suggested name must itself pass the validator against the originals
+    #expect(JobConfig.validateName(copy.name, existingNames: ["Audit"]) == nil)
+}

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -58,12 +58,16 @@ public struct JobFormView: View {
 
     /// - Parameters:
     ///   - job: An existing job to edit, or `nil` to create a new one.
+    ///   - isDuplicate: When `true`, the form prefills its fields from `job` but
+    ///     treats the result as a brand-new job — it gets a fresh `id` and
+    ///     `createdAt`, a cleared `lastRunAt`, and the save button reads "Add".
     ///   - workspaces: Workspaces to choose from; their providers source the repo list.
     ///   - existingNames: Names of other jobs, used for duplicate detection.
     ///   - listRepos: Loads the `owner/repo` slugs available to a workspace.
     ///   - onSave: Called with the validated `JobConfig` when the user taps Save/Add.
     public init(
         job: JobConfig? = nil,
+        isDuplicate: Bool = false,
         workspaces: [WorkspaceInfo] = [],
         existingNames: [String] = [],
         listRepos: @escaping (WorkspaceInfo) async -> [String] = { _ in [] },
@@ -71,9 +75,9 @@ public struct JobFormView: View {
     ) {
         self.workspaces = workspaces
         self.listRepos = listRepos
-        self.existingID = job?.id
-        self.existingLastRunAt = job?.lastRunAt
-        self.existingCreatedAt = job?.createdAt ?? Date()
+        self.existingID = isDuplicate ? nil : job?.id
+        self.existingLastRunAt = isDuplicate ? nil : job?.lastRunAt
+        self.existingCreatedAt = isDuplicate ? Date() : (job?.createdAt ?? Date())
         self.existingNames = existingNames
         self.onSave = onSave
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -16,6 +16,8 @@ public struct SettingsView: View {
     @State private var editingWorkspace: WorkspaceInfo?
     @State private var isAddingJob = false
     @State private var editingJob: JobConfig?
+    /// A pre-filled copy of a job, presented in the form (create mode) to duplicate it.
+    @State private var duplicatingJob: JobConfig?
     @State private var summaryReposText: String
 
     public var onSave: ((String, AppConfig) -> Void)?
@@ -106,6 +108,18 @@ public struct SettingsView: View {
                     config.jobs[idx] = updated
                     save()
                 }
+            }
+        }
+        .sheet(item: $duplicatingJob) { job in
+            JobFormView(
+                job: job,
+                isDuplicate: true,
+                workspaces: config.workspaces,
+                existingNames: otherJobNames(),
+                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? [] }
+            ) { newJob in
+                config.jobs.append(newJob)
+                save()
             }
         }
     }
@@ -383,6 +397,14 @@ public struct SettingsView: View {
                             }
                             .buttonStyle(.borderless)
                             .accessibilityLabel("Edit \(job.name)")
+
+                            Button {
+                                duplicatingJob = job.duplicated(existingNames: config.jobs.map(\.name))
+                            } label: {
+                                Image(systemName: "plus.square.on.square")
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel("Duplicate \(job.name)")
 
                             Button(role: .destructive) {
                                 config.jobs.removeAll { $0.id == job.id }


### PR DESCRIPTION
Closes #378

## What

Adds a **Duplicate** action to each job row in the Jobs tab. Jobs often differ only slightly (same repo/workspace, a tweaked prompt set or schedule), but the only way to make a near-copy was to re-enter everything by hand. Duplicating clones an existing job as a starting point the user can review and tweak before saving.

## How

- **`JobConfig.duplicated(existingNames:)`** — clones a job with a fresh `id` and `createdAt`, cleared `lastRunAt`, and `enabled = false` so it can't fire before review. `workspace`/`repo`/`prompts`/`schedule` are copied verbatim. The name is made unique against existing names (`"… copy"`, `"… copy 2"`, …) via a new `uniqueCopyName` helper that matches `validateName`'s case-insensitive rule.
- **`JobFormView`** — gains an `isDuplicate` flag: it prefills its fields from the passed job but treats the result as a brand-new job (fresh id/createdAt, cleared lastRunAt, **"Add"** button), reusing the existing create flow.
- **`SettingsView`** — a duplicate icon button on each job row opens the prefilled form; saving appends a new `JobConfig` via the existing `config.jobs.append` + `save()` path.

## Acceptance criteria

- [x] Each job row has a Duplicate action
- [x] Duplicating produces a new job: new `id`, unique `"… copy"` name, copied repo/workspace/prompts/schedule, `lastRunAt` cleared, fresh `createdAt`
- [x] Persisted to `config.jobs` via the existing `save()` path
- [x] Duplicate does not immediately fire (disabled by default + fresh `createdAt`)
- [x] Editing/deleting the duplicate doesn't affect the original (value type + new `id`)
- [x] Unit test for the clone helper (new id, unique name, reset run state, `"copy N"` escalation)

## Testing

CrowCore test suite passes (10/10), including the new `jobConfigDuplicated`. The CrowUI changes mirror the existing Add/Edit sheet patterns; full app build verification is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)