### PR TITLE
setup.sh: stop hardcoding origin/main as base ref

### DIFF
--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -234,6 +234,16 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}
 gh api repos/{owner}/{repo}/issues/{pr_number}/comments
 ```
 
+**Also detect the repo's default branch** so the worktree base ref and the prompt template's PR/MR commands aren't pinned to `main` (issue #397). One clean call per repo:
+
+```bash
+gh repo view {owner}/{repo} --json defaultBranchRef --jq .defaultBranchRef.name
+# GitLab equivalent:
+glab repo view {org}/{repo} -F json | jq -r .default_branch
+```
+
+Store the result as `{base_branch}` for substitution into Step 2 and into the prompt template. `setup.sh` will auto-detect from `origin/HEAD` if you omit the flag, but passing it explicitly avoids the round-trip and keeps the prompt template accurate.
+
 Render the fetched content into the prompt template per the formatting rules in **First Prompt Template** below.
 
 #### Step 1: Write the prompt file
@@ -258,6 +268,7 @@ PROMPT
   --slug "{slug}" \
   --branch "{branch}" \
   --worktree-path "{worktree_path}" \
+  --base-branch "{base_branch}" \
   --session-name "{session_name}" \
   --provider "{provider}" \
   --cli "{cli}" \
@@ -313,6 +324,8 @@ For cross-workspace setups with multiple repos, call `setup.sh` once per repo:
 1. **First repo** (primary): Use `--primary` flag. Capture `session_id` from output.
 2. **Additional repos**: Pass `--session-id {uuid}` from the first call's output and use `--skip-launch` (Claude only launches once, in the primary worktree).
 
+Detect each secondary repo's default branch with the same `gh repo view --json defaultBranchRef` call from Step 0 — each repo has its own (bigbang uses `master`, others use `main`).
+
 ```bash
 # Secondary repo (no launch, attach to existing session):
 .claude/skills/crow-workspace/setup.sh \
@@ -322,7 +335,8 @@ For cross-workspace setups with multiple repos, call `setup.sh` once per repo:
   --repo "{other_repo}" \
   --repo-path "{other_repo_path}" \
   --slug "{slug}" \
-  --branch "main" \
+  --branch "{other_base_branch}" \
+  --base-branch "{other_base_branch}" \
   --worktree-path "{other_repo_path}" \
   --session-name "{session_name}" \
   --provider "{provider}" \
@@ -379,7 +393,7 @@ gh api repos/{owner}/{repo}/issues/{number}/comments
 6. Open a pull request linked to the ticket:
 
 ```bash
-gh pr create --title "<summary>" --body "Closes #123" --base main
+gh pr create --title "<summary>" --body "Closes #123" --base {base_branch}
 ```
 
 ## Custom Instructions
@@ -389,7 +403,7 @@ gh pr create --title "<summary>" --body "Closes #123" --base main
 
 If the workspace config contains a non-empty `customInstructions` field, append a `## Custom Instructions` section at the end of the prompt with its contents verbatim. Omit this section entirely if the field is absent, null, or empty.
 
