### PR TITLE
Support wildcard patterns in auto-review repo selector

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Check whether a repo name matches any of the exclude patterns.
+/// Check whether a repo name matches any of the given patterns.
 /// Supports exact matches and simple glob patterns with `*` (e.g., `org/*`, `*/repo`).
-public func repoMatchesExcludePatterns(_ repo: String, patterns: [String]) -> Bool {
+public func repoMatchesPatterns(_ repo: String, patterns: [String]) -> Bool {
     let lowerRepo = repo.lowercased()
     for pattern in patterns {
         let lowerPattern = pattern.lowercased()
@@ -180,7 +180,7 @@ public final class AppState {
     public var filteredReviewRequests: [ReviewRequest] {
         var result = reviewRequests
         if !excludeReviewRepos.isEmpty {
-            result = result.filter { !repoMatchesExcludePatterns($0.repo, patterns: excludeReviewRepos) }
+            result = result.filter { !repoMatchesPatterns($0.repo, patterns: excludeReviewRepos) }
         }
         if !ignoreReviewLabels.isEmpty {
             let lowerLabels = Set(ignoreReviewLabels.map { $0.lowercased() })
@@ -417,7 +417,7 @@ public final class AppState {
     /// Issues after applying repo exclusion filter.
     public var filteredAssignedIssues: [AssignedIssue] {
         guard !excludeTicketRepos.isEmpty else { return assignedIssues }
-        return assignedIssues.filter { !repoMatchesExcludePatterns($0.repo, patterns: excludeTicketRepos) }
+        return assignedIssues.filter { !repoMatchesPatterns($0.repo, patterns: excludeTicketRepos) }
     }
 
     /// Count of issues in a given pipeline status. Treats `.unknown` as `.backlog`.

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -286,40 +286,52 @@ import Testing
 // MARK: - Repo Exclude Pattern Matching
 
 @Test func repoExcludeExactMatch() {
-    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["org/repo"]) == true)
-    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["org/other"]) == false)
+    #expect(repoMatchesPatterns("org/repo", patterns: ["org/repo"]) == true)
+    #expect(repoMatchesPatterns("org/repo", patterns: ["org/other"]) == false)
 }
 
 @Test func repoExcludeCaseInsensitive() {
-    #expect(repoMatchesExcludePatterns("Org/Repo", patterns: ["org/repo"]) == true)
-    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["ORG/REPO"]) == true)
+    #expect(repoMatchesPatterns("Org/Repo", patterns: ["org/repo"]) == true)
+    #expect(repoMatchesPatterns("org/repo", patterns: ["ORG/REPO"]) == true)
 }
 
 @Test func repoExcludeWildcardSuffix() {
-    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["org/*"]) == true)
-    #expect(repoMatchesExcludePatterns("org/other", patterns: ["org/*"]) == true)
-    #expect(repoMatchesExcludePatterns("different/repo", patterns: ["org/*"]) == false)
+    #expect(repoMatchesPatterns("org/repo", patterns: ["org/*"]) == true)
+    #expect(repoMatchesPatterns("org/other", patterns: ["org/*"]) == true)
+    #expect(repoMatchesPatterns("different/repo", patterns: ["org/*"]) == false)
 }
 
 @Test func repoExcludeWildcardPrefix() {
-    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["*/repo"]) == true)
-    #expect(repoMatchesExcludePatterns("other/repo", patterns: ["*/repo"]) == true)
-    #expect(repoMatchesExcludePatterns("org/other", patterns: ["*/repo"]) == false)
+    #expect(repoMatchesPatterns("org/repo", patterns: ["*/repo"]) == true)
+    #expect(repoMatchesPatterns("other/repo", patterns: ["*/repo"]) == true)
+    #expect(repoMatchesPatterns("org/other", patterns: ["*/repo"]) == false)
 }
 
 @Test func repoExcludeWildcardOnly() {
-    #expect(repoMatchesExcludePatterns("org/repo", patterns: ["*"]) == true)
+    #expect(repoMatchesPatterns("org/repo", patterns: ["*"]) == true)
 }
 
 @Test func repoExcludeMultiplePatterns() {
     let patterns = ["org/specific", "other-org/*"]
-    #expect(repoMatchesExcludePatterns("org/specific", patterns: patterns) == true)
-    #expect(repoMatchesExcludePatterns("other-org/anything", patterns: patterns) == true)
-    #expect(repoMatchesExcludePatterns("org/different", patterns: patterns) == false)
+    #expect(repoMatchesPatterns("org/specific", patterns: patterns) == true)
+    #expect(repoMatchesPatterns("other-org/anything", patterns: patterns) == true)
+    #expect(repoMatchesPatterns("org/different", patterns: patterns) == false)
 }
 
 @Test func repoExcludeEmptyPatterns() {
-    #expect(repoMatchesExcludePatterns("org/repo", patterns: []) == false)
+    #expect(repoMatchesPatterns("org/repo", patterns: []) == false)
+}
+
+@Test func repoMiddleWildcard() {
+    #expect(repoMatchesPatterns("org/prefix-foo", patterns: ["org/prefix-*"]) == true)
+    #expect(repoMatchesPatterns("org/prefix-bar-baz", patterns: ["org/prefix-*"]) == true)
+    #expect(repoMatchesPatterns("org/other", patterns: ["org/prefix-*"]) == false)
+}
+
+@Test func repoSuffixWildcard() {
+    #expect(repoMatchesPatterns("org/foo-suffix", patterns: ["*-suffix"]) == true)
+    #expect(repoMatchesPatterns("org/bar-suffix", patterns: ["*-suffix"]) == true)
+    #expect(repoMatchesPatterns("org/suffix-bar", patterns: ["*-suffix"]) == false)
 }
 
 @Test func appConfigDecodesLegacyExperimentalTmuxBackendKey() throws {

--- a/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
@@ -77,7 +77,7 @@ public struct WorkspaceFormView: View {
 
                 TextField("Auto-Review Repos", text: $autoReviewReposText)
                     .textFieldStyle(.roundedBorder)
-                Text("Comma-separated repos (e.g. org/repo). New review requests from these repos will automatically create a review session.")
+                Text("Comma-separated repos or patterns (e.g. org/repo, org/*). New review requests from matching repos will automatically create a review session.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -573,14 +573,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         var autoReviewedFingerprints: Set<String> = []
         tracker.onReviewRequestsRefreshed = { [weak self] requests in
             guard let self else { return }
-            let enabledRepos = Set((self.appConfig?.workspaces ?? [])
+            let enabledPatterns = (self.appConfig?.workspaces ?? [])
                 .flatMap(\.autoReviewRepos)
-                .map { $0.lowercased() })
-            guard !enabledRepos.isEmpty else { return }
+            guard !enabledPatterns.isEmpty else { return }
 
             var pendingURLs: [String] = []
             for request in requests {
-                guard enabledRepos.contains(request.repo.lowercased()) else { continue }
+                guard repoMatchesPatterns(request.repo, patterns: enabledPatterns) else { continue }
                 let fingerprint = "\(request.id)@\(request.headRefOid ?? "")"
                 guard !autoReviewedFingerprints.contains(fingerprint) else { continue }
 

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -349,7 +349,7 @@ final class IssueTracker {
         let ticketExcludePatterns = config.defaults.excludeTicketRepos
         let autoCreateCandidates = ticketExcludePatterns.isEmpty
             ? allIssues
-            : allIssues.filter { !repoMatchesExcludePatterns($0.repo, patterns: ticketExcludePatterns) }
+            : allIssues.filter { !repoMatchesPatterns($0.repo, patterns: ticketExcludePatterns) }
         detectAutoCreateCandidates(issues: autoCreateCandidates)
 
         if let ghResult {
@@ -391,7 +391,7 @@ final class IssueTracker {
             let allCurrentIDs = Set(reviews.map(\.id))
             let reviewExcludePatterns = config.defaults.excludeReviewRepos
             if !reviewExcludePatterns.isEmpty {
-                reviews = reviews.filter { !repoMatchesExcludePatterns($0.repo, patterns: reviewExcludePatterns) }
+                reviews = reviews.filter { !repoMatchesPatterns($0.repo, patterns: reviewExcludePatterns) }
             }
             let ignoreLabels = config.defaults.ignoreReviewLabels
             if !ignoreLabels.isEmpty {


### PR DESCRIPTION
## Summary
- Reuse the existing glob matching function (renamed `repoMatchesExcludePatterns` → `repoMatchesPatterns`) so `autoReviewRepos` entries like `org/*` and `org/prefix-*` resolve at review-time
- Patterns are matched when review requests arrive, not at config-time, so newly created repos are picked up automatically
- Updated UI help text to mention wildcard support

Closes #382

## Test plan
- [x] `make build` succeeds
- [x] All 192 CrowCore tests pass (including 2 new glob pattern tests)
- [ ] Set auto-review repos to `RadiusMethod/*` in Settings, verify matching PRs trigger auto-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)