### PR TITLE
Surface attention indicator on manager sessions

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/AttentionDot.swift
+++ b/Packages/CrowUI/Sources/CrowUI/AttentionDot.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// 8pt solid dot with a softer scaled-stroke halo. Used in the sidebar to
+/// flag rows that need user attention (orange) or are actively working (green).
+struct AttentionDot: View {
+    let color: Color
+    let accessibilityLabel: String
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+            .overlay(
+                Circle()
+                    .stroke(color.opacity(0.4), lineWidth: 2)
+                    .scaleEffect(1.6)
+            )
+            .accessibilityLabel(accessibilityLabel)
+    }
+}

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -361,13 +361,50 @@ public struct ManagerReviewsAllowListRow: View {
         .padding(.vertical, 2)
     }
 
+    private var managerNeedsAttention: Bool {
+        appState.hookState(for: AppState.managerSessionID).pendingNotification != nil
+    }
+
     private var managerButton: some View {
-        sidebarButton(
-            title: "Manager",
-            isActive: appState.selectedSessionID == AppState.managerSessionID
-        ) {
+        let isActive = appState.selectedSessionID == AppState.managerSessionID
+        let needsAttention = managerNeedsAttention
+        return Button {
             appState.selectedSessionID = AppState.managerSessionID
+        } label: {
+            HStack(spacing: 4) {
+                if needsAttention {
+                    Circle()
+                        .fill(.orange)
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .stroke(.orange.opacity(0.4), lineWidth: 2)
+                                .scaleEffect(1.6)
+                        )
+                        .accessibilityLabel("Needs attention")
+                }
+                Text("Manager")
+                    .font(.system(size: 12, weight: .bold))
+            }
+            .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(needsAttention ? Color.orange.opacity(0.12) : (isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(
+                                needsAttention
+                                    ? Color.orange.opacity(0.4)
+                                    : (isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3)),
+                                lineWidth: 1
+                            )
+                    )
+            )
+            .animation(.easeInOut(duration: 0.2), value: needsAttention)
         }