-For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch main` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the body/description and fall back to `gh pr create --fill` / `glab mr create --fill`.
+For GitLab tickets, substitute `glab mr create --title "<summary>" --description "Closes #{number}" --target-branch {base_branch}` on step 6 (use "merge request" instead of "pull request"). When no ticket number is available, drop the body/description and fall back to `gh pr create --fill` / `glab mr create --fill`.
 
 ### Embedding pre-fetched content
 
@@ -416,7 +430,7 @@ If the pre-fetch fails (network, auth, rate limit), fall back to the prior behav
 
 ---
 
-This workspace is checked out on the PR's branch. Review existing changes with `git log origin/main..HEAD` before adding new work.
+This workspace is checked out on the PR's branch. Review existing changes with `git log origin/{base_branch}..HEAD` before adding new work.
 
 If you need fresher PR data later, re-fetch with (dangerouslyDisableSandbox: true):
 
@@ -432,7 +446,7 @@ And update the Instructions section to:
 
 ~~~markdown
 ## Instructions
-1. Review the existing PR and ticket above — both have been pre-fetched and embedded. Use `git log origin/main..HEAD` to see the current branch's changes. Only re-run gh/glab if you need fresher data; those calls use dangerouslyDisableSandbox: true and will prompt for approval.
+1. Review the existing PR and ticket above — both have been pre-fetched and embedded. Use `git log origin/{base_branch}..HEAD` to see the current branch's changes. Only re-run gh/glab if you need fresher data; those calls use dangerouslyDisableSandbox: true and will prompt for approval.
 2. Create an implementation plan that builds on the existing work
 3. Implement the plan
 4. Commit the changes with a descriptive message

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -39,6 +39,7 @@ PRIMARY=false
 SKIP_LAUNCH=false
 SKIP_ASSIGN=false
 SKIP_PROJECT_STATUS=false
+BASE_BRANCH=""
 
 # Runtime state
 TERMINAL_ID=""
@@ -129,6 +130,7 @@ Optional:
   --prompt-content <path>    Path to LLM-written prompt file
   --claude-binary <path>     Full path to claude binary
   --session-id <uuid>        Existing session ID (for secondary repos)
+  --base-branch <branch>     Default base branch (auto-detected from origin/HEAD if omitted)
   --primary                  Mark worktree as primary
   --skip-launch              Skip Claude Code launch
   --skip-assign              Skip auto-assign
@@ -161,6 +163,7 @@ parse_args() {
       --prompt-content)    PROMPT_CONTENT="$2"; shift 2 ;;
       --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
       --session-id)        SESSION_ID="$2"; shift 2 ;;
+      --base-branch)       BASE_BRANCH="$2"; shift 2 ;;
       --primary)           PRIMARY=true; shift ;;
       --skip-launch)       SKIP_LAUNCH=true; shift ;;
       --skip-assign)       SKIP_ASSIGN=true; shift ;;
@@ -201,16 +204,42 @@ preflight() {
 
 # ─── Git Worktree ────────────────────────────────────────────────────────────
 
+# Resolve BASE_BRANCH: explicit --base-branch flag wins, otherwise probe
+# origin/HEAD locally (set by `git clone` for most repos), otherwise ask the
+# remote, otherwise warn loudly and fall back to "main".
+resolve_base_branch() {
+  if [[ -n "$BASE_BRANCH" ]]; then
+    log "Using base branch from --base-branch: $BASE_BRANCH"
+    return
+  fi
+  local detected
+  detected=$(git -C "$REPO_PATH" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || true
+  detected="${detected#origin/}"
+  if [[ -z "$detected" ]]; then
+    detected=$(git -C "$REPO_PATH" ls-remote --symref origin HEAD 2>/dev/null \
+      | awk '/^ref:/ { sub("refs/heads/", "", $2); print $2; exit }') || true
+  fi
+  if [[ -n "$detected" ]]; then
+    BASE_BRANCH="$detected"
+    log "Auto-detected base branch from origin/HEAD: $BASE_BRANCH"
+  else
+    BASE_BRANCH="main"
+    log "WARNING: could not detect default branch for $REPO_PATH; falling back to 'main'"
+  fi
+}
+
 setup_worktree() {
   log "Fetching origin..."
   if ! git -C "$REPO_PATH" fetch origin >&2 2>&1; then
     die "git_fetch" "git fetch origin failed"
   fi
 
+  resolve_base_branch
+
   # Determine which branch and tracking mode to use
   local use_branch="$BRANCH"
   local track_flag="--no-track"
-  local base_ref="origin/main"
+  local base_ref="origin/$BASE_BRANCH"
 
   if [[ -n "$PR_BRANCH" ]]; then
     # PR branch: track the remote PR branch
@@ -227,7 +256,7 @@ setup_worktree() {
       base_ref="origin/$BRANCH"
       log "Branch $BRANCH exists on remote, will track"
     else
-      log "Creating new branch $BRANCH from origin/main"
+      log "Creating new branch $BRANCH from origin/$BASE_BRANCH"
     fi
   fi
 


### PR DESCRIPTION
Closes #397

## Summary

`skills/crow-workspace/setup.sh` hardcoded `origin/main` as the base ref when creating new feature-branch worktrees, so `/crow-workspace` blew up against any repo whose default branch is `master` (bigbang, securityscorecard/max-monorepo, …) with `fatal: invalid reference: origin/main`. The skill's prompt template had the same hardcode in three more places (`gh pr create --base main`, `glab mr ... --target-branch main`, two `git log origin/main..HEAD` snippets).

Two commits, in order:

1. **`setup.sh: auto-detect default branch, add --base-branch override`** — adds a `--base-branch` flag and a `resolve_base_branch` helper that probes `git symbolic-ref refs/remotes/origin/HEAD` (and `git ls-remote --symref origin HEAD` as a network fallback) after the existing `git fetch origin`. Falls back to `main` with a `[setup.sh] WARNING:` line so silent fallbacks are visible. Safe to ship on its own — the skill keeps working unchanged because auto-detect picks `main` whenever the old behavior would have.

2. **`crow-workspace: thread detected default branch through setup.sh and prompt template`** — Step 0 of the skill now also calls `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name` (and the `glab` equivalent) and stores the result as `{base_branch}`. Step 2 passes `--base-branch "{base_branch}"`. The multi-repo flow does the same per repo. Prompt template's `gh pr create`, `glab mr create`, and both `git log` snippets now substitute `{base_branch}`.

## Test plan

Not run end-to-end against external repos in this PR — but the helper logic was unit-tested inline against this worktree's `git`:

| Scenario | `--base-branch` passed? | `origin/HEAD` set? | Resolved `base_ref` | Log line |
|---|---|---|---|---|
| Repo defaults to `main` | no | yes → `main` | `origin/main` | `Auto-detected base branch from origin/HEAD: main` ✅ |
| Repo defaults to `master` (bigbang, max-monorepo) | no | yes → `master` | `origin/master` | `Auto-detected base branch from origin/HEAD: master` |
| Operator override on a `main` repo | yes (`master`) | (skipped) | `origin/master` | `Using base branch from --base-branch: master` ✅ |
| Clone with no `origin/HEAD` and no network | no | no → ls-remote also fails | `origin/main` | `WARNING: could not detect default branch for /tmp; falling back to 'main'` ✅ |

`bash setup.sh --help` confirms the new flag is documented.

## Follow-up

Once this lands, the first line under "Known Issues / Corrections" in `~/Dev/.claude/CLAUDE.md` (`bigbang's default branch is master, not main…`) can be retired — `setup.sh` now handles that natively. The adjacent `alwaysInclude`/`--skip-launch` line about reusing an existing clone is unrelated and should stay.