### PR TITLE
Launch scheduled jobs in auto-permission mode

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -43,6 +43,12 @@ public final class AppState {
     /// launch; worker sessions and CLI-spawned terminals are unaffected.
     public var managerAutoPermissionMode: Bool = true
 
+    /// Whether sessions launched by the Jobs scheduler start with
+    /// `--permission-mode auto` so the job's prompts can run `crow`, `gh`, and
+    /// `git` without per-call approval. Mirrors `AppConfig.jobsAutoPermissionMode`.
+    /// Applies only to `.job`-kind sessions; manager/review/CLI sessions are unaffected.
+    public var jobsAutoPermissionMode: Bool = true
+
     /// `true` when the Manager's `claude` process has exited (crash, kill, OOM)
     /// and has not yet been restarted. Drives the "Manager process exited" banner
     /// and enables the "Restart Manager" action. Reset when the Manager relaunches.

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -12,6 +12,11 @@ public struct AppConfig: Codable, Sendable, Equatable {
     public var sidebar: SidebarSettings
     public var remoteControlEnabled: Bool
     public var managerAutoPermissionMode: Bool
+    /// When true, sessions launched by the Jobs scheduler start with
+    /// `--permission-mode auto` so their prompts can run `crow`, `gh`, and
+    /// `git` without per-call approval. Defaults to true — jobs are
+    /// unattended by definition.
+    public var jobsAutoPermissionMode: Bool
     public var telemetry: TelemetryConfig
     public var autoRespond: AutoRespondSettings
     /// When true, `setup.sh` writes a per-worktree `.claude/settings.local.json`
@@ -48,6 +53,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         sidebar: SidebarSettings = SidebarSettings(),
         remoteControlEnabled: Bool = false,
         managerAutoPermissionMode: Bool = true,
+        jobsAutoPermissionMode: Bool = true,
         telemetry: TelemetryConfig = TelemetryConfig(),
         autoRespond: AutoRespondSettings = AutoRespondSettings(),
         attributionTrailers: Bool = true,
@@ -63,6 +69,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.sidebar = sidebar
         self.remoteControlEnabled = remoteControlEnabled
         self.managerAutoPermissionMode = managerAutoPermissionMode
+        self.jobsAutoPermissionMode = jobsAutoPermissionMode
         self.telemetry = telemetry
         self.autoRespond = autoRespond
         self.attributionTrailers = attributionTrailers
@@ -81,6 +88,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         sidebar = try container.decodeIfPresent(SidebarSettings.self, forKey: .sidebar) ?? SidebarSettings()
         remoteControlEnabled = try container.decodeIfPresent(Bool.self, forKey: .remoteControlEnabled) ?? false
         managerAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .managerAutoPermissionMode) ?? true
+        jobsAutoPermissionMode = try container.decodeIfPresent(Bool.self, forKey: .jobsAutoPermissionMode) ?? true
         telemetry = try container.decodeIfPresent(TelemetryConfig.self, forKey: .telemetry) ?? TelemetryConfig()
         autoRespond = try container.decodeIfPresent(AutoRespondSettings.self, forKey: .autoRespond) ?? AutoRespondSettings()
         attributionTrailers = try container.decodeIfPresent(Bool.self, forKey: .attributionTrailers) ?? true
@@ -92,7 +100,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, autoRebaseWatcherEnabled, cleanup, jobs
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, autoRebaseWatcherEnabled, cleanup, jobs
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -144,6 +144,29 @@ import Testing
     #expect(config.managerAutoPermissionMode == true)
 }
 
