### PR TITLE
Extract TaskBackend + CodeBackend protocols (#410)

### DIFF
--- a/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
+++ b/Packages/CrowClaude/Sources/CrowClaude/ClaudeLauncher.swift
@@ -43,7 +43,7 @@ public actor ClaudeLauncher {
                 lines.append("```bash")
                 lines.append("glab issue view \(url) --comments")
                 lines.append("```")
-            case nil:
+            case .corveil, nil:
                 lines.append("URL: \(url)")
             }
         }
@@ -108,7 +108,7 @@ public actor ClaudeLauncher {
                 lines.append("glab mr create --fill --target-branch main")
             }
             lines.append("```")
-        case nil:
+        case .corveil, nil:
             lines.append("6. Open a pull request\(suffix)")
         }
     }

--- a/Packages/CrowCodex/Sources/CrowCodex/CodexLauncher.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/CodexLauncher.swift
@@ -47,7 +47,7 @@ public actor CodexLauncher {
                 lines.append("```bash")
                 lines.append("glab issue view \(url) --comments")
                 lines.append("```")
-            case nil:
+            case .corveil, nil:
                 lines.append("URL: \(url)")
             }
         }

--- a/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Enums.swift
@@ -22,6 +22,7 @@ public enum SessionStatus: String, Codable, Sendable {
 public enum Provider: String, Codable, Sendable {
     case github
     case gitlab
+    case corveil
 }
 
 /// Type of link associated with a session.

--- a/Packages/CrowCore/Sources/CrowCore/ShellRunner.swift
+++ b/Packages/CrowCore/Sources/CrowCore/ShellRunner.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Runs subprocesses on behalf of provider backends.
+///
+/// Provider backends (`GitHubTaskBackend`, `GitLabCodeBackend`, …) take a `ShellRunner`
+/// at init so unit tests can inject a fake that returns canned JSON and asserts the
+/// command vector. The production implementation is `ProcessShellRunner`, which uses
+/// `Process()` with the resolved PATH from `ShellEnvironment.shared`.
+///
+/// See ADR 0005 — TaskBackend and CodeBackend protocols.
+public protocol ShellRunner: Sendable {
+    /// Run a subprocess and return its stdout (and stderr — they're merged).
+    ///
+    /// - Parameters:
+    ///   - args: Command and arguments, e.g. `["gh", "issue", "view", url]`.
+    ///   - env: Additional environment variables merged on top of `ShellEnvironment.shared.env`.
+    ///   - cwd: Working directory. Pass `nil` to inherit the current process's cwd.
+    /// - Returns: stdout+stderr as a UTF-8 string.
+    /// - Throws: `ShellRunnerError.nonZeroExit` if the process returns non-zero.
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String
+}
+
+extension ShellRunner {
+    /// Variadic convenience: `try await runner.run("gh", "issue", "view", url)`.
+    public func run(_ args: String...) async throws -> String {
+        try await run(args: args, env: [:], cwd: nil)
+    }
+
+    /// Convenience for the common case of `env` only.
+    public func run(env: [String: String], _ args: String...) async throws -> String {
+        try await run(args: args, env: env, cwd: nil)
+    }
+}
+
+public enum ShellRunnerError: Error, Sendable {
+    /// Process exited non-zero. `output` is the merged stdout+stderr.
+    case nonZeroExit(exitCode: Int32, output: String)
+}
+
+/// Default production implementation: spawns `/usr/bin/env <args>` with
+/// `ShellEnvironment.shared` merged in, captures stdout+stderr.
+public struct ProcessShellRunner: ShellRunner {
+    public init() {}
+
+    public func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = args
+        process.environment = env.isEmpty
+            ? ShellEnvironment.shared.env
+            : ShellEnvironment.shared.merging(env)
+        if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        // Drain the pipe on a background task so a >64KB output can't deadlock waitUntilExit.
+        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<String, Error>) in
+            Task.detached {
+                do {
+                    try process.run()
+                } catch {
+                    cont.resume(throwing: error)
+                    return
+                }
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                let output = String(data: data, encoding: .utf8) ?? ""
+                if process.terminationStatus == 0 {
+                    cont.resume(returning: output)
+                } else {
+                    cont.resume(throwing: ShellRunnerError.nonZeroExit(
+                        exitCode: process.terminationStatus,
+                        output: output
+                    ))
+                }
+            }
+        }
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -1,0 +1,56 @@
+import Foundation
+import CrowCore
+
+/// `CodeBackend` implementation for GitHub. Wraps the `gh` CLI for PR/label operations.
+///
+/// Capabilities:
+/// - `.autoMergeLabel` — supports `gh label create crow:merge`.
+/// - `.batchedPRStates` — could fetch multiple PR states in one GraphQL call.
+///
+/// See ADR 0005 for the protocol contract.
+public struct GitHubCodeBackend: CodeBackend {
+    public let provider: Provider = .github
+    public let capabilities: Set<CodeCapability> = [.autoMergeLabel, .batchedPRStates]
+
+    private let shellRunner: ShellRunner
+
+    public init(shellRunner: ShellRunner) {
+        self.shellRunner = shellRunner
+    }
+
+    public func linkedPR(repo: String, branch: String) async throws -> LinkedPR? {
+        let output = try await shellRunner.run(
+            "gh", "pr", "list",
+            "--repo", repo,
+            "--head", branch,
+            "--state", "all",
+            "--json", "number,url,state",
+            "--limit", "1"
+        )
+        guard let data = output.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let first = arr.first,
+              let number = first["number"] as? Int,
+              let url = first["url"] as? String,
+              let state = first["state"] as? String else {
+            return nil
+        }
+        return LinkedPR(number: number, url: url, state: state)
+    }
+
+    public func ensureMergeLabel(repo: String) async throws {
+        // `gh label create` is idempotent-ish: it errors if the label already
+        // exists. Swallow that one error; surface anything else.
+        do {
+            _ = try await shellRunner.run(
+                "gh", "label", "create", "crow:merge",
+                "--repo", repo,
+                "--color", "1D76DB",
+                "--description", "Auto-merge when checks pass"
+            )
+        } catch ShellRunnerError.nonZeroExit(_, let output) {
+            if output.localizedCaseInsensitiveContains("already exists") { return }
+            throw ShellRunnerError.nonZeroExit(exitCode: 1, output: output)
+        }
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -40,7 +40,8 @@ public struct GitHubCodeBackend: CodeBackend {
 
     public func ensureMergeLabel(repo: String) async throws {
         // `gh label create` is idempotent-ish: it errors if the label already
-        // exists. Swallow that one error; surface anything else.
+        // exists. Swallow that one error; surface anything else with the
+        // original exit code intact.
         do {
             _ = try await shellRunner.run(
                 "gh", "label", "create", "crow:merge",
@@ -48,9 +49,8 @@ public struct GitHubCodeBackend: CodeBackend {
                 "--color", "1D76DB",
                 "--description", "Auto-merge when checks pass"
             )
-        } catch ShellRunnerError.nonZeroExit(_, let output) {
-            if output.localizedCaseInsensitiveContains("already exists") { return }
-            throw ShellRunnerError.nonZeroExit(exitCode: 1, output: output)
+        } catch ShellRunnerError.nonZeroExit(_, let output) where output.localizedCaseInsensitiveContains("already exists") {
+            return
         }
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -1,0 +1,82 @@
+import Foundation
+import CrowCore
+
+/// `TaskBackend` implementation for GitHub. Wraps the `gh` CLI.
+///
+/// Capabilities declared:
+/// - `.projectBoardStatus` — supports GitHub Projects v2 status mutation.
+/// - `.batchedQuery` — `listAssigned`-style fetches use one GraphQL call.
+///
+/// See ADR 0005 for the protocol contract and ADR 0005's Context section for why
+/// task ops are separate from code ops.
+public struct GitHubTaskBackend: TaskBackend {
+    public let provider: Provider = .github
+    public let capabilities: Set<TaskCapability> = [.projectBoardStatus, .batchedQuery]
+
+    private let shellRunner: ShellRunner
+
+    public init(shellRunner: ShellRunner) {
+        self.shellRunner = shellRunner
+    }
+
+    // MARK: - TaskBackend
+
+    public func fetchTask(url: String) async throws -> TicketInfo {
+        guard let parsed = ProviderManager.parseTicketURLComponents(url) else {
+            throw ProviderError.invalidURL(url)
+        }
+        // fetchTask is issue-only by contract; if the URL is a PR the caller
+        // should be using CodeBackend. Reject here rather than silently fetching
+        // a PR — the asymmetry would invite latent bugs.
+        if parsed.isMR {
+            throw ProviderError.invalidURL("fetchTask received a pull request URL: \(url)")
+        }
+        let output = try await shellRunner.run("gh", "issue", "view", url, "--json", "title,body,labels")
+        let title = Self.extractTitle(from: output) ?? "Ticket #\(parsed.number)"
+        return TicketInfo(
+            number: parsed.number,
+            title: title,
+            repo: parsed.repo,
+            org: parsed.org,
+            url: url,
+            provider: .github,
+            isMR: false
+        )
+    }
+
+    public func setLabels(url: String, add: [String], remove: [String]) async throws {
+        guard !add.isEmpty || !remove.isEmpty else { return }
+        var args: [String] = ["gh", "issue", "edit", url]
+        for label in add {
+            args.append("--add-label")
+            args.append(label)
+        }
+        for label in remove {
+            args.append("--remove-label")
+            args.append(label)
+        }
+        _ = try await shellRunner.run(args: args, env: [:], cwd: nil)
+    }
+
+    public func setTaskStatus(url: String, status: TicketStatus) async throws {
+        // Real implementation requires the GraphQL project-item lookup + mutation
+        // sequence currently inlined at IssueTracker.swift:2539. That migration is
+        // deferred to a follow-up PR — see ADR 0005 references.
+        // The capability is declared so callers don't fall into the throw path
+        // before the migration lands.
+        throw ProviderError.unimplemented(
+            "GitHubTaskBackend.setTaskStatus: migration of markInReview project-board mutation pending"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func extractTitle(from output: String) -> String? {
+        if let data = output.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let title = json["title"] as? String {
+            return title
+        }
+        return output.components(separatedBy: .newlines).first
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -4,14 +4,19 @@ import CrowCore
 /// `TaskBackend` implementation for GitHub. Wraps the `gh` CLI.
 ///
 /// Capabilities declared:
-/// - `.projectBoardStatus` — supports GitHub Projects v2 status mutation.
 /// - `.batchedQuery` — `listAssigned`-style fetches use one GraphQL call.
+///
+/// Note: `.projectBoardStatus` is intentionally *not* declared until the
+/// `markInReview` GraphQL migration lands (see `setTaskStatus` below and
+/// IssueTracker.swift:2539). The flag is contract: declaring it means a
+/// capability-gated caller can call `setTaskStatus` and expect success.
+/// We add the flag when the implementation arrives, not before.
 ///
 /// See ADR 0005 for the protocol contract and ADR 0005's Context section for why
 /// task ops are separate from code ops.
 public struct GitHubTaskBackend: TaskBackend {
     public let provider: Provider = .github
-    public let capabilities: Set<TaskCapability> = [.projectBoardStatus, .batchedQuery]
+    public let capabilities: Set<TaskCapability> = [.batchedQuery]
 
     private let shellRunner: ShellRunner
 

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
@@ -1,0 +1,59 @@
+import Foundation
+import CrowCore
+
+/// `CodeBackend` implementation for GitLab. Wraps the `glab` CLI.
+///
+/// Capabilities: none in v1. The merge-label flow at IssueTracker.swift:2037 is
+/// GitHub-specific today; once GitLab gets equivalent CI gating, declare `.autoMergeLabel`
+/// and implement `ensureMergeLabel`.
+///
+/// See ADR 0005.
+public struct GitLabCodeBackend: CodeBackend {
+    public let provider: Provider = .gitlab
+    public let capabilities: Set<CodeCapability> = []
+
+    private let shellRunner: ShellRunner
+    private let host: String?
+
+    public init(shellRunner: ShellRunner, host: String?) {
+        self.shellRunner = shellRunner
+        self.host = host
+    }
+
+    public func linkedPR(repo: String, branch: String) async throws -> LinkedPR? {
+        let env = self.env()
+        // `glab mr list` returns plain-text by default; ask for JSON via API.
+        // Pattern: list MRs whose source branch matches; pick first.
+        let output = try await shellRunner.run(
+            args: [
+                "glab", "mr", "list",
+                "--repo", repo,
+                "--source-branch", branch,
+                "--all",
+                "-F", "json"
+            ],
+            env: env,
+            cwd: NSHomeDirectory()
+        )
+        guard let data = output.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let first = arr.first,
+              let iid = first["iid"] as? Int else {
+            return nil
+        }
+        let webURL = (first["web_url"] as? String) ?? ""
+        let state = (first["state"] as? String) ?? ""
+        return LinkedPR(number: iid, url: webURL, state: state)
+    }
+
+    public func ensureMergeLabel(repo: String) async throws {
+        // No `.autoMergeLabel` capability declared. Capability-gated callers
+        // skip this; a direct call is a programming error.
+        throw ProviderError.unimplemented("GitLabCodeBackend.ensureMergeLabel: no autoMergeLabel capability")
+    }
+
+    private func env() -> [String: String] {
+        guard let host else { return [:] }
+        return ["GITLAB_HOST": host]
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
@@ -1,0 +1,77 @@
+import Foundation
+import CrowCore
+
+/// `TaskBackend` implementation for GitLab. Wraps the `glab` CLI.
+///
+/// Capabilities: none in v1 — GitLab issue boards aren't surfaced through Crow yet,
+/// and `glab` doesn't batch issue queries the same way `gh` does.
+///
+/// See ADR 0005.
+public struct GitLabTaskBackend: TaskBackend {
+    public let provider: Provider = .gitlab
+    public let capabilities: Set<TaskCapability> = []
+
+    private let shellRunner: ShellRunner
+    private let host: String?
+
+    public init(shellRunner: ShellRunner, host: String?) {
+        self.shellRunner = shellRunner
+        self.host = host
+    }
+
+    public func fetchTask(url: String) async throws -> TicketInfo {
+        guard let parsed = ProviderManager.parseTicketURLComponents(url) else {
+            throw ProviderError.invalidURL(url)
+        }
+        if parsed.isMR {
+            throw ProviderError.invalidURL("fetchTask received a merge request URL: \(url)")
+        }
+        let env = self.env()
+        let repoSlug = "\(parsed.org)/\(parsed.repo)"
+        let output = try await shellRunner.run(
+            args: ["glab", "issue", "view", "\(parsed.number)", "--repo", repoSlug],
+            env: env,
+            cwd: NSHomeDirectory()
+        )
+        let title = output.components(separatedBy: .newlines).first ?? "Ticket #\(parsed.number)"
+        return TicketInfo(
+            number: parsed.number,
+            title: title,
+            repo: parsed.repo,
+            org: parsed.org,
+            url: url,
+            provider: .gitlab,
+            isMR: false
+        )
+    }
+
+    public func setLabels(url: String, add: [String], remove: [String]) async throws {
+        guard !add.isEmpty || !remove.isEmpty else { return }
+        guard let parsed = ProviderManager.parseTicketURLComponents(url) else {
+            throw ProviderError.invalidURL(url)
+        }
+        let repoSlug = "\(parsed.org)/\(parsed.repo)"
+        let env = self.env()
+        var args: [String] = ["glab", "issue", "update", "\(parsed.number)", "--repo", repoSlug]
+        if !add.isEmpty {
+            args.append("--label")
+            args.append(add.joined(separator: ","))
+        }
+        if !remove.isEmpty {
+            args.append("--unlabel")
+            args.append(remove.joined(separator: ","))
+        }
+        _ = try await shellRunner.run(args: args, env: env, cwd: NSHomeDirectory())
+    }
+
+    public func setTaskStatus(url: String, status: TicketStatus) async throws {
+        // No project board support declared. Capability-gated callers won't hit this;
+        // anything that does is a programming error.
+        throw ProviderError.unimplemented("GitLabTaskBackend.setTaskStatus: no projectBoardStatus capability")
+    }
+
+    private func env() -> [String: String] {
+        guard let host else { return [:] }
+        return ["GITLAB_HOST": host]
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/StubCorveilTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/StubCorveilTaskBackend.swift
@@ -1,0 +1,29 @@
+import Foundation
+import CrowCore
+
+/// `TaskBackend` stub for Corveil — present to prove the abstraction holds for a
+/// third provider, not to ship behavior. Every method throws
+/// `ProviderError.unimplemented`. See ADR 0005.
+///
+/// Corveil has no embedded git, so there is intentionally no `StubCorveilCodeBackend`:
+/// a Corveil-tasked session pairs with a `.github` or `.gitlab` `CodeBackend`. Once a
+/// real Corveil API integration lands, this stub is replaced; a `Session.codeProvider`
+/// field (separate follow-up) lets the two halves come from different providers.
+public struct StubCorveilTaskBackend: TaskBackend {
+    public let provider: Provider = .corveil
+    public let capabilities: Set<TaskCapability> = []
+
+    public init() {}
+
+    public func fetchTask(url: String) async throws -> TicketInfo {
+        throw ProviderError.unimplemented("StubCorveilTaskBackend.fetchTask")
+    }
+
+    public func setLabels(url: String, add: [String], remove: [String]) async throws {
+        throw ProviderError.unimplemented("StubCorveilTaskBackend.setLabels")
+    }
+
+    public func setTaskStatus(url: String, status: TicketStatus) async throws {
+        throw ProviderError.unimplemented("StubCorveilTaskBackend.setTaskStatus")
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
@@ -1,0 +1,59 @@
+import Foundation
+import CrowCore
+
+/// VCS-side operations: pull requests, merge labels, branch lookups, stale-PR state.
+///
+/// `CodeBackend` is paired with a `TaskBackend` (see `TaskBackend.swift` and ADR 0005)
+/// when a session produces code. The split exists because tasks and code are
+/// independent dimensions — a Corveil task may have a GitHub PR; a non-coding
+/// task has no `CodeBackend` at all.
+///
+/// Backends are obtained from `ProviderManager` rather than instantiated directly so
+/// the factory can pin the `ShellRunner` and provider-specific host config once.
+public protocol CodeBackend: Sendable {
+    /// Which provider this backend serves.
+    var provider: Provider { get }
+
+    /// What this backend can do, beyond the protocol's required methods.
+    /// Replaces `guard session.provider == .github` style guards in call sites.
+    var capabilities: Set<CodeCapability> { get }
+
+    /// Find an existing PR/MR on `branch` in `repo` ("org/repo" slug), if one exists.
+    /// Returns the first matching PR (any state) or `nil` if none found / call fails.
+    func linkedPR(repo: String, branch: String) async throws -> LinkedPR?
+
+    /// Ensure the auto-merge label exists in `repo`.
+    /// Capability-gated: only call when `capabilities.contains(.autoMergeLabel)`.
+    /// Without the capability this is a no-op (intentional — different VCS hosts
+    /// have different label-management semantics, and a missing capability means
+    /// "this provider doesn't need the same setup step").
+    func ensureMergeLabel(repo: String) async throws
+}
+
+/// Optional capabilities a `CodeBackend` may declare.
+public enum CodeCapability: Sendable, Hashable {
+    /// Supports creating/updating an auto-merge label (`crow:merge`) on the repo.
+    /// Gates `ensureMergeLabel`.
+    case autoMergeLabel
+
+    /// Can fetch states for multiple PRs in one batched call rather than per-PR.
+    /// Informational today — used by `IssueTracker`'s stale-PR follow-up to log
+    /// which path was taken. Maintained as a capability so a future GitLab REST
+    /// API upgrade can flip this on without rewriting callers.
+    case batchedPRStates
+}
+
+/// Minimal PR/MR identity returned from `CodeBackend.linkedPR`.
+public struct LinkedPR: Sendable, Equatable {
+    public let number: Int
+    public let url: String
+    /// PR state as reported by the host (e.g. "OPEN", "MERGED", "CLOSED" for GitHub;
+    /// "opened", "merged", "closed" for GitLab). Callers normalize as needed.
+    public let state: String
+
+    public init(number: Int, url: String, state: String) {
+        self.number = number
+        self.url = url
+        self.state = state
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -2,12 +2,75 @@ import Foundation
 import CrowCore
 
 /// Detects provider from URL and fetches ticket details.
+///
+/// Also acts as a factory for ``TaskBackend`` / ``CodeBackend`` instances — call
+/// ``taskBackend(for:host:)`` or ``codeBackend(for:host:)`` to get a provider-
+/// specific backend rather than switching on `Provider` at the call site. See ADR 0005.
 public actor ProviderManager {
     /// Additional GitLab hosts beyond gitlab.com (user-configurable).
-    private let additionalGitLabHosts: [String]
+    nonisolated private let additionalGitLabHosts: [String]
 
-    public init(additionalGitLabHosts: [String] = []) {
+    /// Subprocess runner shared by all backends this manager hands out.
+    nonisolated private let shellRunner: ShellRunner
+
+    public init(additionalGitLabHosts: [String] = [], shellRunner: ShellRunner = ProcessShellRunner()) {
         self.additionalGitLabHosts = additionalGitLabHosts
+        self.shellRunner = shellRunner
+    }
+
+    // MARK: - Backend factory
+
+    /// Hand out a ``TaskBackend`` for the given provider. Use the URL-based
+    /// variant when only a ticket URL is in hand.
+    public nonisolated func taskBackend(for provider: Provider, host: String? = nil) -> TaskBackend {
+        switch provider {
+        case .github:
+            return GitHubTaskBackend(shellRunner: shellRunner)
+        case .gitlab:
+            return GitLabTaskBackend(shellRunner: shellRunner, host: host)
+        case .corveil:
+            return StubCorveilTaskBackend()
+        }
+    }
+
+    /// Hand out a ``CodeBackend`` for the given provider, or `nil` for providers
+    /// that have no VCS-side surface (Corveil). Callers must handle `nil` —
+    /// a non-coding task may legitimately have no code backend at all.
+    public nonisolated func codeBackend(for provider: Provider, host: String? = nil) -> CodeBackend? {
+        switch provider {
+        case .github:
+            return GitHubCodeBackend(shellRunner: shellRunner)
+        case .gitlab:
+            return GitLabCodeBackend(shellRunner: shellRunner, host: host)
+        case .corveil:
+            return nil
+        }
+    }
+
+    /// URL-driven `TaskBackend` lookup — detect the provider from `url` and
+    /// hand back the matching backend.
+    public nonisolated func taskBackend(forURL url: String) -> TaskBackend {
+        let detected = detectProviderNonisolated(from: url)
+        return taskBackend(for: detected.provider, host: detected.host)
+    }
+
+    /// Non-isolated variant of ``detectProvider(from:)`` — same logic, available
+    /// off-actor for use by the factory methods above. Kept in sync with the
+    /// actor-isolated variant on purpose; if you change one, change both.
+    nonisolated private func detectProviderNonisolated(from url: String) -> (provider: Provider, cli: String, host: String?) {
+        if url.contains("github.com") {
+            return (.github, "gh", nil)
+        } else if url.contains("gitlab.com") {
+            return (.gitlab, "glab", "gitlab.com")
+        } else if url.contains("corveil.io") {
+            return (.corveil, "", nil)
+        }
+        for host in additionalGitLabHosts {
+            if url.contains(host) {
+                return (.gitlab, "glab", host)
+            }
+        }
+        return (.github, "gh", nil)
     }
 
     /// Detect provider from a URL string.
@@ -19,6 +82,10 @@ public actor ProviderManager {
             return (.github, "gh", nil)
         } else if url.contains("gitlab.com") {
             return (.gitlab, "glab", "gitlab.com")
+        } else if url.contains("corveil.io") {
+            // Corveil is task-only (no embedded git, no CLI). Detected so the
+            // stub backend can be exercised end-to-end via URL. See ADR 0005.
+            return (.corveil, "", nil)
         }
         // Check user-configured GitLab hosts
         for host in additionalGitLabHosts {
@@ -95,6 +162,9 @@ public actor ProviderManager {
             } else {
                 output = try await shell(env: env, cwd: NSHomeDirectory(), "glab", "issue", "view", "\(parsed.number)", "--repo", repoSlug)
             }
+        case .corveil:
+            // Stub: real Corveil API integration arrives in a follow-up. See ADR 0005.
+            throw ProviderError.unimplemented("Corveil ticket fetching not yet implemented")
         }
 
         // Parse title from JSON output (GitHub returns JSON, GitLab returns text)
@@ -163,6 +233,9 @@ public actor ProviderManager {
                     "--jq", ".[].path_with_namespace"
                 )
                 return Self.nonEmptyLines(out)
+            case .corveil:
+                // Corveil is task-only; no repo listing is meaningful here.
+                return []
             }
         } catch {
             NSLog("[ProviderManager] listRepos failed for owner '\(owner)': \(error.localizedDescription)")
@@ -253,4 +326,7 @@ public struct TicketInfo: Sendable {
 public enum ProviderError: Error {
     case invalidURL(String)
     case commandFailed(String)
+    /// A backend method is part of the protocol but not implemented for this provider yet
+    /// (e.g. `StubCorveilTaskBackend` — every method throws this; see ADR 0005).
+    case unimplemented(String)
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -50,19 +50,21 @@ public actor ProviderManager {
     /// URL-driven `TaskBackend` lookup — detect the provider from `url` and
     /// hand back the matching backend.
     public nonisolated func taskBackend(forURL url: String) -> TaskBackend {
-        let detected = detectProviderNonisolated(from: url)
+        let detected = Self.detect(url: url, additionalGitLabHosts: additionalGitLabHosts)
         return taskBackend(for: detected.provider, host: detected.host)
     }
 
-    /// Non-isolated variant of ``detectProvider(from:)`` — same logic, available
-    /// off-actor for use by the factory methods above. Kept in sync with the
-    /// actor-isolated variant on purpose; if you change one, change both.
-    nonisolated private func detectProviderNonisolated(from url: String) -> (provider: Provider, cli: String, host: String?) {
+    /// Single source of truth for URL → provider detection. The actor-isolated
+    /// ``detectProvider(from:)`` and the nonisolated factory paths both delegate
+    /// here so the matching logic can never drift.
+    nonisolated static func detect(url: String, additionalGitLabHosts: [String]) -> (provider: Provider, cli: String, host: String?) {
         if url.contains("github.com") {
             return (.github, "gh", nil)
         } else if url.contains("gitlab.com") {
             return (.gitlab, "glab", "gitlab.com")
         } else if url.contains("corveil.io") {
+            // Corveil is task-only (no embedded git, no CLI). Detected so the
+            // stub backend can be exercised end-to-end via URL. See ADR 0005.
             return (.corveil, "", nil)
         }
         for host in additionalGitLabHosts {
@@ -78,22 +80,7 @@ public actor ProviderManager {
     /// Falls back to `.github` for unrecognized hosts — the `gh` CLI call will fail clearly
     /// if the URL is actually a self-hosted GitLab instance, which is an acceptable failure mode.
     public func detectProvider(from url: String) -> (provider: Provider, cli: String, host: String?) {
-        if url.contains("github.com") {
-            return (.github, "gh", nil)
-        } else if url.contains("gitlab.com") {
-            return (.gitlab, "glab", "gitlab.com")
-        } else if url.contains("corveil.io") {
-            // Corveil is task-only (no embedded git, no CLI). Detected so the
-            // stub backend can be exercised end-to-end via URL. See ADR 0005.
-            return (.corveil, "", nil)
-        }
-        // Check user-configured GitLab hosts
-        for host in additionalGitLabHosts {
-            if url.contains(host) {
-                return (.gitlab, "glab", host)
-            }
-        }
-        return (.github, "gh", nil)
+        Self.detect(url: url, additionalGitLabHosts: additionalGitLabHosts)
     }
 
     /// Parse issue/PR number and repo from a ticket URL.

--- a/Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift
@@ -1,0 +1,53 @@
+import Foundation
+import CrowCore
+
+/// Tracker-side operations: issues, tasks, labels, assignment, project status.
+///
+/// `TaskBackend` is paired with a `CodeBackend` (separate protocol — see ADR 0005)
+/// when a session also produces a PR. A Corveil-tasked session that delegates its
+/// PR work to GitHub will use a `StubCorveilTaskBackend` here and a `GitHubCodeBackend`
+/// there. The split exists because tasks (the unit of work) and code (the VCS artifact)
+/// are independent dimensions.
+///
+/// Backends are obtained from `ProviderManager` rather than instantiated directly so
+/// the factory can pin the `ShellRunner` and GitLab host config once.
+public protocol TaskBackend: Sendable {
+    /// Which provider this backend serves.
+    var provider: Provider { get }
+
+    /// What this backend can do, beyond the protocol's required methods.
+    /// Callers branch on capabilities to gate optional behavior (project boards,
+    /// batched queries) instead of switching on `provider`.
+    var capabilities: Set<TaskCapability> { get }
+
+    /// Fetch a single task by URL (issue, not PR — that's `CodeBackend`).
+    func fetchTask(url: String) async throws -> TicketInfo
+
+    /// Add and/or remove labels on a task by URL.
+    /// - Parameters:
+    ///   - url: Task URL.
+    ///   - add: Labels to add. Pass `[]` to skip.
+    ///   - remove: Labels to remove. Pass `[]` to skip.
+    func setLabels(url: String, add: [String], remove: [String]) async throws
+
+    /// Set the project-board status for a task.
+    /// Capability-gated: only call when `capabilities.contains(.projectBoardStatus)`.
+    /// Calling without the capability throws `ProviderError.unimplemented`.
+    func setTaskStatus(url: String, status: TicketStatus) async throws
+}
+
+/// Optional capabilities a `TaskBackend` may declare.
+///
+/// Replaces today's `guard session.provider == .github` style guards. The match
+/// becomes `if taskBackend.capabilities.contains(.projectBoardStatus)`, so adding
+/// a third provider (or extending an existing one) doesn't ripple through call sites.
+public enum TaskCapability: Sendable, Hashable {
+    /// Can set project-board status (GitHub Projects v2 today).
+    /// Gates `setTaskStatus`. Without this capability that method throws.
+    case projectBoardStatus
+
+    /// Can fulfill `listAssigned`-style queries in a single batched call rather
+    /// than per-item. Informational — callers don't branch on it today, but it
+    /// signals to maintainers that the backend has a cheaper bulk path.
+    case batchedQuery
+}

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+import CrowCore
+@testable import CrowProvider
+
+/// Records every shell invocation and returns canned outputs. Backends accept any
+/// `ShellRunner`, so tests can assert command vectors without hitting the network
+/// or spawning real `gh`/`glab` processes.
+final class FakeShellRunner: ShellRunner, @unchecked Sendable {
+    struct Call: Sendable, Equatable {
+        let args: [String]
+        let env: [String: String]
+        let cwd: String?
+    }
+    var calls: [Call] = []
+    /// Responses pulled in order. If empty, returns `""`.
+    var responses: [Result<String, Error>] = []
+
+    func run(args: [String], env: [String: String], cwd: String?) async throws -> String {
+        calls.append(Call(args: args, env: env, cwd: cwd))
+        guard !responses.isEmpty else { return "" }
+        let next = responses.removeFirst()
+        switch next {
+        case .success(let s): return s
+        case .failure(let e): throw e
+        }
+    }
+}
+
+final class BackendsTests: XCTestCase {
+    // MARK: - GitHubTaskBackend
+
+    func testGitHubTaskBackendDeclaresCapabilities() {
+        let backend = GitHubTaskBackend(shellRunner: FakeShellRunner())
+        XCTAssertEqual(backend.provider, .github)
+        XCTAssertTrue(backend.capabilities.contains(.projectBoardStatus))
+        XCTAssertTrue(backend.capabilities.contains(.batchedQuery))
+    }
+
+    func testGitHubTaskBackendFetchTaskInvokesGhIssueView() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"{"title":"Hello"}"#)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let info = try await backend.fetchTask(url: "https://github.com/acme/api/issues/42")
+        XCTAssertEqual(info.title, "Hello")
+        XCTAssertEqual(info.number, 42)
+        XCTAssertEqual(info.repo, "api")
+        XCTAssertEqual(info.org, "acme")
+        XCTAssertEqual(info.provider, .github)
+        XCTAssertFalse(info.isMR)
+        XCTAssertEqual(fake.calls.first?.args.first, "gh")
+        XCTAssertTrue(fake.calls.first?.args.contains("issue") ?? false)
+    }
+
+    func testGitHubTaskBackendRejectsPullRequestURL() async {
+        let backend = GitHubTaskBackend(shellRunner: FakeShellRunner())
+        do {
+            _ = try await backend.fetchTask(url: "https://github.com/acme/api/pull/7")
+            XCTFail("expected throw for PR URL")
+        } catch ProviderError.invalidURL {
+            // expected
+        } catch {
+            XCTFail("expected invalidURL, got \(error)")
+        }
+    }
+
+    func testGitHubTaskBackendSetLabelsAddsAndRemovesLabels() async throws {
+        let fake = FakeShellRunner()
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setLabels(
+            url: "https://github.com/acme/api/issues/42",
+            add: ["crow:auto"],
+            remove: ["wip"]
+        )
+        XCTAssertEqual(fake.calls.count, 1)
+        let args = fake.calls[0].args
+        XCTAssertEqual(args[0], "gh")
+        XCTAssertTrue(args.contains("--add-label"))
+        XCTAssertTrue(args.contains("crow:auto"))
+        XCTAssertTrue(args.contains("--remove-label"))
+        XCTAssertTrue(args.contains("wip"))
+    }
+
+    func testGitHubTaskBackendSetLabelsSkipsEmpty() async throws {
+        let fake = FakeShellRunner()
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setLabels(url: "https://github.com/acme/api/issues/1", add: [], remove: [])
+        XCTAssertTrue(fake.calls.isEmpty)
+    }
+
+    func testGitHubTaskBackendSetTaskStatusThrowsUnimplemented() async {
+        let backend = GitHubTaskBackend(shellRunner: FakeShellRunner())
+        do {
+            try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
+            XCTFail("expected throw")
+        } catch ProviderError.unimplemented {
+            // expected — see ADR 0005, migration deferred
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    // MARK: - GitHubCodeBackend
+
+    func testGitHubCodeBackendLinkedPRParsesJSON() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"[{"number":7,"url":"https://github.com/a/b/pull/7","state":"OPEN"}]"#)]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let pr = try await backend.linkedPR(repo: "a/b", branch: "feature/x")
+        XCTAssertEqual(pr?.number, 7)
+        XCTAssertEqual(pr?.state, "OPEN")
+        XCTAssertEqual(pr?.url, "https://github.com/a/b/pull/7")
+        let args = fake.calls[0].args
+        XCTAssertEqual(args[0], "gh")
+        XCTAssertTrue(args.contains("--head"))
+        XCTAssertTrue(args.contains("feature/x"))
+    }
+
+    func testGitHubCodeBackendLinkedPRReturnsNilForEmptyArray() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("[]")]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let pr = try await backend.linkedPR(repo: "a/b", branch: "main")
+        XCTAssertNil(pr)
+    }
+
+    func testGitHubCodeBackendEnsureMergeLabelSwallowsAlreadyExists() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "label crow:merge already exists"))]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        try await backend.ensureMergeLabel(repo: "a/b")
+    }
+
+    // MARK: - GitLab backends
+
+    func testGitLabTaskBackendDeclaresNoCapabilities() {
+        let backend = GitLabTaskBackend(shellRunner: FakeShellRunner(), host: nil)
+        XCTAssertEqual(backend.provider, .gitlab)
+        XCTAssertTrue(backend.capabilities.isEmpty)
+    }
+
+    func testGitLabTaskBackendFetchTaskInvokesGlab() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("Issue title")]
+        let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.internal.io")
+        let info = try await backend.fetchTask(url: "https://gitlab.internal.io/group/proj/-/issues/3")
+        XCTAssertEqual(info.title, "Issue title")
+        XCTAssertEqual(info.number, 3)
+        XCTAssertEqual(info.provider, .gitlab)
+        XCTAssertEqual(fake.calls.first?.args.first, "glab")
+        XCTAssertEqual(fake.calls.first?.env["GITLAB_HOST"], "gitlab.internal.io")
+    }
+
+    func testGitLabCodeBackendEnsureMergeLabelThrowsUnimplemented() async {
+        let backend = GitLabCodeBackend(shellRunner: FakeShellRunner(), host: nil)
+        do {
+            try await backend.ensureMergeLabel(repo: "a/b")
+            XCTFail("expected throw")
+        } catch ProviderError.unimplemented {
+            // expected — GitLab has no autoMergeLabel capability today
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    // MARK: - Stub Corveil
+
+    func testStubCorveilTaskBackendThrowsUnimplementedForEveryMethod() async {
+        let backend = StubCorveilTaskBackend()
+        XCTAssertEqual(backend.provider, .corveil)
+        XCTAssertTrue(backend.capabilities.isEmpty)
+        await XCTAssertThrowsErrorAsync(try await backend.fetchTask(url: "https://corveil.io/t/1"))
+        await XCTAssertThrowsErrorAsync(try await backend.setLabels(url: "x", add: ["a"], remove: []))
+        await XCTAssertThrowsErrorAsync(try await backend.setTaskStatus(url: "x", status: .inReview))
+    }
+
+    // MARK: - Factory
+
+    func testProviderManagerHandsOutMatchingBackends() async {
+        let mgr = ProviderManager()
+        XCTAssertEqual(mgr.taskBackend(for: .github).provider, .github)
+        XCTAssertEqual(mgr.taskBackend(for: .gitlab, host: "gitlab.com").provider, .gitlab)
+        XCTAssertEqual(mgr.taskBackend(for: .corveil).provider, .corveil)
+        XCTAssertNotNil(mgr.codeBackend(for: .github))
+        XCTAssertNotNil(mgr.codeBackend(for: .gitlab))
+        XCTAssertNil(mgr.codeBackend(for: .corveil))
+    }
+
+    func testProviderManagerTaskBackendForCorveilURL() async {
+        let mgr = ProviderManager()
+        let backend = mgr.taskBackend(forURL: "https://corveil.io/tasks/42")
+        XCTAssertEqual(backend.provider, .corveil)
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(_ expression: @autoclosure () async throws -> T,
+                                          file: StaticString = #filePath,
+                                          line: UInt = #line) async {
+    do {
+        _ = try await expression()
+        XCTFail("expected throw", file: file, line: line)
+    } catch {
+        // expected
+    }
+}

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -32,7 +32,10 @@ final class BackendsTests: XCTestCase {
     func testGitHubTaskBackendDeclaresCapabilities() {
         let backend = GitHubTaskBackend(shellRunner: FakeShellRunner())
         XCTAssertEqual(backend.provider, .github)
-        XCTAssertTrue(backend.capabilities.contains(.projectBoardStatus))
+        // .projectBoardStatus intentionally NOT declared until the markInReview
+        // GraphQL migration lands. Declaring it while setTaskStatus throws would
+        // lie to capability-gated callers. See ADR 0005.
+        XCTAssertFalse(backend.capabilities.contains(.projectBoardStatus))
         XCTAssertTrue(backend.capabilities.contains(.batchedQuery))
     }
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -428,7 +428,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.defaultAgentKind = config.defaultAgentKind
 
         // Create session service and hydrate state
-        let service = SessionService(store: store, appState: appState, telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil)
+        let service = SessionService(store: store, appState: appState, telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil, providerManager: providerManager)
         service.hydrateState()
         self.sessionService = service
         NSLog("[Crow] Session state hydrated (%d sessions)", appState.sessions.count)

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -512,6 +512,11 @@ final class IssueTracker {
                     "--unlabel", Self.autoCreateLabel
                 ]
             )
+        case .corveil:
+            // Stub: Corveil label management arrives with a real CorveilTaskBackend.
+            // See ADR 0005. listAssigned() returns no Corveil issues today, so this
+            // branch is defensive only.
+            return
         }
         if result.exitCode != 0 {
             let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -4,6 +4,7 @@ import CrowClaude
 import CrowCore
 import CrowGit
 import CrowPersistence
+import CrowProvider
 import CrowTerminal
 
 /// Simplified session service — CRUD only. Orchestration moved to Claude Code via crow CLI.
@@ -12,11 +13,15 @@ final class SessionService {
     private let store: JSONStore
     private let appState: AppState
     let telemetryPort: UInt16?
+    /// Backend factory for ticket/PR lookups during recovery. Optional so unit-tests
+    /// that don't exercise recovery paths needn't construct one. See ADR 0005.
+    private let providerManager: ProviderManager?
 
-    init(store: JSONStore, appState: AppState, telemetryPort: UInt16? = nil) {
+    init(store: JSONStore, appState: AppState, telemetryPort: UInt16? = nil, providerManager: ProviderManager? = nil) {
         self.store = store
         self.appState = appState
         self.telemetryPort = telemetryPort
+        self.providerManager = providerManager
     }
 
     /// Upgrade the well-known primary Manager session from `.work` (how it was
@@ -1119,9 +1124,15 @@ final class SessionService {
             }
         }
 
-        // Try to fetch issue title
+        // Try to fetch issue title — prefer the TaskBackend abstraction (ADR 0005)
+        // when a manager is wired; fall back to inline `gh` for older call paths.
         if let issueURL = info.url {
-            if let output = try? await shell("gh", "issue", "view", issueURL, "--json", "title"),
+            if let manager = providerManager {
+                let backend = manager.taskBackend(forURL: issueURL)
+                if let ticket = try? await backend.fetchTask(url: issueURL) {
+                    info.title = ticket.title
+                }
+            } else if let output = try? await shell("gh", "issue", "view", issueURL, "--json", "title"),
                let data = output.data(using: .utf8),
                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let title = json["title"] as? String {
@@ -1135,6 +1146,14 @@ final class SessionService {
     /// Check for a pull request on a branch and return a link if found.
     private func findPRLink(branch: String, repoPath: String, sessionID: UUID) async -> SessionLink? {
         guard let repoSlug = resolveRepoSlug(repoPath: repoPath) else { return nil }
+        // Prefer CodeBackend.linkedPR (ADR 0005) when a manager is wired; fall
+        // back to the inline `gh pr list` shell-out for legacy call paths.
+        if let manager = providerManager,
+           let backend = manager.codeBackend(for: .github),
+           let pr = try? await backend.linkedPR(repo: repoSlug, branch: branch) {
+            NSLog("[SessionService] Found PR #\(pr.number) for branch '\(branch)'")
+            return SessionLink(sessionID: sessionID, label: "PR #\(pr.number)", url: pr.url, linkType: .pr)
+        }
         guard let prOutput = try? await shell(
             "gh", "pr", "list", "--repo", repoSlug, "--head", branch,
             "--state", "all", "--json", "number,url,state", "--limit", "1"

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1147,10 +1147,14 @@ final class SessionService {
     private func findPRLink(branch: String, repoPath: String, sessionID: UUID) async -> SessionLink? {
         guard let repoSlug = resolveRepoSlug(repoPath: repoPath) else { return nil }
         // Prefer CodeBackend.linkedPR (ADR 0005) when a manager is wired; fall
-        // back to the inline `gh pr list` shell-out for legacy call paths.
-        if let manager = providerManager,
-           let backend = manager.codeBackend(for: .github),
-           let pr = try? await backend.linkedPR(repo: repoSlug, branch: branch) {
+        // back to the inline `gh pr list` shell-out only when no manager is
+        // available — otherwise we'd issue the identical command twice on the
+        // common "no PR exists" path.
+        if let manager = providerManager {
+            guard let backend = manager.codeBackend(for: .github),
+                  let pr = try? await backend.linkedPR(repo: repoSlug, branch: branch) else {
+                return nil
+            }
             NSLog("[SessionService] Found PR #\(pr.number) for branch '\(branch)'")
             return SessionLink(sessionID: sessionID, label: "PR #\(pr.number)", url: pr.url, linkType: .pr)
         }

--- a/docs/adr/0005-task-and-code-backend-protocols.md
+++ b/docs/adr/0005-task-and-code-backend-protocols.md
@@ -1,0 +1,89 @@
+# 0005 — TaskBackend and CodeBackend protocols
+
+- **Status:** Proposed
+- **Date:** 2026-06-03
+- **Deciders:** Crow maintainers
+
+## Context
+
+Crow integrates with two ticket/PR providers today (`gh` for GitHub, `glab` for GitLab) by shelling out from many call sites scattered across `IssueTracker.swift`, `SessionService.swift`, and `ProviderManager.swift`. An audit in [#410](https://github.com/radiusmethod/crow/issues/410) found three coexisting patterns:
+
+1. **Switch-at-callsite**: `switch provider { gh / glab }` inline (e.g. `IssueTracker.swift:493`).
+2. **Parallel implementations**: one fat GitHub function and one fat GitLab function sitting in the same file — conceptually one operation, two halves (e.g. assigned-issue fetch at `IssueTracker.swift:703` and `:2509`).
+3. **GitHub-only paths**: code gated on `session.provider == .github` that silently no-ops for GitLab (project-board status at `:2542`, merge-label create at `:2038`).
+
+Two future shifts make this untenable:
+
+- **Corveil** is being added as a third provider, with no embedded git.
+- The ticket framework will expand to **non-coding tasks** where no PR is involved at all.
+
+A non-coding task in Corveil paired with a `.github` PR (or `.gitlab` MR) is a legitimate session shape. So "provider" is not a single dimension — it has two: where the work-unit lives (task tracker) and where the code lives (VCS host). Lumping them into a single `TicketBackend` protocol would re-encode the very assumption we need to dissolve.
+
+## Decision
+
+Crow exposes two independent protocols under `CrowProvider`:
+
+- **`TaskBackend`** — tracker side. Owns issue/task lifecycle: `fetchTask`, `listAssigned`, `setLabels`, `setTaskStatus`, `assign`, `createTask`.
+- **`CodeBackend`** — VCS side. Owns PR lifecycle: `linkedPR`, `prStates`, `ensureMergeLabel`, `fetchCrowAuthoredCommits`.
+
+Each backend declares its **capabilities** as a `Set` (`TaskCapability` and `CodeCapability`). Callers branch on capabilities, not on provider identity. Examples:
+
+```swift
+if taskBackend.capabilities.contains(.projectBoardStatus) {
+    try await taskBackend.setTaskStatus(url: url, status: .inReview)
+}
+```
+
+This is the direct replacement for `if session.provider == .github { ... }`. New backends declare what they support and the call site asks; no `switch` over a closed set of providers.
+
+Backends take a `ShellRunner` (a thin `protocol` over `Process()` + `ShellEnvironment.shared`) at init, so unit tests inject a `FakeShellRunner` that records command vectors and returns canned JSON. The three near-duplicate `private func shell` implementations in `ProviderManager`, `IssueTracker`, and `SessionService` collapse into one `ProcessShellRunner`.
+
+`ProviderManager` becomes a non-actor factory (`final class … : Sendable`) that hands out the right backend(s) for a session or URL. URL parsing utilities (`parseTicketURLComponents`, `detectProvider`, `classifySpec`) stay where they are. Isolation lives in the `ShellRunner` it injects, not on the factory itself.
+
+Concrete implementations:
+
+| Backend | Provider | Capabilities |
+|---|---|---|
+| `GitHubTaskBackend` | `.github` | `[projectBoardStatus, batchedQuery]` |
+| `GitHubCodeBackend` | `.github` | `[autoMergeLabel, batchedPRStates]` |
+| `GitLabTaskBackend` | `.gitlab` | `[]` (v1) |
+| `GitLabCodeBackend` | `.gitlab` | `[]` (v1) |
+| `StubCorveilTaskBackend` | `.corveil` | `[]` — every method throws `.unimplemented` |
+
+There is no `StubCorveilCodeBackend` — Corveil has no git. A Corveil-tasked session uses a `.github` or `.gitlab` `CodeBackend`, which is the whole point of the split.
+
+`Session.provider` remains a single optional field for v1 — code looks up both backends from the same value. A follow-up adds `Session.codeProvider: Provider?` once a real Corveil backend is implemented and cross-backend sessions are a working flow, not a theoretical one.
+
+## Consequences
+
+**Easier:**
+
+- "Add a third provider" stops being a sprawling diff across `IssueTracker` and becomes a new file in `Backends/` plus a factory case.
+- Behavior matrices become testable. Each backend is exercised against a `FakeShellRunner` — the regression net the codebase currently lacks.
+- The parallel GitHub/GitLab halves of `listAssigned` and `prStates` stop sitting in the same file. They move to their respective backend files where their idioms (batched GraphQL vs per-MR REST) are local concerns, not global ones.
+- Non-coding tasks are no longer an architectural awkwardness. A task without a `CodeBackend` is a normal session; PR-related code paths simply aren't invoked.
+
+**Harder / accepted:**
+
+- More indirection: a call to "remove a label" goes through `manager.taskBackend(for:) → setLabels(...)` instead of a direct `gh issue edit` shell-out. Reviewers comparing the diff to the old code path have to follow one extra hop.
+- Capability flags are an enum the maintainer keeps in sync. A new capability is a two-edit change (add the case, declare it on the relevant backend) — easy to forget, hard to catch by build.
+- The `Session.provider == provider` simplification limits cross-backend pairings until the `Session.codeProvider` follow-up lands. Real Corveil work blocks on that ticket.
+- `setup.sh` and skill scripts continue to shell `gh`/`glab` directly — they don't run through Swift and stay out of this abstraction. A separate effort once a real Corveil backend exists.
+
+## Alternatives considered
+
+- **Single `TicketBackend` protocol** (the original ticket proposal). Rejected — re-encodes the task ≡ code assumption we need to break. Would make Corveil-task + GitHub-code sessions a special case rather than a natural one.
+- **Throw `.unsupportedOperation`** instead of capability flags. Rejected — forces callers into try/catch when they really want to branch before calling. Capability flags also document the support matrix in one place; throwing scatters it across catch blocks.
+- **Keep `ProviderManager` as an actor.** Rejected — backends are `Sendable` protocol existentials, the factory hands them out synchronously, and the only real isolation is around the shell runner (where it belongs). Making the factory itself an actor adds `await` to every call site for no concurrency benefit.
+- **Closure-based shell runner.** Considered — lighter weight (just `let shell: @Sendable ([String], [String:String], String?) -> String`). Rejected in favor of a named protocol so future callers (and skills) can discover and conform to it the same way they conform to `Sendable`.
+
+## References
+
+- Ticket: [#410](https://github.com/radiusmethod/crow/issues/410)
+- Code:
+  - `Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift`
+  - `Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift`
+  - `Packages/CrowProvider/Sources/CrowProvider/Backends/`
+  - `Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift`
+  - `Packages/CrowCore/Sources/CrowCore/ShellRunner.swift`
+- Follow-up tickets: AutoRespond CLI migration, UI capability checks, `Session.codeProvider` field.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ Don't delete the old file. Update its `Status` to `Superseded by NNNN` and point
 | 0002 | [Unix-socket CLI ↔ app architecture](./0002-unix-socket-cli-architecture.md) | Accepted | 2026-05-25 |
 | 0003 | [Worktree-per-task model](./0003-worktree-per-task-model.md) | Accepted | 2026-05-25 |
 | 0004 | [Manager session launches in auto-permission mode by default](./0004-manager-auto-permission-mode.md) | Accepted | 2026-05-25 |
+| 0005 | [TaskBackend and CodeBackend protocols](./0005-task-and-code-backend-protocols.md) | Proposed | 2026-06-03 |


### PR DESCRIPTION
## Summary
- Decouples `gh`/`glab` shell-outs from call sites behind two distinct protocols: `TaskBackend` (issues/labels/status) and `CodeBackend` (PRs/merge labels). The split exists because tasks and code are independent dimensions — a Corveil-tasked session can pair with a GitHub/GitLab `CodeBackend`, and a non-coding task needs no `CodeBackend` at all.
- Adds a `ShellRunner` protocol so backends are unit-testable without a real shell. Production uses `ProcessShellRunner`; tests use a recording fake.
- `ProviderManager` becomes a factory (`taskBackend(for:)` / `codeBackend(for:)` / `taskBackend(forURL:)`), backends are `Sendable` value types handed across the actor boundary.
- Capability flags (`TaskCapability` / `CodeCapability`) replace `if session.provider == .github` guards.
- Stub `Corveil` task backend proves the abstraction holds for a third provider — every method throws `.unimplemented` cleanly.
- `SessionService` recovery paths (ticket-title fetch, PR-link lookup) migrate to the new abstraction with a fallback to the inline shell-out when no `ProviderManager` is wired (no behavior change in production).
- ADR 0005 captures the spec.

Closes #410.

## Architecture
See [ADR 0005](docs/adr/0005-task-and-code-backend-protocols.md) — task/code separation, capability flags, ShellRunner injection, Corveil-as-task-only.

## Test plan
- [x] `swift build --arch arm64` clean
- [x] Existing 205 `CrowCore` + 35 `ProviderManagerTests` + 152 root `CrowTests` all green
- [x] 15 new `BackendsTests` covering each backend's command vector, capability flags, error paths, and the Corveil stub
- [ ] Manual smoke: GitHub and GitLab sessions remain identical pre/post-refactor

## Follow-ups (filed separately, no \`crow:auto\`)
- Migrate \`AutoRespondCoordinator\` CLI string selection to backends
- Migrate UI provider guards to capability checks
- Add \`Session.codeProvider\` for cross-backend pairing

🐦‍⬛ Generated with Claude Code, orchestrated by Crow