### PR TITLE
Generalize crow-workspace agent launch dispatch (CROW-440)

### DIFF
--- a/Resources/crow-batch-workspace-SKILL.md.template
+++ b/Resources/crow-batch-workspace-SKILL.md.template
@@ -115,7 +115,6 @@ Then, in a **single message**, fire one Bash tool call per workspace:
   --ticket-title "{ticket_title}" \
   --ticket-number {ticket_number} \
   --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
-  --claude-binary "$(which claude)" \
   --primary
 ```
 

--- a/Resources/crow-workspace-SKILL.md.template
+++ b/Resources/crow-workspace-SKILL.md.template
@@ -214,6 +214,8 @@ PROMPT
 
 #### Step 2: Run setup.sh
 
+`setup.sh` resolves the coding agent automatically from `{devRoot}/.claude/config.json`: it prefers `agentsByKind["work"]`, falls back to `defaultAgentKind`, and finally to `claude-code`. Pass `--agent-kind <claude-code|cursor|codex>` only if you need to override the configured choice for a single invocation. Use `--agent-binary <path>` to pin the binary explicitly.
+
 ```bash
 .claude/skills/crow-workspace/setup.sh \
   --dev-root "{devRoot}" \
@@ -230,7 +232,6 @@ PROMPT
   --ticket-title "{ticket_title}" \
   --ticket-number {ticket_number} \
   --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