+@Test func appConfigJobsAutoPermissionModeRoundTrip() throws {
+    var config = AppConfig()
+    config.jobsAutoPermissionMode = false
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.jobsAutoPermissionMode == false)
+
+    config.jobsAutoPermissionMode = true
+    let data2 = try JSONEncoder().encode(config)
+    let decoded2 = try JSONDecoder().decode(AppConfig.self, from: data2)
+    #expect(decoded2.jobsAutoPermissionMode == true)
+}
+
+@Test func appConfigJobsAutoPermissionModeDefaultsTrueWhenKeyMissing() throws {
+    // Jobs are unattended by definition — legacy configs without the key opt
+    // in by default so scheduled runs can execute crow/gh/git without
+    // per-call approval, matching the Manager toggle's default.
+    let json = #"{"workspaces": [], "remoteControlEnabled": false}"#.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.jobsAutoPermissionMode == true)
+}
+
 @Test func appConfigDecodeWithPartialKeys() throws {
     let json = """
     {"workspaces": [{"id": "00000000-0000-0000-0000-000000000001", "name": "Org", "provider": "github", "cli": "gh", "alwaysInclude": []}]}

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -342,6 +342,14 @@ public struct SettingsView: View {
 
     private var jobsTab: some View {
         Form {
+            Section("Auto-permission mode") {
+                Toggle("Run scheduled jobs in auto permission mode", isOn: $config.jobsAutoPermissionMode)
+                    .onChange(of: config.jobsAutoPermissionMode) { _, _ in save() }
+                Text("Passes --permission-mode auto so scheduled jobs can run crow, gh, and git commands without per-call approval. Requires Claude Code 2.1.83+ on a Max, Team, Enterprise, or API plan with the Anthropic provider. Turn off if your account reports auto mode as unavailable. Takes effect on the next job run.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section {
                 if config.jobs.isEmpty {
                     Text("No jobs configured")

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -384,6 +384,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // be rebuilt to include (or drop) `--rc` before its surface is pre-initialized.
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
+        appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
@@ -994,6 +995,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.hideSessionDetails = config.sidebar.hideSessionDetails
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
+        appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
         appState.excludeReviewRepos = config.defaults.excludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -411,9 +411,18 @@ final class SessionService {
         }
 
         let claudePath = Self.findClaudeBinary() ?? "claude"
-        let sessionName = sessionID.flatMap { id in appState.sessions.first(where: { $0.id == id })?.name }
+        let session = sessionID.flatMap { id in appState.sessions.first(where: { $0.id == id }) }
+        let sessionName = session?.name
         let rcEnabled = appState.remoteControlEnabled
-        let rcArgs = ClaudeLaunchArgs.argsSuffix(remoteControl: rcEnabled, sessionName: sessionName)
+        // Jobs are unattended, so opt-in (default-on) auto-permission mode lets
+        // their prompts run crow/gh/git without per-call approval. Scoped to
+        // .job kind so review and other session kinds are unaffected.
+        let autoPermissionMode = (session?.kind == .job) && appState.jobsAutoPermissionMode
+        let rcArgs = ClaudeLaunchArgs.argsSuffix(
+            remoteControl: rcEnabled,
+            sessionName: sessionName,
+            autoPermissionMode: autoPermissionMode
+        )
 
         // Build OTEL telemetry env var prefix if enabled
         let envPrefix: String


### PR DESCRIPTION
## Summary

- Adds a global **Jobs auto-permission mode** toggle (default ON) under Settings → Jobs, mirroring `managerAutoPermissionMode` end-to-end.
- When ON, sessions spawned by the Jobs scheduler launch `claude` with `--permission-mode auto`, so unattended runs don't prompt for every `crow`/`gh`/`git` call.
- Scoped to `.job`-kind sessions only — review and other session kinds are unaffected by the toggle.

Closes #390

## Implementation

| File | Change |
|---|---|
| `AppConfig.swift` | Add `jobsAutoPermissionMode: Bool` (default `true`) — stored property, init param, decoder fallback, `CodingKeys`. |
| `AppState.swift` | Mirror property with doc comment. |
| `AppDelegate.swift` | Two sync points (launch + on-save) parallel to `managerAutoPermissionMode`. |
| `SessionService.swift` (`launchClaude`) | Resolve the session once; pass `autoPermissionMode = (session.kind == .job) && appState.jobsAutoPermissionMode` to `ClaudeLaunchArgs.argsSuffix`. |
| `SettingsView.swift` (`jobsTab`) | New "Auto-permission mode" section above the job list with copy mirroring the Manager toggle (`AutomationSettingsView`). |
| `AppConfigTests.swift` | Round-trip + missing-key default tests, mirroring the existing Manager tests. |

`ClaudeLaunchArgs.argsSuffix` already accepts `autoPermissionMode` — no helper change needed.

## Default value

`true` (opt-out), matching `managerAutoPermissionMode`. Rationale: jobs are unattended by definition; users who have Manager auto-mode on almost certainly want it for jobs too, and legacy configs without the key get the behavior automatically.

## Test plan

- [x] `make build` — clean.
- [x] `swift test --package-path Packages/CrowCore` — all 194 tests pass, including the two new ones (`appConfigJobsAutoPermissionModeRoundTrip`, `appConfigJobsAutoPermissionModeDefaultsTrueWhenKeyMissing`).
- [ ] Manual: Settings → Jobs shows the new toggle defaulted ON; toggling persists across app restarts.
- [ ] Manual: with toggle ON, running a job (▶) launches `claude --permission-mode auto …` in the job's terminal.
- [ ] Manual: with toggle OFF, the same job launches without `--permission-mode auto`.
- [ ] Manual: non-job sessions (Review, Manager) are unaffected by the toggle either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)