### PR TITLE
Enable Cursor as a review-capable agent

### DIFF
--- a/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
+++ b/Packages/CrowCursor/Sources/CrowCursor/CursorAgent.swift
@@ -69,22 +69,30 @@ public struct CursorAgent: CodingAgent {
             // control is `crow send` typing into the TUI — agent-agnostic,
             // handled by `SessionService.send`, not a per-launch flag).
             return "\(agentPath)\n"
-        case .job:
-            // Jobs write their first prompt to `.crow-job-prompt.md` in the
-            // worktree before the terminal becomes shell-ready. On first
-            // launch we pass that prompt as argv so Cursor starts working
-            // unattended; on subsequent app restarts we fall back to a bare
+        case .job, .review:
+            // Jobs and reviews share the same dispatch shape: a pre-written
+            // initial prompt file (`.crow-job-prompt.md` / `.crow-review-prompt.md`)
+            // is passed as argv on first launch so Cursor starts working
+            // unattended. On subsequent app restarts we fall back to a bare
             // `agent` (Cursor has no `--continue` equivalent in MVP), so the
             // user resumes the TUI rather than re-running the full prompt.
+            //
+            // Review prompts are agent-aware: SessionService.buildReviewPrompt
+            // inlines the crow-review-pr SKILL body for Cursor so the `agent`
+            // CLI gets a self-contained brief — no slash-command engine
+            // needed (#431). `reviewPromptDispatched` gates both kinds.
             if !session.reviewPromptDispatched {
+                let promptFile = session.kind == .review
+                    ? ".crow-review-prompt.md"
+                    : ".crow-job-prompt.md"
                 let promptPath = (worktreePath as NSString)
-                    .appendingPathComponent(".crow-job-prompt.md")
+                    .appendingPathComponent(promptFile)
                 return "\(agentPath) \"$(cat \(promptPath))\"\n"
             }
             return "\(agentPath)\n"
-        case .review, .manager:
-            // Review-on-Cursor isn't supported in Phase C — the review skill
-            // is Claude-only. Manager sessions don't auto-launch an agent.
+        case .manager:
+            // Manager sessions never auto-launch an agent — Crow drives them
+            // externally. Returning nil here is the contract, not a gap.
             return nil
         }
     }

--- a/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
+++ b/Packages/CrowCursor/Tests/CrowCursorTests/CursorAgentTests.swift
@@ -50,7 +50,12 @@ struct CursorAgentTests {
         #expect(cmd?.contains(".crow-job-prompt.md") == false)
     }
 
