### PR TITLE
Finalize nav: Reviews→Allowlist→Manager + Manager boxes one-per-row

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -338,9 +338,10 @@ struct ReviewRow: View {
 
 // MARK: - Sidebar Row
 
-/// Combined Manager, Reviews, and Allowlist toggle buttons in the sidebar. The
-/// Manager toggle and its "new Manager" (+) button appear once the primary
-/// Manager has loaded; Reviews and Allowlist are always present.
+/// Combined Reviews, Allowlist, and Manager toggle buttons in the sidebar, in
+/// that order (Manager last). The Manager toggle and its "new Manager" (+)
+/// button appear once the primary Manager has loaded; Reviews and Allowlist are
+/// always present.
 public struct ManagerReviewsAllowListRow: View {
     @Bindable var appState: AppState
 
@@ -350,12 +351,12 @@ public struct ManagerReviewsAllowListRow: View {
 
     public var body: some View {
         HStack(spacing: 6) {
+            reviewButton
+            allowListButton
             if appState.managerSession != nil {
                 managerButton
                 newManagerButton
             }
-            reviewButton
-            allowListButton
         }
         .padding(.vertical, 2)
     }

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -78,18 +78,26 @@ public struct SessionListView: View {
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
 
-            // Additional (non-primary) Manager sessions, packed as wrapping
-            // chips so they don't each consume a full row.
+            // Additional (non-primary) Manager sessions, each deletable.
             let extraManagers = appState.managerSessions.filter { $0.id != AppState.managerSessionID }
-            if !extraManagers.isEmpty {
-                ManagerChipsFlow(
-                    sessions: extraManagers,
-                    appState: appState,
-                    editingSessionID: $editingManagerID,
-                    sessionToDelete: $sessionToDelete
-                )
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+            ForEach(extraManagers) { session in
+                ManagerSessionRow(session: session, appState: appState, editingSessionID: $editingManagerID)
+                    .tag(session.id)
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+                    .contextMenu {
+                        Button {
+                            editingManagerID = session.id
+                        } label: {
+                            Label("Rename", systemImage: "pencil")
+                        }
+                        Button(role: .destructive) {
+                            sessionToDelete = session
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .disabled(appState.isDeletingSession[session.id] == true)
+                    }
             }
 
             // Job sessions
@@ -392,89 +400,15 @@ struct SectionDivider: View {
     }
 }
 
-// MARK: - Manager Chips
+// MARK: - Manager Session Row
 
-/// Layout that flows its subviews left-to-right, wrapping to a new line when
-/// the next subview would overflow the proposed width. Used to pack the extra
-/// Manager chips densely instead of stacking one per row.
-struct FlowLayout: Layout {
-    var spacing: CGFloat = 6
-    var lineSpacing: CGFloat = 6
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let maxWidth = proposal.width ?? .infinity
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var lineHeight: CGFloat = 0
-        var widestLine: CGFloat = 0
-
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            if x > 0, x + size.width > maxWidth {
-                // Wrap to the next line.
-                y += lineHeight + lineSpacing
-                x = 0
-                lineHeight = 0
-            }
-            x += size.width + spacing
-            lineHeight = max(lineHeight, size.height)
-            widestLine = max(widestLine, x - spacing)
-        }
-
-        return CGSize(width: min(widestLine, maxWidth), height: y + lineHeight)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        var x = bounds.minX
-        var y = bounds.minY
-        var lineHeight: CGFloat = 0
-
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            if x > bounds.minX, x + size.width > bounds.maxX {
-                y += lineHeight + lineSpacing
-                x = bounds.minX
-                lineHeight = 0
-            }
-            subview.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: ProposedViewSize(size))
-            x += size.width + spacing
-            lineHeight = max(lineHeight, size.height)
-        }
-    }
-}
-
-/// Wrapping flow of `ManagerChip`s for the additional (non-primary) Manager
-/// sessions. Rendered as a single list row so the chips pack multiple-per-line.
-struct ManagerChipsFlow: View {
-    let sessions: [Session]
-    @Bindable var appState: AppState
-    @Binding var editingSessionID: UUID?
-    @Binding var sessionToDelete: Session?
-
-    var body: some View {
-        FlowLayout(spacing: 6, lineSpacing: 6) {
-            ForEach(sessions) { session in
-                ManagerChip(
-                    session: session,
-                    appState: appState,
-                    editingSessionID: $editingSessionID,
-                    sessionToDelete: $sessionToDelete
-                )
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 2)
-    }
-}
-
-/// Compact selectable pill for an additional (non-primary) Manager session.
-/// Sizes to its content so chips wrap; supports inline rename, a deletion
-/// spinner, and a remote-control badge.
-struct ManagerChip: View {
+/// Sidebar row for an additional (non-primary) Manager session. Renders a
+/// full-width selectable button with the manager's name, a remote-control
+/// badge, and a deletion spinner when cleanup is in flight.
+struct ManagerSessionRow: View {
     let session: Session
     @Bindable var appState: AppState
     @Binding var editingSessionID: UUID?
-    @Binding var sessionToDelete: Session?
 
     @State private var editingName: String = ""
     @FocusState private var isEditing: Bool
@@ -487,18 +421,13 @@ struct ManagerChip: View {
         Button {
             appState.selectedSessionID = session.id
         } label: {
-            HStack(spacing: 4) {
-                if isDeleting {
-                    ProgressView().controlSize(.mini)
-                } else {
-                    Image(systemName: "person.2.fill")
-                        .font(.system(size: 9))
-                }
+            HStack(spacing: 6) {
+                Image(systemName: "person.2.fill")
+                    .font(.system(size: 11))
                 if isEditingThis {
                     TextField("Name", text: $editingName)
                         .textFieldStyle(.plain)
-                        .font(.system(size: 11, weight: .semibold))
-                        .frame(minWidth: 60)
+                        .font(.system(size: 12, weight: .bold))
                         .focused($isEditing)
                         .onSubmit { commitRename() }
                         .onExitCommand { editingSessionID = nil }
@@ -507,18 +436,23 @@ struct ManagerChip: View {
                         }
                 } else {
                     Text(session.name)
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 12, weight: .bold))
                         .lineLimit(1)
+                }
+                Spacer()
+                if isDeleting {
+                    ProgressView().controlSize(.small)
                 }
             }
             .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.vertical, 8)
             .background(
-                RoundedRectangle(cornerRadius: 12)
+                RoundedRectangle(cornerRadius: 6)
                     .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 12)
+                        RoundedRectangle(cornerRadius: 6)
                             .strokeBorder(
                                 isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
                                 lineWidth: 1
@@ -528,25 +462,12 @@ struct ManagerChip: View {
             .overlay(alignment: .topTrailing) {
                 if appState.isRemoteControlActive(sessionID: session.id) {
                     RemoteControlBadge(compact: true)
-                        .padding(2)
+                        .padding(4)
                 }
             }
-            .opacity(isDeleting ? 0.55 : 1.0)
         }
         .buttonStyle(.plain)
-        .contextMenu {
-            Button {
-                editingSessionID = session.id
-            } label: {
-                Label("Rename", systemImage: "pencil")
-            }
-            Button(role: .destructive) {
-                sessionToDelete = session
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
-            .disabled(isDeleting)
-        }
+        .padding(.vertical, 2)
         .onChange(of: editingSessionID) { _, newValue in
             if newValue == session.id {
                 editingName = session.name
@@ -563,30 +484,6 @@ struct ManagerChip: View {
         editingSessionID = nil
     }
 }
-
-#if DEBUG
-#Preview("Manager Chips — Flow") {
-    let appState = AppState()
-    let managers = [
-        Session(name: "infra-manager", kind: .manager),
-        Session(name: "docs", kind: .manager),
-        Session(name: "release-train-orchestrator", kind: .manager),
-        Session(name: "api", kind: .manager),
-        Session(name: "ui", kind: .manager),
-    ]
-    appState.sessions = managers
-    appState.selectedSessionID = managers[1].id
-    return ManagerChipsFlow(
-        sessions: managers,
-        appState: appState,
-        editingSessionID: .constant(nil),
-        sessionToDelete: .constant(nil)
-    )
-    .padding()
-    .frame(width: 260)
-    .background(CorveilTheme.bgDeep)
-}
-#endif
 
 // MARK: - Session Row
 


### PR DESCRIPTION
Closes #389

Completes the consolidated navigation + Manager session-list end state described in #389.

## Context

Most of #389's end state already landed on `main` via **#387** (Changes-feature removal: no `SummaryBoardView`/`summaryBoardSessionID`/`summaryRepos`/RPC/CLI remain; "Allow list" → "Allowlist" rename; Reviews/Allowlist/Manager merged onto one row). This PR finishes the two remaining deltas to reach the intended final state.

This PR also resolves the superseded **#384**, **#385**, and **#388** (folded into #389).

## Changes

- **Nav order** — reorder the consolidated sidebar row to **Reviews → Allowlist → Manager** (Manager last), keeping the "+" new-Manager button adjacent to Manager. (`ReviewBoardView.swift`)
- **Manager boxes, one per row** — revert the #384/#386 "denser" wrapping-chips experiment. Extra (non-primary) Manager sessions render again as full-width boxes, one per row, restoring the pre-consolidation `ManagerSessionRow` card. This also restores **arrow-key List selection** over each Manager, inline rename, and the Rename/Delete context menu. Removed the now-unused `FlowLayout`, `ManagerChipsFlow`, `ManagerChip`, and chips `#Preview`. (`SessionListView.swift`)

The primary Manager (`00000000-…`) keeps its dedicated button and stays filtered out of the extra-Managers list. Unrelated PR-review-status logic (`changesRequested`, `addressChanges`) is untouched.

## Acceptance criteria

- [x] No "Changes" entry/view; dead code removed (already via #387; unrelated git-diff logic untouched)
- [x] Top-level nav order is Reviews → Allowlist → Manager on one row
- [x] Label reads "Allowlist" (one word) everywhere (already via #387)
- [x] Nav button styling matches the single-row layout
- [x] Manager sessions display as boxes, one per row (not pills/dense)
- [x] App builds (`swift build` CrowUI) and existing tests pass (31 CrowUI tests)

## Testing

- `swift build --package-path Packages/CrowUI` — clean.
- `arch -arm64 swift test --package-path Packages/CrowUI` — all 31 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)