### PR TITLE
Add ADR section under docs/ and backfill four key decisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,10 @@
 
 This is the development root managed by Crow. The Manager tab runs Claude Code here to orchestrate work sessions via the `crow` CLI.
 
+## Architecture Decision Records
+
+Architectural decisions live in [`docs/adr/`](docs/adr/). Read [`docs/adr/README.md`](docs/adr/README.md) for the index, and copy [`docs/adr/template.md`](docs/adr/template.md) to start a new one. When superseding a decision, update the old ADR's `Status` field to `Superseded by NNNN` — don't delete it. The history is the point.
+
 ## crow CLI Reference
 
 The `crow` CLI communicates with the Crow app via Unix socket at `~/.local/share/crow/crow.sock`. The app must be running for commands to work. **All `crow`, `gh`, `glab`, and `git worktree` commands require `dangerouslyDisableSandbox: true`** and return JSON.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,12 @@ If a new package is needed, create it under `Packages/` and add it to the root `
    - A link to the related issue
    - Screenshots for UI changes
 
+## Architecture Decision Records
+
+Decisions that will outlive a single PR — defaults, contracts, architecture choices, or anything a new contributor or agent would want to find by grep — get recorded as ADRs under [`docs/adr/`](docs/adr/). Copy [`docs/adr/template.md`](docs/adr/template.md), give it the next 4-digit sequence number, fill in `Context` / `Decision` / `Consequences` / `Alternatives considered`, and add a row to the index in [`docs/adr/README.md`](docs/adr/README.md). PR descriptions are still where you explain *this change*; ADRs are where you explain *the decision* that change is implementing.
+
+When superseding an existing ADR, leave the old file in place and update its `Status` field to `Superseded by NNNN`. We keep the trail.
+
 ## Versioning
 
 Crow follows [Semantic Versioning](https://semver.org/):

--- a/docs/adr/0001-tmux-only-terminal-backend.md
+++ b/docs/adr/0001-tmux-only-terminal-backend.md
@@ -1,0 +1,53 @@
+# 0001 — tmux as the sole terminal backend
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Deciders:** Crow maintainers
+
+## Context
+
+Crow originally embedded one libghostty surface per terminal pane. As we built out the Manager pattern and parallel sessions, three problems became load-bearing rather than incidental:
+
+1. **Shell-readiness was guesswork.** We used a 5-second sleep before sending the first command into a new terminal, because there was no signal that the shell had drained its rc files and was ready for input. Anything that took longer than 5 s dropped its first input on the floor; anything faster wasted seconds per session.
+2. **Input was bounded by libghostty's write path.** Large prompt bodies (especially the pre-fetched ticket text in initial prompts) could outrun the surface's input buffer, producing dropped characters and reordered keystrokes.
+3. **Survival across app restarts was effectively impossible.** Each terminal was tied to a per-process libghostty surface; relaunching Crow meant rebuilding every session from scratch.
+
+`docs/terminal-runtime-research.md` documents the underlying analysis and the libghostty bottleneck in detail.
+
+## Decision
+
+Crow uses **tmux as its sole terminal backend.** A single libghostty surface attaches to a persistent tmux server at a stable socket (`$TMPDIR/crow-tmux.sock`); per-session state is the tmux binding (window/pane) stored on `SessionTerminal.tmuxBinding`.
+
+A single-instance lock at `$TMPDIR/crow-instance.lock` prevents two Crow processes from racing the same tmux server. The "Restart tmux Server" menu item rebuilds the cockpit on demand without a full app relaunch.
+
+## Consequences
+
+**Easier:**
+
+- Reliable shell-readiness via `SentinelWaiter` (we emit a sentinel from the shell rc and watch for it on the pipe). The 5 s sleep is gone.
+- Bounded, ordered input via `tmux load-buffer` + `paste-buffer` — large prompts paste atomically.
+- Sessions survive app restarts. On launch, Crow re-attaches to the existing tmux server and adopts pre-existing windows via `adoptTerminal`.
+- One libghostty surface to maintain rather than N per-terminal surfaces.
+
+**Harder / accepted:**
+
+- Hard runtime dependency on `tmux` being installed. `TmuxDiscovery` resolves the binary at startup; absence is a hard error.
+- Multi-backend flexibility is gone. Adding another backend (Kitty, iTerm controller mode, etc.) means re-introducing the abstraction we just deleted.
+- Orphan tmux sockets from older Crow versions need explicit reaping (`TmuxOrphanReaper`).
+
+## Alternatives considered
+
+- **Keep per-terminal libghostty surfaces.** Rejected — this was the root cause of the three problems above; no path forward without addressing the surface-per-terminal model itself.
+- **Kitty / iTerm controller-mode backends.** Rejected — would require maintaining a second backend abstraction for marginal gain; tmux is already a hard dependency on most dev machines.
+- **Custom PTY multiplexer in-process.** Rejected — re-implements what tmux already does well, and loses the "tmux session survives Crow crashes" property.
+
+## References
+
+- PRs: [#229](https://github.com/radiusmethod/crow/pull/229) (feature flag), [#302](https://github.com/radiusmethod/crow/pull/302) (default backend), [#334](https://github.com/radiusmethod/crow/pull/334) (remove legacy Ghostty path), [#324](https://github.com/radiusmethod/crow/pull/324) (Manager on tmux), [#353](https://github.com/radiusmethod/crow/pull/353) (persist across restarts), [#377](https://github.com/radiusmethod/crow/pull/377) (restart-server menu)
+- Research: [`docs/terminal-runtime-research.md`](../terminal-runtime-research.md)
+- Code:
+  - `Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift`
+  - `Packages/CrowTerminal/Sources/CrowTerminal/TmuxController.swift`
+  - `Packages/CrowTerminal/Sources/CrowTerminal/SentinelWaiter.swift`
+  - `Packages/CrowTerminal/Sources/CrowTerminal/TmuxOrphanReaper.swift`
+  - `Sources/Crow/App/TmuxDiscovery.swift`

--- a/docs/adr/0002-unix-socket-cli-architecture.md
+++ b/docs/adr/0002-unix-socket-cli-architecture.md
@@ -1,0 +1,48 @@
+# 0002 — Unix-socket CLI ↔ app architecture
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Deciders:** Crow maintainers
+
+## Context
+
+The Manager session (and any external shell) needs to drive Crow programmatically — create sessions, attach worktrees, send keystrokes to a terminal, change session status. The constraints:
+
+- The app already holds the canonical state (sessions, terminals, worktrees, links). Spawning a second process to mutate that state would mean either duplicating the state or building a much more invasive sync layer.
+- We do not want to expose Crow to the network. Even a localhost HTTP listener can be picked up by other processes on the machine, browser fetches, or accidental tunneling.
+- Calls need request/response semantics and typed payloads — a one-shot fire-and-forget queue isn't enough.
+- The CLI is invoked from many places (Manager Claude Code, shell scripts, hooks, `crow-workspace/setup.sh`); per-call cost matters.
+
+## Decision
+
+The `crow` CLI is a **thin client that speaks newline-delimited JSON-RPC 2.0 over a Unix domain socket** at `~/.local/share/crow/crow.sock` to the running Crow app. All state mutations are routed through `CommandRouter` and executed on the main actor.
+
+The socket directory is `0700` and the socket file is `0600`, so only the local user can connect. Maximum message size is bounded (1 MB) to prevent runaway payloads.
+
+## Consequences
+
+**Easier:**
+
+- Single source of truth for app state — the CLI cannot drift from what the app sees.
+- No network exposure. Unix-socket file permissions are sufficient access control on a single-user dev machine.
+- Concurrent CLI calls are safe by construction: each connection is dispatched to GCD's global concurrent queue, and all state mutations land on the main actor via `await MainActor.run { ... }`. This is documented in `CLAUDE.md` under "Concurrency Safety."
+- Typed RPC. The CLI and app share the request/response types, so adding a command is a single Swift-level change.
+
+**Harder / accepted:**
+
+- The app must be running for the CLI to work. This is intentional — the CLI is a remote control, not a stand-alone tool — but it means scripts must check for the app or be tolerant of a missing socket.
+- Cross-machine use (e.g. SSH-ing in to drive Crow) needs SSH socket forwarding rather than a network port; we consider this a feature, not a limitation.
+
+## Alternatives considered
+
+- **AppleScript / OSAScript bridge.** Rejected — slower per call, weakly typed, and harder to drive from non-Apple tooling.
+- **Localhost HTTP listener.** Rejected — port allocation, accidental exposure to other processes, and TLS isn't appropriate for a single-user dev tool.
+- **File-based command queue / drop-box.** Rejected — no native request/response, hard to make atomic, and would still need a polling loop on the app side.
+
+## References
+
+- Code:
+  - `Packages/CrowIPC/Sources/CrowIPC/SocketServer.swift`
+  - `Packages/CrowIPC/Sources/CrowIPC/` (CommandRouter and request/response types)
+  - `Sources/CrowCLI/main.swift`
+- Reference: [`CLAUDE.md`](../../CLAUDE.md) — "Concurrency Safety" and "crow CLI Reference" sections

--- a/docs/adr/0003-worktree-per-task-model.md
+++ b/docs/adr/0003-worktree-per-task-model.md
@@ -1,0 +1,47 @@
+# 0003 — Worktree-per-task model
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Deciders:** Crow maintainers
+
+## Context
+
+Crow's central pattern is running multiple Claude Code sessions in parallel, each working on a different ticket. A single clone of a repo can only have one branch checked out at a time — the working tree, the index, and `HEAD` are shared global state. That makes branch-switching hostile to parallel agents: any two sessions touching the same clone will fight over the working tree, and an agent that runs `git checkout` mid-task can clobber another agent's edits.
+
+We also want the on-disk layout to be self-describing — a path like `/Users/jane/Dev/RadiusMethod/acme-api-197-fix-tab-url-hash` should reveal the repo, the ticket, and the slug at a glance, both for humans and for grep-based agent navigation.
+
+## Decision
+
+Each session gets its **own git worktree** at `{devRoot}/{workspace}/{repo}-{ticket}-{slug}`, on its own branch created with `--no-track origin/main`. Worktrees are **siblings of the main clone**, never nested under a `worktrees/` subdirectory.
+
+The Manager session and other fixed-UUID virtual sessions are exempt from cleanup. Other completed/archived sessions can be auto-cleaned (worktree directory + branch removed) after a configurable retention window; auto-cleanup is opt-in and disabled by default.
+
+## Consequences
+
+**Easier:**
+
+- Parallel sessions are fully isolated — two sessions touching the same repo can run side-by-side without `HEAD` contention.
+- The path scheme is grep-able. `ls {devRoot}/{workspace}/` is the session list.
+- `--no-track` on branch creation prevents an accidental `git push` from publishing a stray feature branch to `main`'s tracking remote.
+- Cleanup is a directory removal plus a branch delete — no orphan state.
+
+**Harder / accepted:**
+
+- Disk usage scales with the number of active sessions (working tree is duplicated, though `.git` objects are shared via the parent clone).
+- `git worktree add` setup time per session (typically <1 s for warm repos, longer for cold).
+- Tooling has to be worktree-aware: `cd`-into-clone scripts break; everything uses `git -C <path>` instead.
+
+## Alternatives considered
+
+- **Branch-switching in one clone.** Rejected — blocks concurrency; one of the original motivating problems.
+- **Per-session full clones.** Rejected — duplicates `.git`, breaks the shared object DB, and slows down `git worktree add`-style operations.
+- **Bare-clone hub with task-specific checkouts.** Rejected — a worktree off a normal clone gives us the same benefit without forcing every developer to maintain a separate bare-clone hub.
+
+## References
+
+- PRs: [#261](https://github.com/radiusmethod/crow/pull/261) (auto-cleanup of completed sessions)
+- Code:
+  - `skills/crow-workspace/setup.sh` (creates the worktree and enforces the naming convention)
+  - `Packages/CrowCore/Sources/CrowCore/Models/Worktree.swift`
+  - `Packages/CrowCLI/Sources/CrowCLILib/Commands/WorktreeCommands.swift`
+- Reference: [`CLAUDE.md`](../../CLAUDE.md) — "Git Worktree Best Practices"

--- a/docs/adr/0004-manager-auto-permission-mode.md
+++ b/docs/adr/0004-manager-auto-permission-mode.md
@@ -1,0 +1,49 @@
+# 0004 — Manager session launches in auto-permission mode by default
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Deciders:** Crow maintainers
+
+## Context
+
+The Manager session is the orchestration tab inside Crow. Its job is to run `crow` subcommands, fetch ticket data via `gh` / `glab`, manipulate worktrees with `git`, and spawn worker sessions. In a typical Manager run, it issues dozens of these calls in quick succession.
+
+Claude Code's default permission model prompts the user before each shell command. For a worker session doing user-facing work, that's the right default — the user is the one driving the task and a prompt is a useful checkpoint. For the Manager, it makes the experience unusable: every `crow list-sessions`, every `gh issue view`, every `git worktree add` would block on a prompt.
+
+A purely permission-allowlist approach was tried first. It works for the most common commands but does not generalize — the long tail of `crow` subcommands, `gh api`, `git -C`, and ad-hoc one-liners is too broad to enumerate, and missing rules silently fall back to a prompt.
+
+## Decision
+
+The Manager terminal is launched with `--permission-mode auto` by default. This is governed by `AppConfig.managerAutoPermissionMode`, which defaults to `true`. Worker sessions and any terminal spawned via `crow new-terminal` do **not** get `--permission-mode auto` — they use Claude Code's default mode.
+
+The trust scope is explicit: only the Manager. The user can disable Manager auto-permission via the config field if their threat model requires it.
+
+## Consequences
+
+**Easier:**
+
+- The Manager can orchestrate without per-call friction. Workflows that issue many `crow` / `gh` / `git` calls finish in the time it takes them to run, not the time it takes the user to click "Allow."
+- Trust boundary is clear — exactly one tab gets the elevated mode, and it's the one running on a curated `CLAUDE.md` with curated allowlists.
+
+**Harder / accepted:**
+
+- Anything the Manager Claude decides to run, runs. The Manager is implicitly trusted; we accept this as the cost of automation.
+- Adding new automation behavior to the Manager requires re-confirming that no command in the workflow is destructive without intent. Manager-context guidance in `CLAUDE.md` (e.g. "use single-clean invocations for ticket fetches") is now load-bearing for both ergonomics *and* safety.
+
+## Alternatives considered
+
+- **Global auto-permission for every session.** Rejected — too broad; a worker session doing actual user-facing work should still prompt.
+- **Per-command allowlist only.** Rejected — tried first; the long tail of subcommands and one-liners falls through to prompts and breaks orchestration.
+- **Confirm-once-per-session interactive mode.** Rejected — the Manager runs unattended for long stretches; an interactive confirm at the start of every run is just a prompt with extra steps.
+
+## References
+
+- PRs: [#189](https://github.com/radiusmethod/crow/pull/189) (introduce `managerAutoPermissionMode`, default `true`)
+- Code:
+  - `Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift`
+  - `Packages/CrowCore/Sources/CrowCore/AppState.swift`
+  - `Packages/CrowCore/Sources/CrowCore/ClaudeLaunchArgs.swift`
+  - `Sources/Crow/App/SessionService.swift`
+- Tests:
+  - `Packages/CrowCore/Tests/CrowCoreTests/ClaudeLaunchArgsTests.swift`
+  - `Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,43 @@
+# Architecture Decision Records
+
+Architectural Decision Records (ADRs) capture decisions that shaped Crow and the reasoning behind them. Each file is one decision. The *what* of a change lives in its PR description; the *why* lives here, where it can be grepped, diffed, and superseded.
+
+## When to write an ADR
+
+Write one when the decision will outlive the PR that implements it. Rules of thumb:
+
+- It establishes a default, contract, or invariant other code relies on.
+- It picks one of several reasonable approaches, and a new contributor (or agent) would want to know why.
+- You'd be unhappy if someone re-litigated it six months later without finding your reasoning.
+- It will be referenced from `CLAUDE.md`, `CONTRIBUTING.md`, or another ADR.
+
+A PR description is enough for changes whose rationale doesn't outlive the diff (bug fixes, small refactors, UI tweaks).
+
+## How to add one
+
+1. Copy [`template.md`](./template.md) to `NNNN-kebab-case-title.md` using the next 4-digit sequence number (next free is shown in the index below).
+2. Fill in `Status`, `Date`, `Deciders`, and the four body sections (`Context`, `Decision`, `Consequences`, `Alternatives considered`).
+3. Link the PR(s) that implement(ed) the decision.
+4. Add a row to the index in this file.
+
+## How to supersede an ADR
+
+Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point to the replacement. The history is the point — a future reader needs to see what we used to do and why we changed.
+
+## Status legend
+
+| Status | Meaning |
+|--------|---------|
+| `Proposed` | Under discussion; not yet adopted. |
+| `Accepted` | Active. Code reflects this decision. |
+| `Superseded by NNNN` | Replaced by ADR `NNNN`. File is kept for history. |
+| `Deprecated` | No longer applies; not yet replaced. |
+
+## Index
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| 0001 | [tmux as the sole terminal backend](./0001-tmux-only-terminal-backend.md) | Accepted | 2026-05-25 |
+| 0002 | [Unix-socket CLI ↔ app architecture](./0002-unix-socket-cli-architecture.md) | Accepted | 2026-05-25 |
+| 0003 | [Worktree-per-task model](./0003-worktree-per-task-model.md) | Accepted | 2026-05-25 |
+| 0004 | [Manager session launches in auto-permission mode by default](./0004-manager-auto-permission-mode.md) | Accepted | 2026-05-25 |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,27 @@
+# NNNN — <Title>
+
+- **Status:** Proposed | Accepted | Superseded by [NNNN](./NNNN-foo.md) | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** @handle, @handle
+
+## Context
+
+What problem are we solving? What constraints / forces are in play? Link prior research, related ADRs, or tickets.
+
+## Decision
+
+The change we're making, in one or two sentences. State it as a present-tense fact ("Crow uses X").
+
+## Consequences
+
+What becomes easier, what becomes harder, what we now have to live with. Be honest about the trade-offs.
+
+## Alternatives considered
+
+What else we looked at and why we didn't pick it. One sentence per alternative is fine.
+
+## References
+
+- PR: <link>
+- Related ADRs: [NNNN](./NNNN-foo.md)
+- Code: relative paths to the key source files