-    @Test func autoLaunchCommandReviewSessionUnsupported() {
+    @Test func autoLaunchCommandReviewSessionFirstLaunch() {
+        // First review launch (reviewPromptDispatched == false) should pass
+        // the pre-written `.crow-review-prompt.md` as argv so Cursor starts
+        // the review unattended. The prompt file content is agent-aware
+        // (inlined SKILL body for Cursor) — see SessionService.buildReviewPrompt
+        // and #431.
         let session = Session(name: "review", kind: .review, agentKind: .cursor)
         let cmd = agent.autoLaunchCommand(
             session: session,
@@ -59,7 +64,43 @@ struct CursorAgentTests {
             autoPermissionMode: false,
             telemetryPort: nil
         )
-        // Phase C: review-on-Cursor isn't supported (review skill is Claude-only).
+        #expect(cmd != nil)
+        #expect(cmd?.contains(".crow-review-prompt.md") == true)
+        #expect(cmd?.contains(".crow-job-prompt.md") == false)
+        #expect(cmd?.hasSuffix("\n") == true)
+    }
+
+    @Test func autoLaunchCommandReviewSessionSubsequentLaunch() {
+        // After the initial review prompt has been dispatched, restarting
+        // Crow should resume the TUI with a bare `agent` (no re-issued
+        // review brief). Mirrors the Jobs subsequent-launch contract.
+        var session = Session(name: "review", kind: .review, agentKind: .cursor)
+        session.reviewPromptDispatched = true
+        let cmd = agent.autoLaunchCommand(
+            session: session,
+            worktreePath: "/tmp/wt",
+            remoteControlEnabled: false,
+            autoPermissionMode: false,
+            telemetryPort: nil
+        )
+        #expect(cmd != nil)
+        #expect(cmd?.contains(".crow-review-prompt.md") == false)
+        #expect(cmd?.hasSuffix("agent\n") == true)
+    }
+
+    @Test func autoLaunchCommandManagerSessionUnsupported() {
+        // Manager sessions never auto-launch an agent; Crow drives them
+        // externally. Cursor must keep returning nil here so the manager
+        // contract isn't accidentally regressed by the review-enable work
+        // in #431.
+        let session = Session(name: "manager", kind: .manager, agentKind: .cursor)
+        let cmd = agent.autoLaunchCommand(
+            session: session,
+            worktreePath: "/tmp/wt",
+            remoteControlEnabled: false,
+            autoPermissionMode: false,
+            telemetryPort: nil
+        )
         #expect(cmd == nil)
     }
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1784,17 +1784,21 @@ final class SessionService {
     /// command engine, so for Cursor we expand the SKILL body inline with
     /// `$ARGUMENTS` already substituted to the PR URL — same instructions,
     /// no second-file indirection (#431).
-    nonisolated private static func buildReviewPrompt(prURL: String, prTitle: String, repoSlug: String, prNumber: Int, agentKind: AgentKind) -> String {
+    ///
+    /// `internal` (not `private`) so `SessionServiceReviewPromptTests` can
+    /// assert the branch dispatch via `@testable import Crow`. The actual
+    /// SKILL-body substitution lives in `cursorReviewPrompt(skillBody:prURL:)`
+    /// so tests can exercise the substitution logic without depending on
+    /// `Scaffolder.bundledReviewSkill()` (which falls back to a trivial stub
+    /// in test environments where the repo path can't be resolved from
+    /// `ProcessInfo.processInfo.arguments[0]`).
+    nonisolated static func buildReviewPrompt(prURL: String, prTitle: String, repoSlug: String, prNumber: Int, agentKind: AgentKind) -> String {
         switch agentKind {
         case .cursor:
-            // Inline the SKILL body so Cursor receives the full review brief
-            // as the prompt argv. Swap the trailing attribution from Claude
-            // Code to Cursor so reviews posted to GitHub correctly identify
-            // the reviewing agent.
-            let skill = Scaffolder.bundledReviewSkill()
-            return skill
-                .replacingOccurrences(of: "$ARGUMENTS", with: prURL)
-                .replacingOccurrences(of: "via Claude Code", with: "via Cursor")
+            return cursorReviewPrompt(
+                skillBody: Scaffolder.bundledReviewSkill(),
+                prURL: prURL
+            )
         default:
             // Claude Code (and any future agent with a compatible slash-
             // command engine) gets the terse `/crow-review-pr <URL>` form.
@@ -1802,6 +1806,20 @@ final class SessionService {
             /crow-review-pr \(prURL)
             """
         }
+    }
+
+    /// Apply the Cursor-specific substitutions to a raw `crow-review-pr`
+    /// SKILL body: replace `$ARGUMENTS` with the PR URL, and swap the
+    /// "via Claude Code" attribution suffix for "via Cursor" so the posted
+    /// GitHub review identifies the reviewing agent correctly.
+    ///
+    /// Split out from `buildReviewPrompt` so unit tests can verify the
+    /// substitutions against a known input without depending on the
+    /// scaffolder's file-resolution fallback.
+    nonisolated static func cursorReviewPrompt(skillBody: String, prURL: String) -> String {
+        return skillBody
+            .replacingOccurrences(of: "$ARGUMENTS", with: prURL)
+            .replacingOccurrences(of: "via Claude Code", with: "via Cursor")
     }
 
     // MARK: - Session Status

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1395,6 +1395,12 @@ final class SessionService {
         // never beachballs while a review spins up (#404). The detached task
         // hands back just the metadata the main-actor tail needs to build
         // the Session/Worktree/Terminal/Link rows.
+        //
+        // The resolved review-agent kind is captured here (main actor) so the
+        // detached prepareReviewClone can pick the right prompt-file content
+        // — Claude reads a `/crow-review-pr` slash command; Cursor reads the
+        // expanded SKILL.md body (#431).
+        let reviewAgentKind = appState.agentKind(for: .review)
         let env = ShellEnvironment.shared.env
         let prep: ReviewClonePrep
         do {
@@ -1405,7 +1411,8 @@ final class SessionService {
                     repoName: repoName,
                     prNumber: prNumber,
                     devRoot: devRoot,
-                    env: env
+                    env: env,
+                    reviewAgentKind: reviewAgentKind
                 )
             }.value
         } catch {
@@ -1498,7 +1505,8 @@ final class SessionService {
         repoName: String,
         prNumber: Int,
         devRoot: String,
-        env: [String: String]
+        env: [String: String],
+        reviewAgentKind: AgentKind
     ) async throws -> ReviewClonePrep {
         // Fetch PR metadata
         let prOutput = try await runShellAsync(env: env, args: [
@@ -1543,7 +1551,7 @@ final class SessionService {
 
         // Write review prompt file into the clone directory
         let promptPath = (clonePath as NSString).appendingPathComponent(".crow-review-prompt.md")
-        let reviewPrompt = Self.buildReviewPrompt(prURL: prURL, prTitle: prTitle, repoSlug: repoSlug, prNumber: prNumber)
+        let reviewPrompt = Self.buildReviewPrompt(prURL: prURL, prTitle: prTitle, repoSlug: repoSlug, prNumber: prNumber, agentKind: reviewAgentKind)
         try? reviewPrompt.write(toFile: promptPath, atomically: true, encoding: .utf8)
 
         // Copy the crow-review-pr skill into the clone's .claude/skills/ so Claude Code can find it
@@ -1768,10 +1776,32 @@ final class SessionService {
     // MARK: - Review Prompt
 
     /// Build the initial prompt for a review session.
-    nonisolated private static func buildReviewPrompt(prURL: String, prTitle: String, repoSlug: String, prNumber: Int) -> String {
-        """
-        /crow-review-pr \(prURL)
-        """
+    ///
+    /// Claude Code resolves `/crow-review-pr <URL>` via its slash-command /
+    /// SKILL engine — the prompt file is a one-liner and the bundled
+    /// `.claude/skills/crow-review-pr/SKILL.md` (copied alongside) supplies
+    /// the actual instructions. Cursor's `agent` CLI has no equivalent slash-
+    /// command engine, so for Cursor we expand the SKILL body inline with
+    /// `$ARGUMENTS` already substituted to the PR URL — same instructions,
+    /// no second-file indirection (#431).
+    nonisolated private static func buildReviewPrompt(prURL: String, prTitle: String, repoSlug: String, prNumber: Int, agentKind: AgentKind) -> String {
+        switch agentKind {
+        case .cursor:
+            // Inline the SKILL body so Cursor receives the full review brief
+            // as the prompt argv. Swap the trailing attribution from Claude
+            // Code to Cursor so reviews posted to GitHub correctly identify
+            // the reviewing agent.
+            let skill = Scaffolder.bundledReviewSkill()
+            return skill
+                .replacingOccurrences(of: "$ARGUMENTS", with: prURL)
+                .replacingOccurrences(of: "via Claude Code", with: "via Cursor")
+        default:
+            // Claude Code (and any future agent with a compatible slash-
+            // command engine) gets the terse `/crow-review-pr <URL>` form.
+            return """
+            /crow-review-pr \(prURL)
+            """
+        }
     }
 
     // MARK: - Session Status

--- a/Tests/CrowTests/SessionServiceReviewPromptTests.swift
+++ b/Tests/CrowTests/SessionServiceReviewPromptTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+import CrowCore
+@testable import Crow
+
+/// Branch tests for `SessionService.buildReviewPrompt` and the underlying
+/// Cursor substitution helper `cursorReviewPrompt(skillBody:prURL:)` (#431).
+///
+/// The Cursor branch is the actual payload Cursor's `agent` CLI receives
+/// as argv and the basis of the GitHub-posted review body — `$ARGUMENTS`
+/// substitution and the `via Claude Code` → `via Cursor` attribution swap
+/// are the deliverable. Without these tests, a reworded attribution line
+/// or a renamed placeholder in the SKILL would silently produce a
+/// misattributed review (or a literal `PR $ARGUMENTS` brief) with nothing
+/// to catch it.
+@Suite("Review prompt branch")
+struct SessionServiceReviewPromptTests {
+
+    private static let prURL = "https://github.com/radiusmethod/crow/pull/123"
+    private static let prTitle = "Some PR"
+    private static let repoSlug = "radiusmethod/crow"
+    private static let prNumber = 123
+
+    /// Minimal SKILL-shaped fixture. Avoids depending on
+    /// `Scaffolder.bundledReviewSkill()`, which falls back to a trivial stub
+    /// when the test executable can't resolve the repo root from its argv0.
+    private static let fixtureSkillBody = """
+    # Crow Review PR
+    Review PR $ARGUMENTS — checkout via `gh pr checkout $ARGUMENTS`.
+
+    [🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+    """
+
+    @Test func cursorPromptSubstitutesPRURLForArguments() {
+        let prompt = SessionService.cursorReviewPrompt(
+            skillBody: Self.fixtureSkillBody,
+            prURL: Self.prURL
+        )
+
+        // Every `$ARGUMENTS` occurrence must become the PR URL — there are
+        // two in the fixture, mirroring the real SKILL's "title + `gh pr
+        // checkout`" pair.
+        #expect(prompt.contains("Review PR \(Self.prURL)"))
+        #expect(prompt.contains("gh pr checkout \(Self.prURL)"))
+        // No raw placeholder should leak through; otherwise Cursor would
+        // receive `gh pr checkout $ARGUMENTS` literally.
+        #expect(!prompt.contains("$ARGUMENTS"))
+    }
+
+    @Test func cursorPromptSwapsAttributionToCursor() {
+        let prompt = SessionService.cursorReviewPrompt(
+            skillBody: Self.fixtureSkillBody,
+            prURL: Self.prURL
+        )
+
+        // Attribution must identify the reviewing agent correctly so the
+        // posted GitHub review body says "via Cursor", not "via Claude Code".
+        #expect(prompt.contains("via Cursor"))
+        #expect(!prompt.contains("via Claude Code"))
+        // The canonical URL must remain — only the agent-name segment is
+        // swapped.
+        #expect(prompt.contains("https://github.com/radiusmethod/crow"))
+    }
+
+    @Test func buildReviewPromptCursorBranchUsesCursorHelper() {
+        let prompt = SessionService.buildReviewPrompt(
+            prURL: Self.prURL,
+            prTitle: Self.prTitle,
+            repoSlug: Self.repoSlug,
+            prNumber: Self.prNumber,
+            agentKind: .cursor
+        )
+
+        // The Cursor branch dispatches into `cursorReviewPrompt` and embeds
+        // the PR URL. Even if `Scaffolder.bundledReviewSkill()` returns the
+        // trivial test-environment fallback (no `$ARGUMENTS`, no
+        // attribution to swap), the dispatch must produce non-empty output
+        // distinct from the Claude one-liner.
+        #expect(!prompt.isEmpty)
+        #expect(!prompt.hasPrefix("/crow-review-pr"))
+    }
+
+    @Test func buildReviewPromptClaudeBranchIsTerseSlashCommand() {
+        let prompt = SessionService.buildReviewPrompt(
+            prURL: Self.prURL,
+            prTitle: Self.prTitle,
+            repoSlug: Self.repoSlug,
+            prNumber: Self.prNumber,
+            agentKind: .claudeCode
+        )
+
+        // Claude Code expands `/crow-review-pr <URL>` via its SKILL engine,
+        // so the prompt file is intentionally a one-liner.
+        #expect(prompt == "/crow-review-pr \(Self.prURL)")
+    }
+
+    @Test func buildReviewPromptUnknownAgentFallsBackToSlashCommand() {
+        // Any non-Cursor agent (including the default branch) should get
+        // the Claude-style slash-command form. This guards against an
+        // accidental capability regression for future agents added to
+        // `AgentKind` without an explicit branch.
+        let prompt = SessionService.buildReviewPrompt(
+            prURL: Self.prURL,
+            prTitle: Self.prTitle,
+            repoSlug: Self.repoSlug,
+            prNumber: Self.prNumber,
+            agentKind: AgentKind(rawValue: "hypothetical-future-agent")
+        )
+
+        #expect(prompt == "/crow-review-pr \(Self.prURL)")
+    }
+}


### PR DESCRIPTION
## Summary

- Lets users pick Cursor as the agent for review sessions (per #422's per-action picker) and have the review actually launch instead of erroring in the terminal.
- `CursorAgent.autoLaunchCommand` now handles `.review` the same way it handles `.job`: reads `.crow-review-prompt.md` on first launch, falls back to a bare `agent` on resume. `.manager` still returns `nil` (unchanged contract).
- `SessionService.buildReviewPrompt` is now agent-aware. Claude Code keeps the terse `/crow-review-pr <URL>` slash command and resolves it via its SKILL engine. Cursor gets the SKILL body inlined with `$ARGUMENTS` substituted to the PR URL and the attribution swapped to "via Cursor" — no second-file indirection, no slash-command engine required.

## Why this approach

Cursor's `agent` CLI doesn't have a slash-command / skill engine like Claude Code, so we can't reuse the one-liner. But the existing `skills/crow-review-pr/SKILL.md` is already structured as a self-contained instruction document — once `$ARGUMENTS` is expanded, it works as a plain prompt. Inlining keeps the design symmetric (both agents read the same prompt file path, gated by `reviewPromptDispatched`) without forking the review instructions into a second source of truth.

The `.claude/skills/crow-review-pr/` copy in the clone stays — it's harmless when Cursor runs and still useful if the user later switches the review agent back to Claude Code in the same clone.

## Test plan

- [x] `swift build --arch arm64` — clean build.
- [x] `swift test --arch arm64 --filter CursorAgent` (in `Packages/CrowCursor`) — 9/9 pass, including new `autoLaunchCommandReviewSessionFirstLaunch`, `autoLaunchCommandReviewSessionSubsequentLaunch`, and `autoLaunchCommandManagerSessionUnsupported` cases.
- [x] `swift test --arch arm64 --filter AppConfigAgentKind` (in `Packages/CrowCore`) — 9/9 pass; per-action override mechanism unchanged.
- [ ] Manual: Settings → Agents → set "Agent for reviews" = Cursor. From Reviews board, launch a review on a real PR; expect the Cursor TUI to come up with the expanded prompt as argv, not the "cannot launch a review session" warning.
- [ ] Manual: switch back to Claude Code, launch a review on a different PR; expect the `/crow-review-pr <URL>` slash-command path unchanged.

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)