-  --claude-binary "$(which claude)" \
   --primary
 ```
 

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -535,6 +535,7 @@ launch_claude_code() {
       "/opt/homebrew/bin/claude") || \
       die "launch_agent" "claude binary not found at PATH or known locations; provide --agent-binary"
   fi
+  log "Resolved claude-code binary: $bin"
   local send_text="cd $WORKTREE_PATH && $bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
   create_agent_terminal "Claude Code" "$send_text"
 }
@@ -553,6 +554,7 @@ launch_cursor() {
       "$HOME/.local/bin/agent") || \
       die "launch_agent" "cursor binary not found at PATH or known locations; provide --agent-binary"
   fi
+  log "Resolved cursor binary: $bin"
   local send_text="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\"\\n"
   create_agent_terminal "Cursor" "$send_text"
 }
@@ -570,6 +572,7 @@ launch_codex() {
       "$HOME/.local/bin/codex") || \
       die "launch_agent" "codex binary not found at PATH or known locations; provide --agent-binary"
   fi
+  log "Resolved codex binary: $bin"
   log "Note: Codex has no prompt-argv form; prompt file is at $prompt_path (paste manually if needed)."
   local send_text="cd $WORKTREE_PATH && $bin\\n"
   create_agent_terminal "OpenAI Codex" "$send_text"

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -34,6 +34,8 @@ PR_URL=""
 PR_BRANCH=""
 PROMPT_CONTENT=""
 CLAUDE_BINARY=""
+AGENT_BINARY=""
+AGENT_KIND=""
 SESSION_ID=""
 PRIMARY=false
 SKIP_LAUNCH=false
@@ -68,6 +70,32 @@ die() {
   exit 1
 }
 
+# Resolve the agent kind for a given SessionKind raw value, mirroring
+# AppConfig.agentKind(for:) in Packages/CrowCore — agentsByKind[<kind>]
+# wins, falling back to defaultAgentKind, falling back to claude-code.
+# The crow-workspace skill is for `work` (coding) sessions.
+read_agent_kind_from_config() {
+  local session_kind="${1:-work}"
+  local cfg="$DEV_ROOT/.claude/config.json"
+  [[ -f "$cfg" ]] || { echo "claude-code"; return; }
+
+  local flat
+  flat=$(tr -d '\n' < "$cfg")
+
+  local override
+  override=$(printf '%s' "$flat" \
+    | grep -oE "\"agentsByKind\"[[:space:]]*:[[:space:]]*\{[^}]*\}" \
+    | grep -oE "\"$session_kind\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" \
+    | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+  if [[ -n "$override" ]]; then echo "$override"; return; fi
+
+  local def
+  def=$(printf '%s' "$flat" \
+    | grep -oE "\"defaultAgentKind\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" \
+    | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+  echo "${def:-claude-code}"
+}
+
 # ─── Argument Parsing ────────────────────────────────────────────────────────
 
 usage() {
@@ -95,10 +123,16 @@ Optional:
   --pr-url <url>             Existing PR URL
   --pr-branch <branch>       Existing PR branch name
   --prompt-content <path>    Path to LLM-written prompt file
-  --claude-binary <path>     Full path to claude binary
+  --agent-kind <kind>        Coding agent: claude-code | cursor | codex.
+                             Defaults to agentsByKind["work"] then
+                             defaultAgentKind from {devRoot}/.claude/config.json
+                             (final fallback: claude-code).
+  --agent-binary <path>      Full path to the selected agent's binary.
+  --claude-binary <path>     [deprecated alias] Same as --agent-binary; only
+                             honored when the resolved agent is claude-code.
   --session-id <uuid>        Existing session ID (for secondary repos)
   --primary                  Mark worktree as primary
-  --skip-launch              Skip Claude Code launch
+  --skip-launch              Skip agent launch
   --skip-assign              Skip auto-assign
   --skip-project-status      Skip project status mutation
   --help                     Show this help
@@ -127,6 +161,8 @@ parse_args() {
       --pr-url)            PR_URL="$2"; shift 2 ;;
       --pr-branch)         PR_BRANCH="$2"; shift 2 ;;
       --prompt-content)    PROMPT_CONTENT="$2"; shift 2 ;;
+      --agent-kind)        AGENT_KIND="$2"; shift 2 ;;
+      --agent-binary)      AGENT_BINARY="$2"; shift 2 ;;
       --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
       --session-id)        SESSION_ID="$2"; shift 2 ;;
       --primary)           PRIMARY=true; shift ;;
@@ -153,6 +189,14 @@ parse_args() {
 
   if [[ ${#missing[@]} -gt 0 ]]; then
     die "parse_args" "Missing required arguments: ${missing[*]}"
+  fi
+
+  # Validate --agent-kind early so bad values fail fast rather than at launch.
+  if [[ -n "$AGENT_KIND" ]]; then
+    case "$AGENT_KIND" in
+      claude-code|cursor|codex) ;;
+      *) die "parse_args" "Unknown --agent-kind: $AGENT_KIND (expected claude-code | cursor | codex)" ;;
+    esac
   fi
 }
 
@@ -425,29 +469,34 @@ write_prompt() {
   fi
 }
 
-# ─── Launch Claude Code ─────────────────────────────────────────────────────
+# ─── Launch Agent ───────────────────────────────────────────────────────────
+#
+# Dispatcher + per-agent launchers. Each sub-launcher knows its own binary,
+# flags, and terminal name; the shared create_agent_terminal helper creates
+# the terminal, waits for the shell, and pastes the launch command. Mirrors
+# the corresponding Swift CodingAgent.autoLaunchCommand for each kind.
 
-launch_claude() {
-  if [[ "$SKIP_LAUNCH" == "true" ]]; then
-    log "Skipping Claude Code launch (--skip-launch)"
-    return
-  fi
+resolve_binary() {
+  local token="$1"; shift
+  local p
+  for p in "$@"; do
+    [[ -n "$p" && -x "$p" ]] && { echo "$p"; return 0; }
+  done
+  p=$(command -v "$token" 2>/dev/null) || true
+  [[ -n "$p" ]] && { echo "$p"; return 0; }
+  return 1
+}
 
-  # Resolve claude binary
-  local claude_bin="$CLAUDE_BINARY"
-  if [[ -z "$claude_bin" ]]; then
-    claude_bin=$(command -v claude 2>/dev/null) || true
-    if [[ -z "$claude_bin" ]]; then
-      die "launch_claude" "claude binary not found — provide --claude-binary"
-    fi
-  fi
+# Shared terminal creation + send-launch path. Sets TERMINAL_ID.
+create_agent_terminal() {
+  local terminal_name="$1"
+  local send_text="$2"
 
-  # Create terminal
-  log "Creating terminal..."
+  log "Creating terminal '$terminal_name'..."
   local term_result
   if ! term_result=$(crow new-terminal --session "$SESSION_ID" \
     --cwd "$WORKTREE_PATH" \
-    --name "Claude Code" \
+    --name "$terminal_name" \
     --managed 2>&1); then
     die "new_terminal" "crow new-terminal failed: $term_result"
   fi
@@ -463,22 +512,97 @@ launch_claude() {
     || log "Warning: select-session failed"
 
   # Wait for the shell to initialize in the new terminal.
-  # The terminal surface is pre-initialized by crow new-terminal, but the
-  # shell process needs time to start and display its prompt.
   log "Waiting for shell to initialize..."
   sleep 3
 
-  # Build the prompt file path
-  local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
-
-  # Send launch command
-  log "Launching Claude Code..."
-  local send_text="cd $WORKTREE_PATH && $claude_bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
+  log "Launching $terminal_name..."
   if ! crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1; then
     die "send_launch" "crow send failed"
   fi
+  log "$terminal_name launched"
+}
 
-  log "Claude Code launched"
+launch_claude_code() {
+  local prompt_path="$1"
+  local override_bin="$2"
+  local bin
+  if [[ -n "$override_bin" ]]; then
+    bin="$override_bin"
+  else
+    bin=$(resolve_binary "claude" \
+      "$HOME/.local/bin/claude" \
+      "/usr/local/bin/claude" \
+      "/opt/homebrew/bin/claude") || \
+      die "launch_agent" "claude binary not found at PATH or known locations; provide --agent-binary"
+  fi
+  local send_text="cd $WORKTREE_PATH && $bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
+  create_agent_terminal "Claude Code" "$send_text"
+}
+
+launch_cursor() {
+  local prompt_path="$1"
+  local override_bin="$2"
+  local bin
+  if [[ -n "$override_bin" ]]; then
+    bin="$override_bin"
+  else
+    # Cursor's CLI binary is named `agent`, not `cursor`.
+    bin=$(resolve_binary "agent" \
+      "/opt/homebrew/bin/agent" \
+      "/usr/local/bin/agent" \
+      "$HOME/.local/bin/agent") || \
+      die "launch_agent" "cursor binary not found at PATH or known locations; provide --agent-binary"
+  fi
+  local send_text="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\"\\n"
+  create_agent_terminal "Cursor" "$send_text"
+}
+
+launch_codex() {
+  local prompt_path="$1"
+  local override_bin="$2"
+  local bin
+  if [[ -n "$override_bin" ]]; then
+    bin="$override_bin"
+  else
+    bin=$(resolve_binary "codex" \
+      "/opt/homebrew/bin/codex" \
+      "/usr/local/bin/codex" \
+      "$HOME/.local/bin/codex") || \
+      die "launch_agent" "codex binary not found at PATH or known locations; provide --agent-binary"
+  fi
+  log "Note: Codex has no prompt-argv form; prompt file is at $prompt_path (paste manually if needed)."
+  local send_text="cd $WORKTREE_PATH && $bin\\n"
+  create_agent_terminal "OpenAI Codex" "$send_text"
+}
+
+launch_agent() {
+  if [[ "$SKIP_LAUNCH" == "true" ]]; then
+    log "Skipping agent launch (--skip-launch)"
+    return
+  fi
+
+  # Resolve agent kind: --agent-kind > config > claude-code fallback.
+  local kind="$AGENT_KIND"
+  if [[ -z "$kind" ]]; then
+    kind=$(read_agent_kind_from_config "work")
+    log "Resolved agent kind from config: $kind"
+  else
+    log "Using agent kind from --agent-kind flag: $kind"
+  fi
+
+  local override_bin="$AGENT_BINARY"
+  if [[ -z "$override_bin" && "$kind" == "claude-code" && -n "$CLAUDE_BINARY" ]]; then
+    override_bin="$CLAUDE_BINARY"
+  fi
+
+  local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
+
+  case "$kind" in
+    claude-code) launch_claude_code "$prompt_path" "$override_bin" ;;
+    cursor)      launch_cursor "$prompt_path" "$override_bin" ;;
+    codex)       launch_codex "$prompt_path" "$override_bin" ;;
+    *) die "launch_agent" "Unknown agent kind: $kind (expected claude-code | cursor | codex)" ;;
+  esac
 }
 
 # ─── Result ──────────────────────────────────────────────────────────────────
@@ -506,7 +630,7 @@ main() {
   create_session
   github_ops
   write_prompt
-  launch_claude
+  launch_agent
   emit_result
 }
 

--- a/skills/crow-batch-workspace/SKILL.md
+++ b/skills/crow-batch-workspace/SKILL.md
@@ -115,7 +115,6 @@ Then, in a **single message**, fire one Bash tool call per workspace:
   --ticket-title "{ticket_title}" \
   --ticket-number {ticket_number} \
   --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
-  --claude-binary "$(which claude)" \
   --primary
 ```
 

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -259,6 +259,8 @@ PROMPT
 
 #### Step 2: Run setup.sh
 