### PR DESCRIPTION
Closes #391

## Summary

- Introduces `docs/adr/` with a MADR-style `template.md` and an index `README.md` (status legend + index table + when-to-write guidance).
- Backfills four ADRs covering the most load-bearing architectural decisions a new contributor (or agent) is most likely to question first:
  - **[0001 — tmux as the sole terminal backend](docs/adr/0001-tmux-only-terminal-backend.md)** — supersedes the per-terminal Ghostty model. Cites #229, #302, #334, #324, #353, #377.
  - **[0002 — Unix-socket CLI ↔ app architecture](docs/adr/0002-unix-socket-cli-architecture.md)** — why `crow` is a thin JSON-RPC client over `~/.local/share/crow/crow.sock`.
  - **[0003 — Worktree-per-task model](docs/adr/0003-worktree-per-task-model.md)** — why each session gets its own worktree at `{devRoot}/{workspace}/{repo}-{ticket}-{slug}`. Cites #261.
  - **[0004 — Manager session launches in auto-permission mode by default](docs/adr/0004-manager-auto-permission-mode.md)** — the Manager-only trust scope and why per-command allowlisting wasn't enough. Cites #189.
- Adds a short pointer to `docs/adr/` near the top of `CLAUDE.md` (so the scaffolded Manager `CLAUDE.md` picks it up) and a "When to write an ADR" section in `CONTRIBUTING.md`.

ADRs 5–13 from the ticket's candidate list (Plan-mode flag, `Crow-Session` trailer, ticket pre-fetch, review-session isolation, label-based automation opt-in, hook-driven status colors, multiple Manager sessions, scheduled Jobs) are intentionally out of scope — per the ticket, "the rest can land as we touch the area."

## Test plan

- [ ] `ls docs/adr/` shows 6 files (README, template, 0001–0004).
- [ ] Open `docs/adr/README.md` on GitHub and click through every index link — each lands on the right ADR.
- [ ] `grep -l tmux docs/adr/` returns `0001-…`; `grep -l socket` → `0002-…`; `grep -l worktree` → `0003-…`; `grep -l permission` → `0004-…`. (Agent grep use case.)
- [ ] Relaunch Crow; confirm the scaffolded `{devRoot}/.claude/CLAUDE.md` contains the new `## Architecture Decision Records` section.
- [ ] CONTRIBUTING.md reads cleanly: the new section sits between "Pull Requests" and "Versioning".
- [ ] `make test` still passes (docs-only change, sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)