+        .buttonStyle(.plain)
         .overlay(alignment: .topTrailing) {
             if appState.isRemoteControlActive(sessionID: AppState.managerSessionID) {
                 RemoteControlBadge(compact: true)

--- a/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/ReviewBoardView.swift
@@ -366,45 +366,16 @@ public struct ManagerReviewsAllowListRow: View {
     }
 
     private var managerButton: some View {
-        let isActive = appState.selectedSessionID == AppState.managerSessionID
-        let needsAttention = managerNeedsAttention
-        return Button {
+        sidebarButton(
+            title: "Manager",
+            isActive: appState.selectedSessionID == AppState.managerSessionID,
+            needsAttention: managerNeedsAttention,
+            leading: managerNeedsAttention
+                ? AnyView(AttentionDot(color: Color.orange, accessibilityLabel: "Needs attention"))
+                : nil
+        ) {
             appState.selectedSessionID = AppState.managerSessionID
-        } label: {
-            HStack(spacing: 4) {
-                if needsAttention {
-                    Circle()
-                        .fill(.orange)
-                        .frame(width: 8, height: 8)
-                        .overlay(
-                            Circle()
-                                .stroke(.orange.opacity(0.4), lineWidth: 2)
-                                .scaleEffect(1.6)
-                        )
-                        .accessibilityLabel("Needs attention")
-                }
-                Text("Manager")
-                    .font(.system(size: 12, weight: .bold))
-            }
-            .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(needsAttention ? Color.orange.opacity(0.12) : (isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .strokeBorder(
-                                needsAttention
-                                    ? Color.orange.opacity(0.4)
-                                    : (isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3)),
-                                lineWidth: 1
-                            )
-                    )
-            )
-            .animation(.easeInOut(duration: 0.2), value: needsAttention)
         }
-        .buttonStyle(.plain)
         .overlay(alignment: .topTrailing) {
             if appState.isRemoteControlActive(sessionID: AppState.managerSessionID) {
                 RemoteControlBadge(compact: true)
@@ -437,24 +408,42 @@ public struct ManagerReviewsAllowListRow: View {
     }
 
     /// Shared full-width pill styling for the toggle buttons in this row.
-    private func sidebarButton(title: String, isActive: Bool, action: @escaping () -> Void) -> some View {
+    /// Supports an optional leading view (e.g. an attention dot) and an
+    /// attention-flag that swaps the fill/border to the orange palette.
+    private func sidebarButton(
+        title: String,
+        isActive: Bool,
+        needsAttention: Bool = false,
+        leading: AnyView? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
-            Text(title)
-                .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6)
-                                .strokeBorder(
-                                    isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
-                                    lineWidth: 1
-                                )
-                        )
-                )
+            HStack(spacing: 4) {
+                if let leading {
+                    leading
+                }
+                Text(title)
+                    .font(.system(size: 12, weight: .bold))
+            }
+            .foregroundStyle(isActive ? CorveilTheme.gold : CorveilTheme.goldDark)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(needsAttention
+                        ? Color.orange.opacity(0.12)
+                        : (isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(
+                                needsAttention
+                                    ? Color.orange.opacity(0.4)
+                                    : (isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3)),
+                                lineWidth: 1
+                            )
+                    )
+            )
+            .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: needsAttention)
         }
         .buttonStyle(.plain)
     }

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -416,12 +416,40 @@ struct ManagerSessionRow: View {
     private var isActive: Bool { appState.selectedSessionID == session.id }
     private var isDeleting: Bool { appState.isDeletingSession[session.id] == true }
     private var isEditingThis: Bool { editingSessionID == session.id }
+    private var needsAttention: Bool {
+        appState.hookState(for: session.id).pendingNotification != nil
+    }
+
+    private var backgroundFill: Color {
+        if needsAttention {
+            return Color.orange.opacity(0.12)
+        }
+        return isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface
+    }
+
+    private var borderStroke: Color {
+        if needsAttention {
+            return Color.orange.opacity(0.4)
+        }
+        return isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3)
+    }
 
     var body: some View {
         Button {
             appState.selectedSessionID = session.id
         } label: {
             HStack(spacing: 6) {
+                if needsAttention {
+                    Circle()
+                        .fill(.orange)
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .stroke(.orange.opacity(0.4), lineWidth: 2)
+                                .scaleEffect(1.6)
+                        )
+                        .accessibilityLabel("Needs attention")
+                }
                 Image(systemName: "person.2.fill")
                     .font(.system(size: 11))
                 if isEditingThis {
@@ -450,15 +478,13 @@ struct ManagerSessionRow: View {
             .padding(.vertical, 8)
             .background(
                 RoundedRectangle(cornerRadius: 6)
-                    .fill(isActive ? CorveilTheme.bgCard : CorveilTheme.bgSurface)
+                    .fill(backgroundFill)
                     .overlay(
                         RoundedRectangle(cornerRadius: 6)
-                            .strokeBorder(
-                                isActive ? CorveilTheme.goldDark.opacity(0.6) : CorveilTheme.goldDark.opacity(0.3),
-                                lineWidth: 1
-                            )
+                            .strokeBorder(borderStroke, lineWidth: 1)
                     )
             )
+            .animation(.easeInOut(duration: 0.2), value: needsAttention)
             .overlay(alignment: .topTrailing) {
                 if appState.isRemoteControlActive(sessionID: session.id) {
                     RemoteControlBadge(compact: true)

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -440,15 +440,7 @@ struct ManagerSessionRow: View {
         } label: {
             HStack(spacing: 6) {
                 if needsAttention {
-                    Circle()
-                        .fill(.orange)
-                        .frame(width: 8, height: 8)
-                        .overlay(
-                            Circle()
-                                .stroke(.orange.opacity(0.4), lineWidth: 2)
-                                .scaleEffect(1.6)
-                        )
-                        .accessibilityLabel("Needs attention")
+                    AttentionDot(color: Color.orange, accessibilityLabel: "Needs attention")
                 }
                 Image(systemName: "person.2.fill")
                     .font(.system(size: 11))
@@ -484,7 +476,7 @@ struct ManagerSessionRow: View {
                             .strokeBorder(borderStroke, lineWidth: 1)
                     )
             )
-            .animation(.easeInOut(duration: 0.2), value: needsAttention)
+            .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: needsAttention)
             .overlay(alignment: .topTrailing) {
                 if appState.isRemoteControlActive(sessionID: session.id) {
                     RemoteControlBadge(compact: true)
@@ -706,25 +698,9 @@ struct SessionRow: View {
                     .accessibilityLabel("Shell ready")
             case .claudeLaunched:
                 if needsAttention {
-                    Circle()
-                        .fill(.orange)
-                        .frame(width: 8, height: 8)
-                        .overlay(
-                            Circle()
-                                .stroke(.orange.opacity(0.4), lineWidth: 2)
-                                .scaleEffect(1.6)
-                        )
-                        .accessibilityLabel("Needs attention")
+                    AttentionDot(color: Color.orange, accessibilityLabel: "Needs attention")
                 } else if claudeState == .working {
-                    Circle()
-                        .fill(.green)
-                        .frame(width: 8, height: 8)
-                        .overlay(
-                            Circle()
-                                .stroke(.green.opacity(0.4), lineWidth: 2)
-                                .scaleEffect(1.6)
-                        )
-                        .accessibilityLabel("Claude working")
+                    AttentionDot(color: Color.green, accessibilityLabel: "Claude working")
                 } else {
                     // done or idle — solid green
                     Circle()


### PR DESCRIPTION
## Summary
- Manager sessions now show the same orange tint + pulsing dot used on workspace rows whenever Claude is waiting on a permission prompt or an `AskUserQuestion` hook event.
- Applied to both the primary "Manager" pill in `ManagerReviewsAllowListRow` (`ReviewBoardView.swift`) and each extra `ManagerSessionRow` for additional manager sessions (`SessionListView.swift`).
- No model, AppState, or AppDelegate changes — `appState.hookState(for:).pendingNotification` was already populated for any session UUID including `AppState.managerSessionID`. This wires that existing signal into the two manager surfaces.

## Test plan
- [ ] Launch Crow with the primary Manager session running.
- [ ] In the Manager terminal, run a command that triggers a permission prompt — the "Manager" pill in the sidebar should turn orange with a pulsing dot.
- [ ] Approve/deny the prompt; the indicator should clear.
- [ ] Click the `+` next to "Manager" to create an extra manager session. Trigger a prompt in that session and confirm its `ManagerSessionRow` turns orange with a pulsing dot.
- [ ] Confirm Reviews count badge, Allowlist pill, and remote-control badge overlay render unchanged.
- [ ] VoiceOver announces "Needs attention" on the new dot.

Closes #399