+`setup.sh` resolves the coding agent automatically from `{devRoot}/.claude/config.json`: it prefers `agentsByKind["work"]`, falls back to `defaultAgentKind`, and finally to `claude-code`. Pass `--agent-kind <claude-code|cursor|codex>` only if you need to override the configured choice for a single invocation (e.g. for testing). The binary is looked up on PATH and in the standard install locations for the selected agent — pass `--agent-binary <path>` to pin it explicitly.
+
 ```bash
 .claude/skills/crow-workspace/setup.sh \
   --dev-root "{devRoot}" \
@@ -276,7 +278,6 @@ PROMPT
   --ticket-title "{ticket_title}" \
   --ticket-number {ticket_number} \
   --prompt-content "{devRoot}/.claude/prompts/crow-prompt-{session_name}.md" \
-  --claude-binary "$(which claude)" \
   --primary
 ```
 

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -624,6 +624,7 @@ launch_claude_code() {
       "/opt/homebrew/bin/claude") || \
       die "launch_agent" "claude binary not found at PATH or known locations; provide --agent-binary"
   fi
+  log "Resolved claude-code binary: $bin"
 
   # Build the agent launch command and hand it to crow at terminal-creation
   # time via --command. Crow holds the command and pastes it only once the
@@ -662,8 +663,12 @@ launch_cursor() {
       "$HOME/.local/bin/agent") || \
       die "launch_agent" "cursor binary not found at PATH or known locations; provide --agent-binary"
   fi
