### PR TITLE
Add Bash Conventions section to scaffolded CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,23 @@ echo "=== api ==="; gh api repos/owner/repo/issues/123 | head -120
 
 This keeps the allowlist tight (preferred over broadening it with `cd:*` / `find:*`).
 
+## Bash Conventions
+
+Same allowlist-prefix problem applies to `find -exec`: the rule engine can't see what gets exec'd, so `find ... -exec X` falls back to a permission prompt even when both `find` and `X` are individually allowlisted. Prefer these instead — they avoid the prompt entirely:
+
+| Intent | Use | Not |
+|---|---|---|
+| Search files for text | `rg PATTERN` (recursive by default, respects `.gitignore`) | `find . -exec grep PATTERN {} \;` |
+| Search by file type | `rg PATTERN --type py` / `--type swift` | `find . -name '*.py' -exec grep ...` |
+| Find files by name | `find . -name X` (no `-exec`) | — |
+| Delete matches | `find . -name X -delete` | `find . -name X -exec rm {} \;` |
+| Run a command per match | `find ... -print0 \| xargs -0 CMD` | `find ... -exec CMD {} \;` |
+| Filter then count | `find ... \| wc -l` (single pipe is fine) | — |
+
+`rg` (ripgrep) is the default search tool — much faster than `grep -r` and skips ignored files. Install via `brew install ripgrep` if missing.
+
+`find -exec` is essentially never the right tool today — `-delete` and `xargs` cover what it was originally needed for, and both keep the allowlist clean.
+
 ## Known Issues / Corrections
 
 <!-- Auto-maintained by Claude Code during workspace setup -->

--- a/Resources/CLAUDE.md.template
+++ b/Resources/CLAUDE.md.template
@@ -78,6 +78,23 @@ echo "=== api ==="; gh api repos/owner/repo/issues/123 | head -120
 
 This keeps the allowlist tight (preferred over broadening it with `cd:*` / `find:*`).
 
+## Bash Conventions
+
+Same allowlist-prefix problem applies to `find -exec`: the rule engine can't see what gets exec'd, so `find ... -exec X` falls back to a permission prompt even when both `find` and `X` are individually allowlisted. Prefer these instead — they avoid the prompt entirely:
+
+| Intent | Use | Not |
+|---|---|---|
+| Search files for text | `rg PATTERN` (recursive by default, respects `.gitignore`) | `find . -exec grep PATTERN {} \;` |
+| Search by file type | `rg PATTERN --type py` / `--type swift` | `find . -name '*.py' -exec grep ...` |
+| Find files by name | `find . -name X` (no `-exec`) | — |
+| Delete matches | `find . -name X -delete` | `find . -name X -exec rm {} \;` |
+| Run a command per match | `find ... -print0 \| xargs -0 CMD` | `find ... -exec CMD {} \;` |
+| Filter then count | `find ... \| wc -l` (single pipe is fine) | — |
+
+`rg` (ripgrep) is the default search tool — much faster than `grep -r` and skips ignored files. Install via `brew install ripgrep` if missing.
+
+`find -exec` is essentially never the right tool today — `-delete` and `xargs` cover what it was originally needed for, and both keep the allowlist clean.
+
 ## Known Issues / Corrections
 
 <!-- Claude Code appends corrections here when crow commands fail -->


### PR DESCRIPTION
## Summary

- Adds a new **Bash Conventions** section to the scaffolded `{devRoot}/.claude/CLAUDE.md`, immediately after **Fetching Ticket / PR Data** and before **Known Issues / Corrections**.
- Nudges Claude toward `rg`, `find -delete`, and `xargs` over `find -exec` — same allowlist-prefix problem already documented for `cd && X`, pipes, and `echo` banners (Claude Code's rule engine can't see what `-exec` launches, so the call falls back to a permission prompt even when both `find` and the exec'd binary are individually allowlisted).
- Prompt-only fix — no changes to `settings.json` or permission rules.
- Mirrors the edit in both the repo-level `CLAUDE.md` (used for dev builds) and `Resources/CLAUDE.md.template` (bundled in `.app` builds) so the two template sources stay in sync.

No Swift code change is needed: `Scaffolder.scaffold` already regenerates everything above `## Known Issues / Corrections` on every launch, so the new section lands automatically on the next Crow start and existing user corrections under that section are preserved.

Closes #426

## Test plan

- [ ] Quit Crow, relaunch, and confirm `{devRoot}/.claude/CLAUDE.md` now contains the `## Bash Conventions` section between "Fetching Ticket / PR Data" and "Known Issues / Corrections".
- [ ] Confirm any prior `## Known Issues / Corrections` content in the live `CLAUDE.md` is preserved after the relaunch.
- [ ] Confirm `.claude/settings.json` is unchanged (this is prompt-only guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)