### PR TITLE
Add per-action agent selection (coding/review/job)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -59,6 +59,20 @@ public final class AppState {
     /// current default without a config round-trip.
     public var defaultAgentKind: AgentKind = .claudeCode
 
+    /// Per-action agent overrides keyed by `SessionKind.rawValue`. Mirrors
+    /// `AppConfig.agentsByKind`. Empty means every kind falls back to
+    /// `defaultAgentKind` (CROW-421).
+    public var agentsByKind: [String: AgentKind] = [:]
+
+    /// Resolve the agent that should drive a newly-created session of the
+    /// given kind. Manager sessions are pinned to Claude Code; all other
+    /// kinds prefer an `agentsByKind` override and fall back to
+    /// `defaultAgentKind` when no override is set (CROW-421).
+    public func agentKind(for sessionKind: SessionKind) -> AgentKind {
+        if sessionKind == .manager { return .claudeCode }
+        return agentsByKind[sessionKind.rawValue] ?? defaultAgentKind
+    }
+
     /// Terminal IDs whose Claude Code was launched with `--rc` — drives the
     /// per-session indicator badge. Survives toggle changes so existing sessions
     /// keep showing the badge until they're restarted.

--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -48,6 +48,16 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// The agent used for newly created sessions when none is specified.
     /// Existing persisted configs without this key decode to `.claudeCode`.
     public var defaultAgentKind: AgentKind
+    /// Per-action-type overrides. When a key is present, sessions of that
+    /// kind are created with the mapped agent; when absent, they fall back
+    /// to `defaultAgentKind`. Manager sessions are pinned to `.claudeCode`
+    /// and intentionally not honored by this map (CROW-421).
+    ///
+    /// Keyed by `SessionKind.rawValue` (string) rather than `SessionKind`
+    /// directly so JSON serializes as an object literal like
+    /// `{"review": "codex"}` — Swift's default `JSONEncoder` only treats
+    /// dictionaries with `String`/`Int` keys as JSON objects.
+    public var agentsByKind: [String: AgentKind]
 
     public init(
         workspaces: [WorkspaceInfo] = [],
@@ -65,7 +75,8 @@ public struct AppConfig: Codable, Sendable, Equatable {
         autoRebaseWatcherEnabled: Bool = false,
         cleanup: CleanupConfig = CleanupConfig(),
         jobs: [JobConfig] = [],
-        defaultAgentKind: AgentKind = .claudeCode
+        defaultAgentKind: AgentKind = .claudeCode,
+        agentsByKind: [String: AgentKind] = [:]
     ) {
         self.workspaces = workspaces
         self.defaults = defaults
@@ -83,6 +94,7 @@ public struct AppConfig: Codable, Sendable, Equatable {
         self.cleanup = cleanup
         self.jobs = jobs
         self.defaultAgentKind = defaultAgentKind
+        self.agentsByKind = agentsByKind
     }
 
     public init(from decoder: Decoder) throws {
@@ -103,10 +115,20 @@ public struct AppConfig: Codable, Sendable, Equatable {
         cleanup = try container.decodeIfPresent(CleanupConfig.self, forKey: .cleanup) ?? CleanupConfig()
         jobs = try container.decodeIfPresent([JobConfig].self, forKey: .jobs) ?? []
         defaultAgentKind = try container.decodeIfPresent(AgentKind.self, forKey: .defaultAgentKind) ?? .claudeCode
+        agentsByKind = try container.decodeIfPresent([String: AgentKind].self, forKey: .agentsByKind) ?? [:]
     }
 
     private enum CodingKeys: String, CodingKey {
-        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, autoRebaseWatcherEnabled, cleanup, jobs, defaultAgentKind
+        case workspaces, defaults, notifications, sidebar, remoteControlEnabled, managerAutoPermissionMode, jobsAutoPermissionMode, telemetry, autoRespond, attributionTrailers, autoMergeWatcherEnabled, autoCreateWatcherEnabled, autoRebaseWatcherEnabled, cleanup, jobs, defaultAgentKind, agentsByKind
+    }
+
+    /// Resolve the agent that should drive a newly-created session of the
+    /// given kind. Manager sessions are always Claude Code (pinned by spec).
+    /// All other kinds prefer an explicit `agentsByKind` override, falling
+    /// back to `defaultAgentKind` (CROW-421).
+    public func agentKind(for sessionKind: SessionKind) -> AgentKind {
+        if sessionKind == .manager { return .claudeCode }
+        return agentsByKind[sessionKind.rawValue] ?? defaultAgentKind
     }
 }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigAgentKindTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigAgentKindTests.swift
@@ -33,3 +33,67 @@ import Testing
     #expect(config.defaultAgentKind == .claudeCode)
     #expect(config.remoteControlEnabled == true)
 }
+
+// CROW-421: per-action agent selection.
+
+@Test func appConfigAgentsByKindDefaultsToEmpty() {
+    let config = AppConfig()
+    #expect(config.agentsByKind.isEmpty)
+}
+
+@Test func appConfigAgentsByKindRoundTrip() throws {
+    var config = AppConfig()
+    config.agentsByKind["review"] = AgentKind(rawValue: "codex")
+    config.agentsByKind["job"] = AgentKind(rawValue: "cursor")
+
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+    #expect(decoded.agentsByKind["review"] == AgentKind(rawValue: "codex"))
+    #expect(decoded.agentsByKind["job"] == AgentKind(rawValue: "cursor"))
+}
+
+@Test func appConfigAgentsByKindSerializesAsJSONObject() throws {
+    // Storing the map as `[String: AgentKind]` rather than
+    // `[SessionKind: AgentKind]` is intentional: Swift's JSONEncoder only
+    // emits dictionaries with String/Int keys as JSON objects.
+    var config = AppConfig()
+    config.agentsByKind["review"] = AgentKind(rawValue: "codex")
+
+    let data = try JSONEncoder().encode(config)
+    let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let agentsByKind = try #require(json["agentsByKind"] as? [String: String])
+    #expect(agentsByKind["review"] == "codex")
+}
+
+@Test func appConfigLegacyJSONWithoutAgentsByKindIsEmpty() throws {
+    let json = """
+    {
+      "workspaces": [],
+      "defaultAgentKind": "codex"
+    }
+    """.data(using: .utf8)!
+
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.agentsByKind.isEmpty)
+    // Resolver falls back to defaultAgentKind for every kind when the map is empty.
+    #expect(config.agentKind(for: .work) == AgentKind(rawValue: "codex"))
+    #expect(config.agentKind(for: .review) == AgentKind(rawValue: "codex"))
+    #expect(config.agentKind(for: .job) == AgentKind(rawValue: "codex"))
+}
+
+@Test func appConfigAgentResolverReturnsOverrideWhenSet() {
+    var config = AppConfig(defaultAgentKind: .claudeCode)
+    config.agentsByKind["review"] = AgentKind(rawValue: "codex")
+    #expect(config.agentKind(for: .review) == AgentKind(rawValue: "codex"))
+    // Other kinds still use the default.
+    #expect(config.agentKind(for: .work) == .claudeCode)
+    #expect(config.agentKind(for: .job) == .claudeCode)
+}
+
+@Test func appConfigAgentResolverPinsManagerToClaudeCode() {
+    var config = AppConfig(defaultAgentKind: AgentKind(rawValue: "codex"))
+    // Even if someone hand-edits the map to override manager, it's ignored.
+    config.agentsByKind["manager"] = AgentKind(rawValue: "cursor")
+    #expect(config.agentKind(for: .manager) == .claudeCode)
+}

--- a/Packages/CrowUI/Sources/CrowUI/CreateSessionView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/CreateSessionView.swift
@@ -55,7 +55,7 @@ public struct CreateSessionView: View {
         .padding(24)
         .frame(width: 400)
         .onAppear {
-            agentKind = appState.defaultAgentKind
+            agentKind = appState.agentKind(for: .work)
         }
     }
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -205,6 +205,13 @@ public struct SettingsView: View {
                 Text("Selected agent runs new sessions. Disabled until a second agent (e.g., Codex) is registered.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                perActionAgentPicker(label: "Agent for coding", kind: .work)
+                perActionAgentPicker(label: "Agent for reviews", kind: .review)
+                perActionAgentPicker(label: "Agent for scheduled jobs", kind: .job)
+                Text("Per-action overrides. “Use default” falls back to the Default Agent above.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Sidebar") {
@@ -494,5 +501,33 @@ public struct SettingsView: View {
 
     private func save() {
         onSave?(devRoot, config)
+    }
+
+    /// One per-action agent picker (Coding/Reviews/Jobs). "Use default"
+    /// removes the override; selecting a concrete agent writes the
+    /// `config.agentsByKind` entry. Disabled until a second agent is
+    /// registered, matching the Default Agent picker (CROW-421).
+    @ViewBuilder
+    private func perActionAgentPicker(label: String, kind: SessionKind) -> some View {
+        let key = kind.rawValue
+        let binding = Binding<AgentKind?>(
+            get: { config.agentsByKind[key] },
+            set: { newValue in
+                if let newValue {
+                    config.agentsByKind[key] = newValue
+                } else {
+                    config.agentsByKind.removeValue(forKey: key)
+                }
+                save()
+            }
+        )
+        Picker(label, selection: binding) {
+            Text("Use default").tag(AgentKind?.none)
+            ForEach(AgentRegistry.shared.allAgents(), id: \.kind) { agent in
+                Label(agent.displayName, systemImage: agent.iconSystemName)
+                    .tag(Optional(agent.kind))
+            }
+        }
+        .disabled(AgentRegistry.shared.allAgents().count < 2)
     }
 }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -458,6 +458,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
         appState.defaultAgentKind = config.defaultAgentKind
+        appState.agentsByKind = config.agentsByKind
 
         // Create session service and hydrate state
         let service = SessionService(store: store, appState: appState, telemetryPort: config.telemetry.enabled ? config.telemetry.port : nil, providerManager: providerManager)
@@ -1092,6 +1093,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
         appState.defaultAgentKind = config.defaultAgentKind
+        appState.agentsByKind = config.agentsByKind
     }
 
     /// Record a job's run time in the canonical `appConfig` and persist it, so
@@ -1159,7 +1161,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         let createdName = capturedAppState.sessions.first(where: { $0.id == id })?.name ?? name
                         return ["session_id": .string(id.uuidString), "name": .string(createdName)]
                     }
-                    let agentKind = requestedAgentKind ?? capturedAppState.defaultAgentKind
+                    let agentKind = requestedAgentKind ?? capturedAppState.agentKind(for: .work)
                     let session = Session(name: name, kind: .work, agentKind: agentKind)
                     capturedAppState.sessions.append(session)
                     capturedStore.mutate { $0.sessions.append(session) }

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1178,7 +1178,7 @@ final class SessionService {
         let session = Session(
             name: dirName,
             status: .active,
-            agentKind: appState.defaultAgentKind,
+            agentKind: appState.agentKind(for: .work),
             ticketURL: ticket.url,
             ticketTitle: ticket.title,
             ticketNumber: ticket.number,
@@ -1406,7 +1406,7 @@ final class SessionService {
         let session = Session(
             name: "review-\(repoName)-\(prNumber)",
             kind: .review,
-            agentKind: appState.defaultAgentKind,
+            agentKind: appState.agentKind(for: .review),
             ticketTitle: prep.prTitle,
             provider: .github,
             lastReviewedHeadSha: prep.headRefOid
@@ -1637,7 +1637,8 @@ final class SessionService {
 
         let session = Session(
             name: "job-\(slug)-\(stamp)",
-            kind: .job
+            kind: .job,
+            agentKind: appState.agentKind(for: .job)
         )
         let worktree = SessionWorktree(
             sessionID: session.id,


### PR DESCRIPTION
## Summary
- Adds `AppConfig.agentsByKind` — a map keyed by `SessionKind.rawValue` so users can pick a different agent per action type (coding, reviews, scheduled jobs). Manager stays pinned to Claude Code by spec.
- Sessions resolve their agent through a new `agentKind(for:)` helper on `AppConfig`/`AppState`: prefer the override, fall back to `defaultAgentKind`.
- Settings → General → Defaults gains three pickers ("Agent for coding/reviews/scheduled jobs"), each defaulting to **Use default** so existing users see no behavior change on upgrade.
- The ticket's open question (generalize to a map vs two fixed keys) is resolved in favor of the map — covers jobs too, which previously ignored `defaultAgentKind` entirely.
- No data migration code: the existing `decodeIfPresent ?? [:]` pattern means legacy configs load cleanly and every kind still resolves to `defaultAgentKind`.

Closes #421

## Test plan
- [x] `swift build --arch arm64` (release build green)
- [x] `swift test --package-path Packages/CrowCore` — 217 tests, including 5 new ones (resolver fallback, resolver override, manager pinning, round-trip, JSON-object serialization)
- [x] `swift test` — 170 tests in the top-level package
- [ ] Manual: open Settings → General → Defaults; confirm three new pickers appear with "Use default" first option and are disabled when only one agent is registered
- [ ] Manual: hand-edit `~/Dev/.claude/config.json` to add `{"agentsByKind": {"review": "codex"}}`, restart, trigger a review via `/rr` or `crow:auto` label, confirm review session uses codex while a fresh coding session still uses the default
- [ ] Manual: remove the `review` key from `agentsByKind`, restart, trigger another review — confirm fallback to `defaultAgentKind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)