-  # Cursor: no --permission-mode, no --rc; pass the prompt as argv. Matches
-  # CursorAgent.autoLaunchCommand for the .work session kind.
+  log "Resolved cursor binary: $bin"
+  # Cursor: no --permission-mode, no --rc; pass the prompt as argv.
+  # This intentionally uses CursorAgent's .job/.review first-launch argv
+  # form (NOT the .work bare-`agent` form) so the unattended skill flow
+  # feeds the prompt at launch — same divergence-from-Swift-.work
+  # rationale that launch_claude_code uses for its prompt-argv form.
   local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
   create_agent_terminal "Cursor" "$launch_cmd"
 }
@@ -681,6 +686,7 @@ launch_codex() {
       "$HOME/.local/bin/codex") || \
       die "launch_agent" "codex binary not found at PATH or known locations; provide --agent-binary"
   fi
+  log "Resolved codex binary: $bin"
   # Codex has no prompt-argv form (matches OpenAICodexAgent.autoLaunchCommand
   # — bare `codex` only). The prompt file is still written; the user can
   # paste from it into the TUI.

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -34,6 +34,8 @@ PR_URL=""
 PR_BRANCH=""
 PROMPT_CONTENT=""
 CLAUDE_BINARY=""
+AGENT_BINARY=""
+AGENT_KIND=""
 SESSION_ID=""
 PRIMARY=false
 SKIP_LAUNCH=false
