### PR TITLE
Don't steal focus on crow:auto pickup (#429)

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -687,7 +687,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         tracker.onAutoCreateRequest = { [weak self] issue in
             guard let self else { return }
-            self.appState.onWorkOnIssue?(issue.url)
+            // Send `/crow-workspace <url>` to the Manager terminal WITHOUT
+            // switching the selected session. The manual "Start Working"
+            // button routes through `onWorkOnIssue` (which does select
+            // Manager) because the user explicitly asked for that
+            // workspace; an auto-pickup is background work and must not
+            // yank the user out of their current session (#429). The
+            // sidebar still updates and `notifyAutoWorkspaceCreated`
+            // already surfaces the event.
+            if let managerTerminals = self.appState.terminals[AppState.managerSessionID],
+               let managerTerminal = managerTerminals.first {
+                TerminalRouter.send(managerTerminal, text: "/crow-workspace \(issue.url)\n")
+            }
             self.notificationManager?.notifyAutoWorkspaceCreated(issue)
         }
         tracker.onPRStatusTransitions = { [weak self] transitions in


### PR DESCRIPTION
## Summary

- Auto-pickup of `crow:auto`-labeled issues was routing through `appState.onWorkOnIssue`, which is shared with the manual "Start Working" button and unconditionally switches the sidebar to the Manager tab — yanking the user out of whatever session they were on.
- This PR inlines the "send `/crow-workspace <url>` to the Manager terminal" step in `onAutoCreateRequest` and skips the focus switch. The manual button keeps its current behavior (user explicitly asked for that workspace).
- The Manager's `/crow-workspace` skill ultimately calls `crow new-session`, whose RPC path already leaves `selectedSessionID` alone — so the new session appears in the sidebar without disturbing the user's view, matching the existing silent-spawn behavior of PR auto-review and Job kickoffs.
- `notifyAutoWorkspaceCreated` still fires, so the existing notification surface (chime / system notification) continues to announce the event.

After this change, all four auto/CLI spawn paths called out in the ticket (`crow:auto` pickup, PR auto-review, Job, manual `crow new-session`) no longer change `selectedSessionID`.

## Test plan

- [ ] Build: `make ghostty && swift build --arch arm64` succeeds.
- [ ] Select a non-Manager session, label a test issue `crow:auto`, confirm Manager terminal receives `/crow-workspace <url>` and the system notification fires, while the selected session does **not** change.
- [ ] Regression: click "Start Working" on a ticket from the Ticket Board and confirm the UI still switches to the Manager tab.
- [ ] Regression: confirm PR auto-review and Job kickoff still create their sessions in the sidebar without changing focus.

Closes #429