### PR TITLE
Show actual agent on terminal tab label and icon (CROW-427)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Agent/AgentKind.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Agent/AgentKind.swift
@@ -20,3 +20,20 @@ public struct AgentKind: Hashable, Sendable, Codable, RawRepresentable {
     /// The Cursor agent.
     public static let cursor = AgentKind(rawValue: "cursor")
 }
+
+public extension AgentKind {
+    /// Human-readable label for this kind, resolved through `AgentRegistry`.
+    /// Falls back to `rawValue` (e.g. `"cursor"`) when no agent is registered
+    /// for the kind — per CROW-427 the fallback must NOT silently be
+    /// `"Claude Code"`.
+    var displayName: String {
+        AgentRegistry.shared.agent(for: self)?.displayName ?? rawValue
+    }
+
+    /// SF Symbol name for this kind, resolved through `AgentRegistry`.
+    /// Falls back to a neutral `"sparkles"` when no agent is registered, so
+    /// the tab UI doesn't render an empty SF Symbol box.
+    var iconSystemName: String {
+        AgentRegistry.shared.agent(for: self)?.iconSystemName ?? "sparkles"
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AgentKindDisplayTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AgentKindDisplayTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import CrowCore
+
+// Locks in the fallback semantics CROW-427 specifies: when a kind isn't
+// registered in `AgentRegistry`, `displayName` must return the kind's raw
+// value (e.g. `"cursor"`) and NOT silently degrade to `"Claude Code"`.
+// `iconSystemName` must fall back to a neutral SF Symbol (`"sparkles"`) so
+// the tab UI doesn't render an empty glyph box. A future refactor that
+// "simplifies" `?? rawValue` to `?? "Claude Code"` would reintroduce the
+// exact bug this PR fixes; these tests are the regression guard.
+
+@Test func displayNameFallsBackToRawValueWhenKindUnregistered() {
+    // Use a kind value that no shipped agent claims so the lookup misses
+    // even if the process-wide `AgentRegistry` has been populated by
+    // another test.
+    let unknown = AgentKind(rawValue: "crow-427-unregistered-fallback")
+    #expect(AgentRegistry.shared.agent(for: unknown) == nil)
+    #expect(unknown.displayName == "crow-427-unregistered-fallback")
+}
+
+@Test func iconSystemNameFallsBackToSparklesWhenKindUnregistered() {
+    let unknown = AgentKind(rawValue: "crow-427-unregistered-icon-fallback")
+    #expect(AgentRegistry.shared.agent(for: unknown) == nil)
+    #expect(unknown.iconSystemName == "sparkles")
+}

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -366,6 +366,12 @@ public struct SessionDetailView: View {
             }
         } else {
             VStack(spacing: 0) {
+                // Icon is resolved live from `session.agentKind` on every
+                // render, while the tab label is snapshotted into
+                // `terminal.name` at creation (so a user-typed rename
+                // sticks). The asymmetry is intentional — don't "fix" it by
+                // moving either side without considering rename UX and
+                // legacy persisted names (CROW-427).
                 TerminalTabBar(
                     terminals: sessionTerminals,
                     managedAgentIcon: session.agentKind.iconSystemName,

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -368,6 +368,7 @@ public struct SessionDetailView: View {
             VStack(spacing: 0) {
                 TerminalTabBar(
                     terminals: sessionTerminals,
+                    managedAgentIcon: session.agentKind.iconSystemName,
                     activeID: appState.activeTerminalID[session.id] ?? sessionTerminals[0].id,
                     onSelect: { id in appState.activeTerminalID[session.id] = id },
                     onClose: { id in appState.onCloseTerminal?(session.id, id) },
@@ -425,11 +426,34 @@ struct DetailLabel: View {
 
 public struct TerminalTabBar: View {
     let terminals: [SessionTerminal]
+    /// SF Symbol shown on managed tabs (e.g. `"sparkles"` for Claude Code,
+    /// `"cursorarrow.rays"` for Cursor). Set by the parent from
+    /// `session.agentKind.iconSystemName` so the glyph tracks the agent
+    /// actually launched (CROW-427).
+    let managedAgentIcon: String
     let activeID: UUID
     let onSelect: (UUID) -> Void
     let onClose: (UUID) -> Void
     let onRename: (UUID, String) -> Void
     let onAdd: () -> Void
+
+    public init(
+        terminals: [SessionTerminal],
+        managedAgentIcon: String = "sparkles",
+        activeID: UUID,
+        onSelect: @escaping (UUID) -> Void,
+        onClose: @escaping (UUID) -> Void,
+        onRename: @escaping (UUID, String) -> Void,
+        onAdd: @escaping () -> Void
+    ) {
+        self.terminals = terminals
+        self.managedAgentIcon = managedAgentIcon
+        self.activeID = activeID
+        self.onSelect = onSelect
+        self.onClose = onClose
+        self.onRename = onRename
+        self.onAdd = onAdd
+    }
 
     @State private var editingTerminalID: UUID?
     @State private var editingName: String = ""
@@ -440,7 +464,7 @@ public struct TerminalTabBar: View {
             ForEach(terminals) { terminal in
                 Button { onSelect(terminal.id) } label: {
                     HStack(spacing: 4) {
-                        Image(systemName: terminal.isManaged ? "sparkles" : "terminal")
+                        Image(systemName: terminal.isManaged ? managedAgentIcon : "terminal")
                             .font(.system(size: 9))
                         if editingTerminalID == terminal.id {
                             TextField("Name", text: $editingName)

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1327,8 +1327,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 let rawCommand = params["command"]?.stringValue
                 let isManaged = params["managed"]?.boolValue ?? false
-                let defaultName = isManaged ? "Claude Code" : "Shell"
-                let terminalName = params["name"]?.stringValue ?? defaultName
                 return await MainActor.run {
                     // Resolve claude binary path if command references claude; also
                     // inject --rc --name when remote control is enabled so the session
@@ -1336,9 +1334,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     // session name.
                     var command = rawCommand
                     var rcInjected = false
+                    let session = capturedAppState.sessions.first(where: { $0.id == sessionID })
+                    let sessionName = session?.name
+                    // The default managed-terminal name is the configured agent's
+                    // displayName (CROW-427) — Cursor sessions read "Cursor",
+                    // Codex sessions read "OpenAI Codex", etc. When the session
+                    // can't be found yet, fall back to the AppState default kind.
+                    let agentKind = session?.agentKind ?? capturedAppState.defaultAgentKind
+                    let defaultName = isManaged ? agentKind.displayName : "Shell"
+                    let terminalName = params["name"]?.stringValue ?? defaultName
                     if let cmd = rawCommand, cmd.contains("claude") {
                         let rcEnabled = capturedAppState.remoteControlEnabled
-                        let sessionName = capturedAppState.sessions.first(where: { $0.id == sessionID })?.name
                         command = AppDelegate.resolveClaudeInCommand(
                             cmd,
                             remoteControl: rcEnabled,

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1207,7 +1207,7 @@ final class SessionService {
 
         let rawTerminal = SessionTerminal(
             sessionID: session.id,
-            name: "Claude Code",
+            name: session.agentKind.displayName,
             cwd: worktreePath,
             isManaged: true
         )
@@ -1434,7 +1434,7 @@ final class SessionService {
 
         let terminal = SessionTerminal(
             sessionID: session.id,
-            name: "Claude Code",
+            name: session.agentKind.displayName,
             cwd: prep.clonePath,
             isManaged: true
         )
@@ -1661,7 +1661,7 @@ final class SessionService {
         )
         let terminal = SessionTerminal(
             sessionID: session.id,
-            name: "Claude Code",
+            name: session.agentKind.displayName,
             cwd: worktreePath,
             isManaged: true
         )


### PR DESCRIPTION
## Summary
- Terminal tabs hardcoded `"Claude Code"` and the `sparkles` icon for every managed terminal, ignoring the session's configured agent.
- Resolve tab label and SF Symbol from `session.agentKind` via `AgentRegistry` at both creation time (the four call sites that build managed `SessionTerminal`s) and at render time (the `TerminalTabBar` glyph). Adds `AgentKind.displayName` / `AgentKind.iconSystemName` extensions so every call stays a one-liner and the per-ticket fallback rule lives in one place.
- Per the ticket, when no agent is registered for the kind the label falls back to the raw kind string (e.g. `"cursor"`) — not silently to `"Claude Code"`. The icon falls back to a neutral `sparkles` so the tab doesn't draw an empty SF Symbol box.

## Test plan
- [ ] Build: \`make ghostty && swift build --arch arm64\`
- [ ] Create a new work session with \`defaultAgentKind = cursor\`; confirm the tab reads **Cursor** with the \`cursorarrow.rays\` glyph, and the session-header "Agent:" row agrees.
- [ ] With per-action override \`agentsByKind[review] = codex\` (CROW-421), trigger a review session; confirm the tab reads **OpenAI Codex** with the \`terminal.fill\` glyph.
- [ ] Trigger a job session under a different agent in the same workspace; confirm sibling tabs show different labels **and** different glyphs.
- [ ] Fallback: deregister an agent kind, create a session of that kind, and confirm the tab falls back to the raw kind string (not "Claude Code") and a neutral sparkles glyph.
- [ ] Pre-existing sessions: their tabs still read "Claude Code" because the name is persisted — expected (those sessions actually ran Claude Code). Double-click rename still works and persists.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)