@@ -97,6 +99,34 @@ is_attribution_trailers_enabled() {
   return 0
 }
 
+# Resolve the agent kind for a given SessionKind raw value, mirroring
+# AppConfig.agentKind(for:) in Packages/CrowCore — agentsByKind[<kind>]
+# wins, falling back to defaultAgentKind, falling back to claude-code.
+# The crow-workspace skill is for `work` (coding) sessions.
+read_agent_kind_from_config() {
+  local session_kind="${1:-work}"
+  local cfg="$DEV_ROOT/.claude/config.json"
+  [[ -f "$cfg" ]] || { echo "claude-code"; return; }
+
+  local flat
+  flat=$(tr -d '\n' < "$cfg")
+
+  # agentsByKind["<kind>"]: find the agentsByKind object body, then the key.
+  local override
+  override=$(printf '%s' "$flat" \
+    | grep -oE "\"agentsByKind\"[[:space:]]*:[[:space:]]*\{[^}]*\}" \
+    | grep -oE "\"$session_kind\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" \
+    | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+  if [[ -n "$override" ]]; then echo "$override"; return; fi
+
+  # Fall back to defaultAgentKind.
+  local def
+  def=$(printf '%s' "$flat" \
+    | grep -oE "\"defaultAgentKind\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" \
+    | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+  echo "${def:-claude-code}"
+}
+
 die() {
   local step="$1" msg="$2"
   local partial=""
@@ -137,11 +167,17 @@ Optional:
   --pr-url <url>             Existing PR URL
   --pr-branch <branch>       Existing PR branch name
   --prompt-content <path>    Path to LLM-written prompt file
-  --claude-binary <path>     Full path to claude binary
+  --agent-kind <kind>        Coding agent: claude-code | cursor | codex.
+                             Defaults to agentsByKind["work"] then
+                             defaultAgentKind from {devRoot}/.claude/config.json
+                             (final fallback: claude-code).
+  --agent-binary <path>      Full path to the selected agent's binary.
+  --claude-binary <path>     [deprecated alias] Same as --agent-binary; only
+                             honored when the resolved agent is claude-code.
   --session-id <uuid>        Existing session ID (for secondary repos)
   --base-branch <branch>     Default base branch (auto-detected from origin/HEAD if omitted)
   --primary                  Mark worktree as primary
-  --skip-launch              Skip Claude Code launch
+  --skip-launch              Skip agent launch
   --skip-assign              Skip auto-assign
   --skip-project-status      Skip project status mutation
   --help                     Show this help
@@ -170,6 +206,8 @@ parse_args() {
       --pr-url)            PR_URL="$2"; shift 2 ;;
       --pr-branch)         PR_BRANCH="$2"; shift 2 ;;
       --prompt-content)    PROMPT_CONTENT="$2"; shift 2 ;;
+      --agent-kind)        AGENT_KIND="$2"; shift 2 ;;
+      --agent-binary)      AGENT_BINARY="$2"; shift 2 ;;
       --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
       --session-id)        SESSION_ID="$2"; shift 2 ;;
       --base-branch)       BASE_BRANCH="$2"; shift 2 ;;
