### PR TITLE
Add double-click rename on master session rows

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -486,6 +486,11 @@ struct ManagerSessionRow: View {
         }
         .buttonStyle(.plain)
         .padding(.vertical, 2)
+        .simultaneousGesture(
+            TapGesture(count: 2).onEnded {
+                editingSessionID = session.id
+            }
+        )
         .onChange(of: editingSessionID) { _, newValue in
             if newValue == session.id {
                 editingName = session.name


### PR DESCRIPTION
## Summary
- Double-clicking an extra Manager session row in the sidebar now enters inline-rename mode, matching the right-click → Rename behavior.
- Implemented as a `.simultaneousGesture(TapGesture(count: 2))` on `ManagerSessionRow` so single-click selection still fires; the second click flips `editingSessionID = session.id` to reuse the existing rename machinery (focus, Enter/blur commit, Escape cancel).
- Scoped to rows that already expose the Rename context-menu item — primary manager row and work sessions are untouched, no regression to existing double-click behavior.

## Test plan
- [ ] Launch Crow; create or pick an extra Manager session.
- [ ] Double-click the row → TextField appears, focused.
- [ ] Type a new name, press Enter → rename commits.
- [ ] Double-click again, press Escape → cancels, original name preserved.
- [ ] Double-click again, click outside → blur commits.
- [ ] Right-click → Rename still works (no regression).
- [ ] Double-click on the primary manager row, ticket board, and a work session → unchanged behavior.

Closes #415

🐦‍⬛ Generated with [Claude Code](https://claude.com/claude-code), orchestrated by Crow