### PR TITLE
Add 4h and 8h retention presets to cleanup settings

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -258,6 +258,8 @@ public struct SettingsView: View {
 
                 Picker("Retention", selection: $config.cleanup.retentionHours) {
                     Text("1 hour").tag(1)
+                    Text("4 hours").tag(4)
+                    Text("8 hours").tag(8)
                     Text("1 day").tag(24)
                     Text("3 days").tag(72)
                     Text("7 days").tag(168)


### PR DESCRIPTION
## Summary
- Adds **4 hours** and **8 hours** options to the Session Cleanup retention dropdown in Settings → General.
- Fills the gap between 1 hour and 1 day for typical workday use.
- No config or cleanup-logic changes needed: `CleanupConfig.retentionHours` is already `Int`, and `sessionsEligibleForCleanup` already handles arbitrary integer hours.

Closes #436

## Test plan
- [ ] Open Settings → General → Session Cleanup; confirm dropdown reads: 1 hour, 4 hours, 8 hours, 1 day, 3 days, 7 days, 30 days
- [ ] Select "4 hours" → quit/relaunch → confirm `config.json` shows `cleanup.retentionHours: 4`
- [ ] Select "8 hours" → confirm `config.json` shows `cleanup.retentionHours: 8`
- [ ] Existing legacy values (e.g. 24) still load and work

🐦‍⬛ Generated with Claude Code, orchestrated by Crow