@@ -197,6 +235,14 @@ parse_args() {
 
   if [[ ${#missing[@]} -gt 0 ]]; then
     die "parse_args" "Missing required arguments: ${missing[*]}"
+  fi
+
+  # Validate --agent-kind early so bad values fail fast rather than at launch.
+  if [[ -n "$AGENT_KIND" ]]; then
+    case "$AGENT_KIND" in
+      claude-code|cursor|codex) ;;
+      *) die "parse_args" "Unknown --agent-kind: $AGENT_KIND (expected claude-code | cursor | codex)" ;;
+    esac
   fi
 }
 
@@ -542,21 +588,41 @@ write_prompt() {
   fi
 }
 
-# ─── Launch Claude Code ─────────────────────────────────────────────────────
+# ─── Launch Agent ───────────────────────────────────────────────────────────
+#
+# Dispatcher + per-agent launchers. The dispatcher resolves the agent kind
+# (--agent-kind flag, then config.json, then claude-code default), invokes the
+# matching launch_<kind> sub-launcher to build the --command string and create
+# the terminal, then polls readiness centrally. Each sub-launcher mirrors the
+# corresponding Swift `CodingAgent.autoLaunchCommand` in Packages/Crow{Claude,
+# Cursor,Codex} so the skill and the in-app launch paths stay in agreement.
 
-launch_claude() {
-  if [[ "$SKIP_LAUNCH" == "true" ]]; then
-    log "Skipping Claude Code launch (--skip-launch)"
-    return
-  fi
+# Search a list of candidate paths and PATH for the first executable matching
+# $token (or full path). Echoes the resolved path, or empty on failure.
+# Usage: resolve_binary <token> <candidate1> [candidate2 ...]
+resolve_binary() {
+  local token="$1"; shift
+  local p
+  for p in "$@"; do
+    [[ -n "$p" && -x "$p" ]] && { echo "$p"; return 0; }
+  done
+  p=$(command -v "$token" 2>/dev/null) || true
+  [[ -n "$p" ]] && { echo "$p"; return 0; }
+  return 1
+}
 
-  # Resolve claude binary
-  local claude_bin="$CLAUDE_BINARY"
-  if [[ -z "$claude_bin" ]]; then
-    claude_bin=$(command -v claude 2>/dev/null) || true
-    if [[ -z "$claude_bin" ]]; then
-      die "launch_claude" "claude binary not found — provide --claude-binary"
-    fi
+launch_claude_code() {
+  local prompt_path="$1"
+  local override_bin="$2"   # from --agent-binary or legacy --claude-binary
+  local bin
+  if [[ -n "$override_bin" ]]; then
+    bin="$override_bin"
+  else
+    bin=$(resolve_binary "claude" \
+      "$HOME/.local/bin/claude" \
+      "/usr/local/bin/claude" \
+      "/opt/homebrew/bin/claude") || \
+      die "launch_agent" "claude binary not found at PATH or known locations; provide --agent-binary"
   fi
 
   # Build the agent launch command and hand it to crow at terminal-creation
@@ -569,7 +635,6 @@ launch_claude() {
   # The prompt stays in its file — `"$(cat $prompt_path)"` is expanded by the
   # TARGET shell at paste time, so the command sent over the socket is small
   # (no ARG_MAX / payload concern).
-  local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
   local rc_args=""
   if is_remote_control_enabled; then
     # Keep building --rc here: crow's resolveClaudeInCommand only injects
@@ -578,14 +643,63 @@ launch_claude() {
     rc_args=" --rc --name $(posix_quote "$SESSION_NAME")"
     log "Remote control enabled — launching with --rc --name '$SESSION_NAME'"
   fi
-  local launch_cmd="cd $WORKTREE_PATH && $claude_bin --permission-mode plan$rc_args \"\$(cat $prompt_path)\""
+  local launch_cmd="cd $WORKTREE_PATH && $bin --permission-mode plan$rc_args \"\$(cat $prompt_path)\""
+  create_agent_terminal "Claude Code" "$launch_cmd"
+}
 
-  # Create terminal with the launch command attached.
-  log "Creating terminal (deferred agent launch via --command)..."
+launch_cursor() {
+  local prompt_path="$1"
+  local override_bin="$2"
+  local bin
+  if [[ -n "$override_bin" ]]; then
+    bin="$override_bin"
+  else
+    # Cursor's CLI binary is named `agent`, not `cursor`. Candidate paths
+    # mirror CursorAgent.cursorBinaryCandidates in CrowCursor.
+    bin=$(resolve_binary "agent" \
+      "/opt/homebrew/bin/agent" \
+      "/usr/local/bin/agent" \
+      "$HOME/.local/bin/agent") || \
+      die "launch_agent" "cursor binary not found at PATH or known locations; provide --agent-binary"
+  fi
+  # Cursor: no --permission-mode, no --rc; pass the prompt as argv. Matches
+  # CursorAgent.autoLaunchCommand for the .work session kind.
+  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
+  create_agent_terminal "Cursor" "$launch_cmd"
+}
+
+launch_codex() {
+  local prompt_path="$1"
+  local override_bin="$2"
+  local bin
+  if [[ -n "$override_bin" ]]; then
+    bin="$override_bin"
+  else
+    bin=$(resolve_binary "codex" \
+      "/opt/homebrew/bin/codex" \
+      "/usr/local/bin/codex" \
+      "$HOME/.local/bin/codex") || \
+      die "launch_agent" "codex binary not found at PATH or known locations; provide --agent-binary"
+  fi
+  # Codex has no prompt-argv form (matches OpenAICodexAgent.autoLaunchCommand
+  # — bare `codex` only). The prompt file is still written; the user can
+  # paste from it into the TUI.
+  log "Note: Codex has no prompt-argv form; prompt file is at $prompt_path (paste manually if needed)."
+  local launch_cmd="cd $WORKTREE_PATH && $bin"
+  create_agent_terminal "OpenAI Codex" "$launch_cmd"
+}
+
+# Shared terminal creation + readiness polling, used by every launch_<kind>.
+# Sets TERMINAL_ID on success. Polls `crow list-terminals` for up to 15s.
+create_agent_terminal() {
+  local terminal_name="$1"
+  local launch_cmd="$2"
+
+  log "Creating terminal '$terminal_name' (deferred agent launch via --command)..."
   local term_result
   if ! term_result=$(crow new-terminal --session "$SESSION_ID" \
     --cwd "$WORKTREE_PATH" \
-    --name "Claude Code" \
+    --name "$terminal_name" \
     --managed \
     --command "$launch_cmd" 2>&1); then
     die "new_terminal" "crow new-terminal failed: $term_result"
@@ -620,7 +734,7 @@ launch_claude() {
     readiness=$(terminal_readiness "$TERMINAL_ID" "$lt_result")
     case "$readiness" in
       agentLaunched|shellReady)
-        log "Claude Code launched (readiness=$readiness)"
+        log "$terminal_name launched (readiness=$readiness)"
         return
         ;;
       failed|timedOut)
@@ -633,6 +747,39 @@ launch_claude() {
   done
   log "WARNING: agent launch not confirmed after 15s (last readiness='${readiness:-unknown}')." \
       "The workspace is set up; check the Crow terminal and use Retry if needed."
+}
+
+launch_agent() {
+  if [[ "$SKIP_LAUNCH" == "true" ]]; then
+    log "Skipping agent launch (--skip-launch)"
+    return
+  fi
+
+  # Resolve agent kind: explicit flag > config.json (agentsByKind["work"]
+  # then defaultAgentKind) > claude-code fallback.
+  local kind="$AGENT_KIND"
+  if [[ -z "$kind" ]]; then
+    kind=$(read_agent_kind_from_config "work")
+    log "Resolved agent kind from config: $kind"
+  else
+    log "Using agent kind from --agent-kind flag: $kind"
+  fi
+
+  # Pick the binary override. --agent-binary applies to any kind. The legacy
+  # --claude-binary alias only applies when the resolved kind is claude-code.
+  local override_bin="$AGENT_BINARY"
+  if [[ -z "$override_bin" && "$kind" == "claude-code" && -n "$CLAUDE_BINARY" ]]; then
+    override_bin="$CLAUDE_BINARY"
+  fi
+
+  local prompt_path="$DEV_ROOT/.claude/prompts/crow-prompt-$SESSION_NAME.md"
+
+  case "$kind" in
+    claude-code) launch_claude_code "$prompt_path" "$override_bin" ;;
+    cursor)      launch_cursor "$prompt_path" "$override_bin" ;;
+    codex)       launch_codex "$prompt_path" "$override_bin" ;;
+    *) die "launch_agent" "Unknown agent kind: $kind (expected claude-code | cursor | codex)" ;;
+  esac
 }
 
 # ─── Result ──────────────────────────────────────────────────────────────────
@@ -661,7 +808,7 @@ main() {
   write_settings_local
   github_ops
   write_prompt
-  launch_claude
+  launch_agent
   emit_result
 }
 


### PR DESCRIPTION
Closes #440

## Summary

`skills/crow-workspace/setup.sh` hardcoded Claude Code at every level
(binary lookup, launch flags, `--name "Claude Code"`, log messages), so
the Manager-driven `/crow-workspace` path ignored `defaultAgentKind`
and the per-action `agentsByKind` overrides from #421/#433. This made
the per-action setting toothless for the spawn path and is part of the
same theme as #427 and #424.

Refactors the launch step into a `launch_agent` dispatcher with three
sub-launchers:

- **Resolution** (matches `AppConfig.agentKind(for:)`):
  `--agent-kind` flag → `agentsByKind["work"]` → `defaultAgentKind` →
  `claude-code` fallback.
- **`launch_claude_code`** — preserves the existing `--permission-mode plan`
  + optional `--rc --name` + `cd … && claude … "$(cat prompt)"` form.
  Terminal name: "Claude Code".
- **`launch_cursor`** — binary `agent` (not `cursor`); passes prompt as
  argv; no `--permission-mode`/`--rc`. Terminal name: "Cursor".
- **`launch_codex`** — binary `codex`; bare launch (Codex CLI has no
  prompt-argv form). Terminal name: "OpenAI Codex".

Each sub-launcher mirrors the corresponding Swift
`CodingAgent.autoLaunchCommand` in `Packages/Crow{Claude,Cursor,Codex}`,
so the skill and in-app launch paths stay in agreement.

`--claude-binary` is kept as a back-compat alias for `--agent-binary`
(honored only when the resolved kind is `claude-code`), so existing
SKILL.md and crow-batch-workspace SKILL.md callers keep working.
Binary-not-found error now names the actual agent (`cursor binary not
found …` instead of `claude binary not found …`), per acceptance
criteria. Terminal name reflecting the agent also addresses the root
cause noted in #427.

Mirrored to `Resources/*.template` per the dual-source rule. SKILL.md
examples drop `--claude-binary` (PATH lookup is now agent-aware) and
gain a one-paragraph note about the new `--agent-kind` flag.

## Test plan
- [ ] `setup.sh --help` shows the new `--agent-kind` / `--agent-binary`
      flags and the deprecated `--claude-binary` alias.
- [ ] No-flag invocation with default config still launches Claude Code
      with `--permission-mode plan` and terminal labeled "Claude Code".
- [ ] Setting `{"defaultAgentKind": "cursor"}` in
      `{devRoot}/.claude/config.json` causes `/crow-workspace` to
      launch a terminal labeled "Cursor" running `agent "$(cat …)"`.
- [ ] `agentsByKind: {"work": "cursor"}` wins over a `claude-code`
      `defaultAgentKind` (override priority).
- [ ] `setup.sh … --agent-kind codex` wins over config; terminal
      labeled "OpenAI Codex" runs bare `codex`.
- [ ] Masking the `agent` binary from PATH while cursor is selected
      raises `cursor binary not found at PATH or known locations;
      provide --agent-binary`.
- [ ] `--skip-launch` still short-circuits cleanly with a JSON success.
- [ ] `swift build --arch arm64` still passes (no Swift code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)