### PR TITLE
Attribute Crow footers to the session's agent kind

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -16,6 +16,10 @@ public enum CrowAttribution {
     /// Placeholder in bundled SKILL bodies expanded by `expandSkillBody(_:agentKind:)`.
     public static let skillAgentPlaceholder = "{{CROW_AGENT_DISPLAY_NAME}}"
 
+    /// Bash parameter expansion for footers in skill `gh`/`glab` `--body` arguments.
+    public static let shellAgentDisplayNameExpression =
+        "${\(agentDisplayNameEnvironmentKey):-\(defaultAgentDisplayName)}"
+
     /// Intentional second source of truth: `AgentRegistry` is not populated in
     /// CrowCore-only unit tests, so known kinds resolve here before the registry.
     private static let knownDisplayNames: [String: String] = [
@@ -68,10 +72,11 @@ public enum CrowAttribution {
     /// Default ticket footer (Claude Code) — backward-compatible alias.
     public static var ticketMarkdownLink: String { ticketMarkdownLink() }
 
-    /// Substitute `$CROW_AGENT_DISPLAY_NAME`, legacy `{{…}}` placeholder, and `via Claude Code` segments.
+    /// Substitute shell env expressions, legacy `{{…}}` placeholder, and `via Claude Code` segments.
     public static func expandSkillBody(_ skillBody: String, agentKind: AgentKind) -> String {
         let name = agentDisplayName(for: agentKind)
         return skillBody
+            .replacingOccurrences(of: shellAgentDisplayNameExpression, with: name)
             .replacingOccurrences(of: "$\(agentDisplayNameEnvironmentKey)", with: name)
             .replacingOccurrences(of: skillAgentPlaceholder, with: name)
             .replacingOccurrences(of: "via Claude Code", with: "via \(name)")
@@ -86,8 +91,8 @@ public enum CrowAttribution {
     - `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
     - `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
 
-    **Always** use `$CROW_AGENT_DISPLAY_NAME` for the agent name in attribution footers.
-    If unset, fall back to `Claude Code`.
+    **Always** use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in attribution footers inside
+    double-quoted `gh`/`glab` arguments so the shell applies the default when unset.
 
     The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -96,7 +101,6 @@ public enum CrowAttribution {
     | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
     | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-    Replace `<agent>` with `$CROW_AGENT_DISPLAY_NAME` (or `Claude Code` if unset). Do not change the URL or wrap the line in extra formatting.
-
+    Replace `<agent>` with `${CROW_AGENT_DISPLAY_NAME:-Claude Code}`. Do not change the URL or wrap the line in extra formatting.
     """
 }

--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -1,11 +1,98 @@
 import Foundation
 
+/// Canonical Crow attribution footers for GitHub/GitLab artifacts and skill instructions.
 public enum CrowAttribution {
     public static let repoURL = "https://github.com/radiusmethod/crow"
 
-    public static let reviewMarkdownLink =
-        "[🐦‍⬛ Reviewed by Crow via Claude Code](\(repoURL))"
+    /// Human-readable agent label when kind/env is unknown (legacy installs).
+    public static let defaultAgentDisplayName = "Claude Code"
 
-    public static let ticketMarkdownLink =
-        "[🐦‍⬛ Created with Crow via Claude Code](\(repoURL))"
+    /// Raw agent id injected into managed terminals (`claude-code`, `cursor`, `codex`, …).
+    public static let agentKindEnvironmentKey = "CROW_AGENT_KIND"
+
+    /// Human-readable agent label injected into managed terminals.
+    public static let agentDisplayNameEnvironmentKey = "CROW_AGENT_DISPLAY_NAME"
+
+    /// Placeholder in bundled SKILL bodies expanded by `expandSkillBody(_:agentKind:)`.
+    public static let skillAgentPlaceholder = "{{CROW_AGENT_DISPLAY_NAME}}"
+
+    private static let knownDisplayNames: [String: String] = [
+        AgentKind.claudeCode.rawValue: "Claude Code",
+        AgentKind.cursor.rawValue: "Cursor",
+        AgentKind.codex.rawValue: "OpenAI Codex",
+    ]
+
+    /// Resolve the display name for `agentKind`, falling back to `defaultAgentDisplayName`.
+    public static func agentDisplayName(for agentKind: AgentKind?) -> String {
+        guard let agentKind else { return defaultAgentDisplayName }
+        if let known = knownDisplayNames[agentKind.rawValue] { return known }
+        let registryName = agentKind.displayName
+        return registryName == agentKind.rawValue ? defaultAgentDisplayName : registryName
+    }
+
+    /// Read `CROW_AGENT_DISPLAY_NAME` or map `CROW_AGENT_KIND`; default to Claude Code.
+    public static func agentDisplayName(fromEnvironment environment: [String: String]?) -> String {
+        guard let environment else { return defaultAgentDisplayName }
+        if let explicit = environment[agentDisplayNameEnvironmentKey],
+           !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return explicit
+        }
+        if let raw = environment[agentKindEnvironmentKey],
+           !raw.isEmpty {
+            return agentDisplayName(for: AgentKind(rawValue: raw))
+        }
+        return defaultAgentDisplayName
+    }
+
+    /// Environment entries to inject when spawning a managed terminal.
+    public static func environmentEntries(for agentKind: AgentKind) -> [String: String] {
+        [
+            agentKindEnvironmentKey: agentKind.rawValue,
+            agentDisplayNameEnvironmentKey: agentDisplayName(for: agentKind),
+        ]
+    }
+
+    public static func reviewMarkdownLink(agentDisplayName: String = defaultAgentDisplayName) -> String {
+        "[🐦‍⬛ Reviewed by Crow via \(agentDisplayName)](\(repoURL))"
+    }
+
+    public static func ticketMarkdownLink(agentDisplayName: String = defaultAgentDisplayName) -> String {
+        "[🐦‍⬛ Created with Crow via \(agentDisplayName)](\(repoURL))"
+    }
+
+    /// Default review footer (Claude Code) — backward-compatible alias.
+    public static var reviewMarkdownLink: String { reviewMarkdownLink() }
+
+    /// Default ticket footer (Claude Code) — backward-compatible alias.
+    public static var ticketMarkdownLink: String { ticketMarkdownLink() }
+
+    /// Substitute `{{CROW_AGENT_DISPLAY_NAME}}` and legacy `via Claude Code` segments.
+    public static func expandSkillBody(_ skillBody: String, agentKind: AgentKind) -> String {
+        let name = agentDisplayName(for: agentKind)
+        return skillBody
+            .replacingOccurrences(of: skillAgentPlaceholder, with: name)
+            .replacingOccurrences(of: "via Claude Code", with: "via \(name)")
+    }
+
+    /// Shared attribution rules copied into `.claude/skills/crow-attribution/FOOTER.md`.
+    public static let sharedFooterInstructions: String = """
+    # Crow Attribution Footers
+
+    Crow injects these environment variables into every managed terminal:
+
+    - `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
+    - `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
+
+    **Always** use `$CROW_AGENT_DISPLAY_NAME` for the agent name in attribution footers.
+    If unset, fall back to `Claude Code`.
+
+    The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
+
+    | Artifact | Footer |
+    |----------|--------|
+    | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
+    | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
+
+    Replace `<agent>` with `$CROW_AGENT_DISPLAY_NAME` (or `Claude Code` if unset). Do not change the URL or wrap the line in extra formatting.
+    """
 }

--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -16,6 +16,8 @@ public enum CrowAttribution {
     /// Placeholder in bundled SKILL bodies expanded by `expandSkillBody(_:agentKind:)`.
     public static let skillAgentPlaceholder = "{{CROW_AGENT_DISPLAY_NAME}}"
 
+    /// Intentional second source of truth: `AgentRegistry` is not populated in
+    /// CrowCore-only unit tests, so known kinds resolve here before the registry.
     private static let knownDisplayNames: [String: String] = [
         AgentKind.claudeCode.rawValue: "Claude Code",
         AgentKind.cursor.rawValue: "Cursor",
@@ -95,5 +97,6 @@ public enum CrowAttribution {
     | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
     Replace `<agent>` with `$CROW_AGENT_DISPLAY_NAME` (or `Claude Code` if unset). Do not change the URL or wrap the line in extra formatting.
+
     """
 }

--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -66,10 +66,11 @@ public enum CrowAttribution {
     /// Default ticket footer (Claude Code) — backward-compatible alias.
     public static var ticketMarkdownLink: String { ticketMarkdownLink() }
 
-    /// Substitute `{{CROW_AGENT_DISPLAY_NAME}}` and legacy `via Claude Code` segments.
+    /// Substitute `$CROW_AGENT_DISPLAY_NAME`, legacy `{{…}}` placeholder, and `via Claude Code` segments.
     public static func expandSkillBody(_ skillBody: String, agentKind: AgentKind) -> String {
         let name = agentDisplayName(for: agentKind)
         return skillBody
+            .replacingOccurrences(of: "$\(agentDisplayNameEnvironmentKey)", with: name)
             .replacingOccurrences(of: skillAgentPlaceholder, with: name)
             .replacingOccurrences(of: "via Claude Code", with: "via \(name)")
     }

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -6,9 +6,14 @@ import Testing
     #expect(CrowAttribution.repoURL == "https://github.com/radiusmethod/crow")
 }
 
-@Test func crowAttributionReviewLinkIsCanonical() {
+@Test func crowAttributionReviewLinkDefaultIsClaudeCode() {
     #expect(CrowAttribution.reviewMarkdownLink ==
             "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)")
+}
+
+@Test func crowAttributionReviewLinkForCursor() {
+    #expect(CrowAttribution.reviewMarkdownLink(agentDisplayName: "Cursor") ==
+            "[🐦‍⬛ Reviewed by Crow via Cursor](https://github.com/radiusmethod/crow)")
 }
 
 @Test func crowAttributionReviewLinkEmbedsRepoURL() {
@@ -20,9 +25,14 @@ import Testing
     #expect(!CrowAttribution.reviewMarkdownLink.lowercased().contains("corveil"))
 }
 
-@Test func crowAttributionTicketLinkIsCanonical() {
+@Test func crowAttributionTicketLinkDefaultIsClaudeCode() {
     #expect(CrowAttribution.ticketMarkdownLink ==
             "[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)")
+}
+
+@Test func crowAttributionTicketLinkForCodex() {
+    #expect(CrowAttribution.ticketMarkdownLink(agentDisplayName: "OpenAI Codex") ==
+            "[🐦‍⬛ Created with Crow via OpenAI Codex](https://github.com/radiusmethod/crow)")
 }
 
 @Test func crowAttributionTicketLinkEmbedsRepoURL() {
@@ -32,4 +42,44 @@ import Testing
 @Test func crowAttributionTicketLinkContainsNoForkReferences() {
     #expect(!CrowAttribution.ticketMarkdownLink.contains("nicholasgasior"))
     #expect(!CrowAttribution.ticketMarkdownLink.lowercased().contains("corveil"))
+}
+
+@Test func crowAttributionAgentDisplayNameKnownKinds() {
+    #expect(CrowAttribution.agentDisplayName(for: .claudeCode) == "Claude Code")
+    #expect(CrowAttribution.agentDisplayName(for: .cursor) == "Cursor")
+    #expect(CrowAttribution.agentDisplayName(for: .codex) == "OpenAI Codex")
+    #expect(CrowAttribution.agentDisplayName(for: nil) == "Claude Code")
+}
+
+@Test func crowAttributionReadsDisplayNameFromEnvironment() {
+    let env = [
+        CrowAttribution.agentDisplayNameEnvironmentKey: "Cursor",
+        CrowAttribution.agentKindEnvironmentKey: "claude-code",
+    ]
+    #expect(CrowAttribution.agentDisplayName(fromEnvironment: env) == "Cursor")
+}
+
+@Test func crowAttributionMapsKindFromEnvironment() {
+    let env = [CrowAttribution.agentKindEnvironmentKey: "cursor"]
+    #expect(CrowAttribution.agentDisplayName(fromEnvironment: env) == "Cursor")
+}
+
+@Test func crowAttributionEnvironmentEntries() {
+    let entries = CrowAttribution.environmentEntries(for: .cursor)
+    #expect(entries[CrowAttribution.agentKindEnvironmentKey] == "cursor")
+    #expect(entries[CrowAttribution.agentDisplayNameEnvironmentKey] == "Cursor")
+}
+
+@Test func crowAttributionExpandSkillBodySubstitutesPlaceholder() {
+    let body = "Footer: \(CrowAttribution.skillAgentPlaceholder)"
+    let expanded = CrowAttribution.expandSkillBody(body, agentKind: .cursor)
+    #expect(expanded == "Footer: Cursor")
+    #expect(!expanded.contains(CrowAttribution.skillAgentPlaceholder))
+}
+
+@Test func crowAttributionExpandSkillBodyReplacesLegacyClaudeCodeWording() {
+    let body = "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)"
+    let expanded = CrowAttribution.expandSkillBody(body, agentKind: .codex)
+    #expect(expanded.contains("via OpenAI Codex"))
+    #expect(!expanded.contains("via Claude Code"))
 }

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -70,11 +70,17 @@ import Testing
     #expect(entries[CrowAttribution.agentDisplayNameEnvironmentKey] == "Cursor")
 }
 
-@Test func crowAttributionExpandSkillBodySubstitutesEnvVar() {
+@Test func crowAttributionExpandSkillBodySubstitutesShellExpression() {
+    let body = "Footer: \(CrowAttribution.shellAgentDisplayNameExpression)"
+    let expanded = CrowAttribution.expandSkillBody(body, agentKind: .cursor)
+    #expect(expanded == "Footer: Cursor")
+    #expect(!expanded.contains(CrowAttribution.shellAgentDisplayNameExpression))
+}
+
+@Test func crowAttributionExpandSkillBodySubstitutesBareEnvVar() {
     let body = "Footer: $\(CrowAttribution.agentDisplayNameEnvironmentKey)"
     let expanded = CrowAttribution.expandSkillBody(body, agentKind: .cursor)
     #expect(expanded == "Footer: Cursor")
-    #expect(!expanded.contains("$" + CrowAttribution.agentDisplayNameEnvironmentKey))
 }
 
 @Test func crowAttributionExpandSkillBodySubstitutesLegacyPlaceholder() {

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -90,3 +90,23 @@ import Testing
     #expect(expanded.contains("via OpenAI Codex"))
     #expect(!expanded.contains("via Claude Code"))
 }
+
+@Test func crowAttributionSharedFooterMatchesRepoFooterFile() throws {
+    var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    var found: URL?
+    for _ in 0..<10 {
+        let candidate = dir.appendingPathComponent("skills/crow-attribution/FOOTER.md")
+        if FileManager.default.fileExists(atPath: candidate.path) {
+            found = candidate
+            break
+        }
+        dir = dir.deletingLastPathComponent()
+    }
+    let footerURL = try #require(found)
+    let file = try String(contentsOf: footerURL, encoding: .utf8)
+    let swift = CrowAttribution.sharedFooterInstructions
+    #expect(
+        file == swift,
+        "skills/crow-attribution/FOOTER.md (\(file.count) bytes at \(footerURL.path)) must match CrowAttribution.sharedFooterInstructions (\(swift.count) bytes)"
+    )
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -70,7 +70,14 @@ import Testing
     #expect(entries[CrowAttribution.agentDisplayNameEnvironmentKey] == "Cursor")
 }
 
-@Test func crowAttributionExpandSkillBodySubstitutesPlaceholder() {
+@Test func crowAttributionExpandSkillBodySubstitutesEnvVar() {
+    let body = "Footer: $\(CrowAttribution.agentDisplayNameEnvironmentKey)"
+    let expanded = CrowAttribution.expandSkillBody(body, agentKind: .cursor)
+    #expect(expanded == "Footer: Cursor")
+    #expect(!expanded.contains("$" + CrowAttribution.agentDisplayNameEnvironmentKey))
+}
+
+@Test func crowAttributionExpandSkillBodySubstitutesLegacyPlaceholder() {
     let body = "Footer: \(CrowAttribution.skillAgentPlaceholder)"
     let expanded = CrowAttribution.expandSkillBody(body, agentKind: .cursor)
     #expect(expanded == "Footer: Cursor")

--- a/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift
@@ -97,6 +97,16 @@ import Testing
     #expect(!expanded.contains("via Claude Code"))
 }
 
+/// Normalize footer text so a trailing source-file newline does not fail the drift
+/// guard when the Swift multiline literal omits the closing-delimiter newline.
+private func normalizedFooterText(_ text: String) -> String {
+    var trimmed = text
+    while trimmed.hasSuffix("\n") || trimmed.hasSuffix("\r") {
+        trimmed.removeLast()
+    }
+    return trimmed + "\n"
+}
+
 @Test func crowAttributionSharedFooterMatchesRepoFooterFile() throws {
     var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
     var found: URL?
@@ -112,7 +122,7 @@ import Testing
     let file = try String(contentsOf: footerURL, encoding: .utf8)
     let swift = CrowAttribution.sharedFooterInstructions
     #expect(
-        file == swift,
-        "skills/crow-attribution/FOOTER.md (\(file.count) bytes at \(footerURL.path)) must match CrowAttribution.sharedFooterInstructions (\(swift.count) bytes)"
+        normalizedFooterText(file) == normalizedFooterText(swift),
+        "skills/crow-attribution/FOOTER.md at \(footerURL.path) must match CrowAttribution.sharedFooterInstructions"
     )
 }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
@@ -29,6 +29,10 @@ if [ -z "${CROW_SENTINEL:-}" ]; then
 fi
 export CROW_SENTINEL
 
+# Agent attribution (issue #443). Crow sets these via tmux new-window -e.
+if [ -n "${CROW_AGENT_KIND:-}" ]; then export CROW_AGENT_KIND; fi
+if [ -n "${CROW_AGENT_DISPLAY_NAME:-}" ]; then export CROW_AGENT_DISPLAY_NAME; fi
+
 # CROW_WRAPPER_LOG is optional. Default to /dev/null so the helper is always
 # safe to call without an unset-var guard. Issue #256.
 CROW_WRAPPER_LOG="${CROW_WRAPPER_LOG:-/dev/null}"

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -179,6 +179,7 @@ public final class TmuxBackend {
         cwd: String,
         command: String?,
         trackReadiness: Bool,
+        agentKind: AgentKind? = nil,
         newWindowTimeout: TimeInterval = TmuxController.defaultTimeout
     ) throws -> TmuxBinding {
         precondition(!tmuxBinary.isEmpty, "TmuxBackend.configure(...) must be called first")
@@ -214,6 +215,11 @@ public final class TmuxBackend {
             "CROW_SENTINEL": sentinelPath,
             "CROW_WRAPPER_LOG": wrapperLog,
         ]
+        if let agentKind {
+            for (key, value) in CrowAttribution.environmentEntries(for: agentKind) {
+                env[key] = value
+            }
+        }
         if !cwd.isEmpty { env["PWD"] = cwd }
 
         let windowIndex = try ctrl.newWindow(

--- a/Resources/crow-attribution-FOOTER.md.template
+++ b/Resources/crow-attribution-FOOTER.md.template
@@ -5,8 +5,8 @@ Crow injects these environment variables into every managed terminal:
 - `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
 - `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
 
-**Always** use `$CROW_AGENT_DISPLAY_NAME` for the agent name in attribution footers.
-If unset, fall back to `Claude Code`.
+**Always** use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in attribution footers inside
+double-quoted `gh`/`glab` arguments so the shell applies the default when unset.
 
 The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -15,4 +15,4 @@ The link target is always `https://github.com/radiusmethod/crow` — never a for
 | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
 | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-Replace `<agent>` with `$CROW_AGENT_DISPLAY_NAME` (or `Claude Code` if unset). Do not change the URL or wrap the line in extra formatting.
+Replace `<agent>` with `${CROW_AGENT_DISPLAY_NAME:-Claude Code}`. Do not change the URL or wrap the line in extra formatting.

--- a/Resources/crow-attribution-FOOTER.md.template
+++ b/Resources/crow-attribution-FOOTER.md.template
@@ -1,0 +1,18 @@
+# Crow Attribution Footers
+
+Crow injects these environment variables into every managed terminal:
+
+- `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
+- `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
+
+**Always** use `$CROW_AGENT_DISPLAY_NAME` for the agent name in attribution footers.
+If unset, fall back to `Claude Code`.
+
+The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
+
+| Artifact | Footer |
+|----------|--------|
+| Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
+| Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
+
+Replace `<agent>` with `$CROW_AGENT_DISPLAY_NAME` (or `Claude Code` if unset). Do not change the URL or wrap the line in extra formatting.

--- a/Resources/crow-create-ticket-SKILL.md.template
+++ b/Resources/crow-create-ticket-SKILL.md.template
@@ -63,8 +63,10 @@ Extract the title (required) and optional body from `$ARGUMENTS` per the **Argum
 rules above. If there is no usable title, ask the user for one and stop until provided.
 
 The body is the text the user provided (or empty). It MUST end with the Crow
-attribution footer (see **Step 4b**): a blank line, then exactly
-`[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)`.
+attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
+a blank line, then
+`[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)`
+(use `Claude Code` if `$CROW_AGENT_DISPLAY_NAME` is unset).
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 
@@ -109,7 +111,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -122,7 +124,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -130,14 +132,15 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
 
 ### Step 4b: Attribution (REQUIRED)
 
-The body passed to `gh issue create --body` / `glab issue create --description` MUST
-end with a blank line followed by exactly this line:
+See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body passed to
+`gh issue create --body` / `glab issue create --description` MUST end with a blank line
+followed by:
 
 ```
-[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
 ```
 
-- Do not modify the link text.
+- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/Resources/crow-create-ticket-SKILL.md.template
+++ b/Resources/crow-create-ticket-SKILL.md.template
@@ -65,8 +65,8 @@ rules above. If there is no usable title, ask the user for one and stop until pr
 The body is the text the user provided (or empty). It MUST end with the Crow
 attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
 a blank line, then
-`[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)`
-(use `Claude Code` if `$CROW_AGENT_DISPLAY_NAME` is unset).
+`[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)`
+(shell applies `Claude Code` when the variable is unset).
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 

--- a/Resources/crow-create-ticket-SKILL.md.template
+++ b/Resources/crow-create-ticket-SKILL.md.template
@@ -111,7 +111,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -124,7 +124,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -137,10 +137,10 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body pas
 followed by:
 
 ```
-[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
+- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -131,18 +131,19 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
 
-The review body passed to `gh pr review --body` MUST end with a blank line followed by exactly this line:
+See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review body passed to
+`gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
 ```
 
-- Do not modify the link text.
+- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -140,7 +140,7 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 `gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
 ```
 
 - Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -143,7 +143,7 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 [🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
+- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1427,6 +1427,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                 cwd: cwd,
                                 command: registerCommand,
                                 trackReadiness: trackReadiness,
+                                agentKind: agentKind,
                                 newWindowTimeout: 3.0
                             )
                         }

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -1,3 +1,4 @@
+import CrowCore
 import Foundation
 
 /// Creates the devRoot directory structure and copies bundled resources.

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -31,6 +31,9 @@ struct Scaffolder {
         let createTicketSkillsDir = (claudeDir as NSString).appendingPathComponent("skills/crow-create-ticket")
         try fm.createDirectory(atPath: createTicketSkillsDir, withIntermediateDirectories: true)
 
+        let attributionSkillsDir = (claudeDir as NSString).appendingPathComponent("skills/crow-attribution")
+        try fm.createDirectory(atPath: attributionSkillsDir, withIntermediateDirectories: true)
+
         // Create crow-reviews directory for PR review clones
         let reviewsDir = (devRoot as NSString).appendingPathComponent("crow-reviews")
         try fm.createDirectory(atPath: reviewsDir, withIntermediateDirectories: true)
@@ -86,6 +89,10 @@ struct Scaffolder {
         let createTicketSkillPath = (createTicketSkillsDir as NSString).appendingPathComponent("SKILL.md")
         let createTicketSkillTemplate = Self.bundledCreateTicketSkill()
         try createTicketSkillTemplate.write(toFile: createTicketSkillPath, atomically: true, encoding: .utf8)
+
+        // Shared attribution footer rules (issue #443)
+        let attributionFooterPath = (attributionSkillsDir as NSString).appendingPathComponent("FOOTER.md")
+        try Self.bundledAttributionFooter().write(toFile: attributionFooterPath, atomically: true, encoding: .utf8)
 
         // Always overwrite settings.json (permissions for crow, gh, git commands)
         let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.json")
@@ -220,6 +227,14 @@ struct Scaffolder {
         user and labeled `crow:auto`. All `gh`, `glab`, and `git` commands require
         `dangerouslyDisableSandbox: true`.
         """
+    }
+
+    /// Shared attribution footer instructions (issue #443).
+    static func bundledAttributionFooter() -> String {
+        if let content = loadFromRepo("skills/crow-attribution/FOOTER.md") {
+            return content
+        }
+        return CrowAttribution.sharedFooterInstructions
     }
 
     /// The settings.json template with pre-approved permissions.

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -235,6 +235,10 @@ struct Scaffolder {
         if let content = loadFromRepo("skills/crow-attribution/FOOTER.md") {
             return content
         }
+        if let url = Bundle.main.url(forResource: "crow-attribution-FOOTER.md", withExtension: "template"),
+           let content = try? String(contentsOf: url) {
+            return content
+        }
         return CrowAttribution.sharedFooterInstructions
     }
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -346,12 +346,14 @@ final class SessionService {
         // window was closed, or a legacy per-PID socketPath that no longer
         // matches the stable socket). Create a fresh window as before.
         do {
+            let agentKind = appState.sessions.first(where: { $0.id == terminal.sessionID })?.agentKind
             let binding = try TmuxBackend.shared.registerTerminal(
                 id: terminal.id,
                 name: terminal.name,
                 cwd: terminal.cwd,
                 command: terminal.command,
-                trackReadiness: trackReadiness
+                trackReadiness: trackReadiness,
+                agentKind: agentKind
             )
             var updated = terminal
             updated.tmuxBinding = binding
@@ -1969,17 +1971,18 @@ final class SessionService {
     }
 
     /// Apply the Cursor-specific substitutions to a raw `crow-review-pr`
-    /// SKILL body: replace `$ARGUMENTS` with the PR URL, and swap the
-    /// "via Claude Code" attribution suffix for "via Cursor" so the posted
-    /// GitHub review identifies the reviewing agent correctly.
+    /// SKILL body: replace `$ARGUMENTS` with the PR URL, and expand
+    /// `{{CROW_AGENT_DISPLAY_NAME}}` / legacy "via Claude Code" wording so the
+    /// posted GitHub review identifies the reviewing agent correctly.
     ///
     /// Split out from `buildReviewPrompt` so unit tests can verify the
     /// substitutions against a known input without depending on the
     /// scaffolder's file-resolution fallback.
     nonisolated static func cursorReviewPrompt(skillBody: String, prURL: String) -> String {
-        return skillBody
-            .replacingOccurrences(of: "$ARGUMENTS", with: prURL)
-            .replacingOccurrences(of: "via Claude Code", with: "via Cursor")
+        CrowAttribution.expandSkillBody(
+            skillBody.replacingOccurrences(of: "$ARGUMENTS", with: prURL),
+            agentKind: .cursor
+        )
     }
 
     // MARK: - Session Status
@@ -2111,13 +2114,15 @@ final class SessionService {
             NSLog("[SessionService] tmux not configured; terminal \(t.id) will not render")
             return t
         }
+        let agentKind = appState.sessions.first(where: { $0.id == t.sessionID })?.agentKind
         do {
             let binding = try TmuxBackend.shared.registerTerminal(
                 id: t.id,
                 name: t.name,
                 cwd: t.cwd,
                 command: t.command,
-                trackReadiness: trackReadiness
+                trackReadiness: trackReadiness,
+                agentKind: agentKind
             )
             t.tmuxBinding = binding
         } catch {

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1972,7 +1972,7 @@ final class SessionService {
 
     /// Apply the Cursor-specific substitutions to a raw `crow-review-pr`
     /// SKILL body: replace `$ARGUMENTS` with the PR URL, and expand
-    /// `$CROW_AGENT_DISPLAY_NAME` / legacy "via Claude Code" wording so the
+    /// `${CROW_AGENT_DISPLAY_NAME:-…}` / legacy "via Claude Code" wording so the
     /// posted GitHub review identifies the reviewing agent correctly.
     ///
     /// Split out from `buildReviewPrompt` so unit tests can verify the

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1972,7 +1972,7 @@ final class SessionService {
 
     /// Apply the Cursor-specific substitutions to a raw `crow-review-pr`
     /// SKILL body: replace `$ARGUMENTS` with the PR URL, and expand
-    /// `{{CROW_AGENT_DISPLAY_NAME}}` / legacy "via Claude Code" wording so the
+    /// `$CROW_AGENT_DISPLAY_NAME` / legacy "via Claude Code" wording so the
     /// posted GitHub review identifies the reviewing agent correctly.
     ///
     /// Split out from `buildReviewPrompt` so unit tests can verify the

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -5,14 +5,14 @@ import Testing
 
 /// Snapshot tests for Crow skill attribution instructions (issue #443).
 ///
-/// Skills reference `$CROW_AGENT_DISPLAY_NAME`. The unit tests in
+/// Skills reference `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in footers. The unit tests in
 /// `Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift` verify the
 /// Swift helpers and default Claude Code footers.
 @Suite("Review attribution snapshot")
 struct AttributionSkillTests {
 
     private static let canonicalRepoURL = "https://github.com/radiusmethod/crow"
-    private static let agentDisplayEnvKey = "CROW_AGENT_DISPLAY_NAME"
+    private static let shellAgentExpression = "${CROW_AGENT_DISPLAY_NAME:-Claude Code}"
     private static let agentPlaceholder = "{{CROW_AGENT_DISPLAY_NAME}}"
 
     /// Walk up from this test source file until we find Package.swift.
@@ -69,14 +69,14 @@ struct AttributionSkillTests {
 
     @Test func liveSkillReferencesAgentDisplayNameEnv() throws {
         let content = try Self.liveSkill()
-        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
+        #expect(content.contains(Self.shellAgentExpression))
         #expect(!content.contains(Self.agentPlaceholder))
         #expect(content.contains(Self.canonicalRepoURL))
     }
 
     @Test func bundledTemplateReferencesAgentDisplayNameEnv() throws {
         let content = try Self.bundledTemplate()
-        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
+        #expect(content.contains(Self.shellAgentExpression))
         #expect(!content.contains(Self.agentPlaceholder))
     }
 
@@ -119,14 +119,14 @@ struct AttributionSkillTests {
 
     @Test func liveTicketSkillReferencesAgentDisplayNameEnv() throws {
         let content = try Self.liveTicketSkill()
-        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
+        #expect(content.contains(Self.shellAgentExpression))
         #expect(content.contains(Self.canonicalRepoURL))
         #expect(!content.contains("Do not modify the link text"))
     }
 
     @Test func bundledTicketTemplateReferencesAgentDisplayNameEnv() throws {
         let content = try Self.bundledTicketTemplate()
-        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
+        #expect(content.contains(Self.shellAgentExpression))
     }
 
     @Test func liveTicketSkillAndBundledTemplateAreByteIdentical() throws {

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -2,21 +2,18 @@ import Foundation
 import Testing
 @testable import Crow
 
-/// Snapshot tests for the `/crow-review-pr` skill attribution line.
+/// Snapshot tests for Crow skill attribution instructions (issue #443).
 ///
-/// These tests intentionally hardcode the expected attribution string rather
-/// than importing `CrowCore.CrowAttribution`. The unit test in
-/// `Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift` verifies
-/// that the Swift constant matches this literal, so any drift between the
-/// markdown skill file and the Swift constant is caught from both sides.
+/// Skills reference `$CROW_AGENT_DISPLAY_NAME` (and review templates use
+/// `{{CROW_AGENT_DISPLAY_NAME}}` for Cursor inline expansion). The unit tests in
+/// `Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift` verify the
+/// Swift helpers and default Claude Code footers.
 @Suite("Review attribution snapshot")
 struct AttributionSkillTests {
 
     private static let canonicalRepoURL = "https://github.com/radiusmethod/crow"
-    private static let canonicalReviewLink =
-        "[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)"
-    private static let canonicalTicketLink =
-        "[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)"
+    private static let agentDisplayEnvKey = "CROW_AGENT_DISPLAY_NAME"
+    private static let agentPlaceholder = "{{CROW_AGENT_DISPLAY_NAME}}"
 
     /// Walk up from this test source file until we find Package.swift.
     /// Returns the repo root URL.
@@ -58,14 +55,23 @@ struct AttributionSkillTests {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
-    @Test func liveSkillContainsCanonicalAttributionLink() throws {
-        let content = try Self.liveSkill()
-        #expect(content.contains(Self.canonicalReviewLink))
+    private static func liveAttributionFooter() throws -> String {
+        let url = repoRoot()
+            .appendingPathComponent("skills/crow-attribution/FOOTER.md")
+        return try String(contentsOf: url, encoding: .utf8)
     }
 
-    @Test func bundledTemplateContainsCanonicalAttributionLink() throws {
+    @Test func liveSkillReferencesAgentDisplayNameEnv() throws {
+        let content = try Self.liveSkill()
+        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
+        #expect(content.contains(Self.agentPlaceholder))
+        #expect(content.contains(Self.canonicalRepoURL))
+    }
+
+    @Test func bundledTemplateReferencesAgentDisplayNameEnv() throws {
         let content = try Self.bundledTemplate()
-        #expect(content.contains(Self.canonicalReviewLink))
+        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
+        #expect(content.contains(Self.agentPlaceholder))
     }
 
     @Test func liveSkillAndBundledTemplateAreByteIdentical() throws {
@@ -105,14 +111,16 @@ struct AttributionSkillTests {
         }
     }
 
-    @Test func liveTicketSkillContainsCanonicalAttributionLink() throws {
+    @Test func liveTicketSkillReferencesAgentDisplayNameEnv() throws {
         let content = try Self.liveTicketSkill()
-        #expect(content.contains(Self.canonicalTicketLink))
+        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
+        #expect(content.contains(Self.canonicalRepoURL))
+        #expect(!content.contains("Do not modify the link text"))
     }
 
-    @Test func bundledTicketTemplateContainsCanonicalAttributionLink() throws {
+    @Test func bundledTicketTemplateReferencesAgentDisplayNameEnv() throws {
         let content = try Self.bundledTicketTemplate()
-        #expect(content.contains(Self.canonicalTicketLink))
+        #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
     }
 
     @Test func liveTicketSkillAndBundledTemplateAreByteIdentical() throws {
@@ -136,5 +144,12 @@ struct AttributionSkillTests {
             #expect(url == Self.canonicalRepoURL,
                     "create-ticket skill contains non-canonical github.com link: \(url)")
         }
+    }
+
+    @Test func sharedFooterDocumentsAgentEnvVars() throws {
+        let footer = try Self.liveAttributionFooter()
+        #expect(footer.contains("CROW_AGENT_KIND"))
+        #expect(footer.contains("CROW_AGENT_DISPLAY_NAME"))
+        #expect(footer.contains(Self.canonicalRepoURL))
     }
 }

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -64,14 +64,14 @@ struct AttributionSkillTests {
     @Test func liveSkillReferencesAgentDisplayNameEnv() throws {
         let content = try Self.liveSkill()
         #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
-        #expect(content.contains(Self.agentPlaceholder))
+        #expect(!content.contains(Self.agentPlaceholder))
         #expect(content.contains(Self.canonicalRepoURL))
     }
 
     @Test func bundledTemplateReferencesAgentDisplayNameEnv() throws {
         let content = try Self.bundledTemplate()
         #expect(content.contains("$\(Self.agentDisplayEnvKey)"))
-        #expect(content.contains(Self.agentPlaceholder))
+        #expect(!content.contains(Self.agentPlaceholder))
     }
 
     @Test func liveSkillAndBundledTemplateAreByteIdentical() throws {

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -1,11 +1,11 @@
+import CrowCore
 import Foundation
 import Testing
 @testable import Crow
 
 /// Snapshot tests for Crow skill attribution instructions (issue #443).
 ///
-/// Skills reference `$CROW_AGENT_DISPLAY_NAME` (and review templates use
-/// `{{CROW_AGENT_DISPLAY_NAME}}` for Cursor inline expansion). The unit tests in
+/// Skills reference `$CROW_AGENT_DISPLAY_NAME`. The unit tests in
 /// `Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift` verify the
 /// Swift helpers and default Claude Code footers.
 @Suite("Review attribution snapshot")
@@ -58,6 +58,12 @@ struct AttributionSkillTests {
     private static func liveAttributionFooter() throws -> String {
         let url = repoRoot()
             .appendingPathComponent("skills/crow-attribution/FOOTER.md")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func bundledAttributionTemplate() throws -> String {
+        let url = repoRoot()
+            .appendingPathComponent("Resources/crow-attribution-FOOTER.md.template")
         return try String(contentsOf: url, encoding: .utf8)
     }
 
@@ -151,5 +157,18 @@ struct AttributionSkillTests {
         #expect(footer.contains("CROW_AGENT_KIND"))
         #expect(footer.contains("CROW_AGENT_DISPLAY_NAME"))
         #expect(footer.contains(Self.canonicalRepoURL))
+    }
+
+    @Test func liveAttributionFooterAndBundledTemplateAreByteIdentical() throws {
+        let live = try Self.liveAttributionFooter()
+        let bundled = try Self.bundledAttributionTemplate()
+        #expect(live == bundled,
+                "skills/crow-attribution/FOOTER.md and Resources/crow-attribution-FOOTER.md.template must stay in sync — Scaffolder.bundledAttributionFooter() loads the template in release builds.")
+    }
+
+    @Test func liveAttributionFooterMatchesSwiftConstant() throws {
+        let live = try Self.liveAttributionFooter()
+        #expect(live == CrowAttribution.sharedFooterInstructions,
+                "skills/crow-attribution/FOOTER.md must match CrowAttribution.sharedFooterInstructions — the constant is Scaffolder's final fallback.")
     }
 }

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -168,7 +168,12 @@ struct AttributionSkillTests {
 
     @Test func liveAttributionFooterMatchesSwiftConstant() throws {
         let live = try Self.liveAttributionFooter()
-        #expect(live == CrowAttribution.sharedFooterInstructions,
+        let swift = CrowAttribution.sharedFooterInstructions
+        var trimmed = live
+        while trimmed.hasSuffix("\n") || trimmed.hasSuffix("\r") { trimmed.removeLast() }
+        var swiftTrimmed = swift
+        while swiftTrimmed.hasSuffix("\n") || swiftTrimmed.hasSuffix("\r") { swiftTrimmed.removeLast() }
+        #expect(trimmed + "\n" == swiftTrimmed + "\n",
                 "skills/crow-attribution/FOOTER.md must match CrowAttribution.sharedFooterInstructions — the constant is Scaffolder's final fallback.")
     }
 }

--- a/Tests/CrowTests/SessionServiceReviewPromptTests.swift
+++ b/Tests/CrowTests/SessionServiceReviewPromptTests.swift
@@ -28,7 +28,7 @@ struct SessionServiceReviewPromptTests {
     # Crow Review PR
     Review PR $ARGUMENTS — checkout via `gh pr checkout $ARGUMENTS`.
 
-    [🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+    [🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
     """
 
     @Test func cursorPromptSubstitutesPRURLForArguments() {

--- a/Tests/CrowTests/SessionServiceReviewPromptTests.swift
+++ b/Tests/CrowTests/SessionServiceReviewPromptTests.swift
@@ -28,7 +28,7 @@ struct SessionServiceReviewPromptTests {
     # Crow Review PR
     Review PR $ARGUMENTS — checkout via `gh pr checkout $ARGUMENTS`.
 
-    [🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
+    [🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
     """
 
     @Test func cursorPromptSubstitutesPRURLForArguments() {
@@ -57,6 +57,7 @@ struct SessionServiceReviewPromptTests {
         // posted GitHub review body says "via Cursor", not "via Claude Code".
         #expect(prompt.contains("via Cursor"))
         #expect(!prompt.contains("via Claude Code"))
+        #expect(!prompt.contains("${CROW_AGENT_DISPLAY_NAME:-Claude Code}"))
         #expect(!prompt.contains("$CROW_AGENT_DISPLAY_NAME"))
         // The canonical URL must remain — only the agent-name segment is
         // swapped.

--- a/Tests/CrowTests/SessionServiceReviewPromptTests.swift
+++ b/Tests/CrowTests/SessionServiceReviewPromptTests.swift
@@ -28,7 +28,7 @@ struct SessionServiceReviewPromptTests {
     # Crow Review PR
     Review PR $ARGUMENTS — checkout via `gh pr checkout $ARGUMENTS`.
 
-    [🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+    [🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
     """
 
     @Test func cursorPromptSubstitutesPRURLForArguments() {
@@ -57,6 +57,7 @@ struct SessionServiceReviewPromptTests {
         // posted GitHub review body says "via Cursor", not "via Claude Code".
         #expect(prompt.contains("via Cursor"))
         #expect(!prompt.contains("via Claude Code"))
+        #expect(!prompt.contains("$CROW_AGENT_DISPLAY_NAME"))
         // The canonical URL must remain — only the agent-name segment is
         // swapped.
         #expect(prompt.contains("https://github.com/radiusmethod/crow"))

--- a/skills/crow-attribution/FOOTER.md
+++ b/skills/crow-attribution/FOOTER.md
@@ -5,8 +5,8 @@ Crow injects these environment variables into every managed terminal:
 - `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
 - `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
 
-**Always** use `$CROW_AGENT_DISPLAY_NAME` for the agent name in attribution footers.
-If unset, fall back to `Claude Code`.
+**Always** use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in attribution footers inside
+double-quoted `gh`/`glab` arguments so the shell applies the default when unset.
 
 The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -15,4 +15,4 @@ The link target is always `https://github.com/radiusmethod/crow` — never a for
 | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
 | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-Replace `<agent>` with `$CROW_AGENT_DISPLAY_NAME` (or `Claude Code` if unset). Do not change the URL or wrap the line in extra formatting.
+Replace `<agent>` with `${CROW_AGENT_DISPLAY_NAME:-Claude Code}`. Do not change the URL or wrap the line in extra formatting.

--- a/skills/crow-attribution/FOOTER.md
+++ b/skills/crow-attribution/FOOTER.md
@@ -1,0 +1,18 @@
+# Crow Attribution Footers
+
+Crow injects these environment variables into every managed terminal:
+
+- `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
+- `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
+
+**Always** use `$CROW_AGENT_DISPLAY_NAME` for the agent name in attribution footers.
+If unset, fall back to `Claude Code`.
+
+The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
+
+| Artifact | Footer |
+|----------|--------|
+| Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
+| Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
+
+Replace `<agent>` with `$CROW_AGENT_DISPLAY_NAME` (or `Claude Code` if unset). Do not change the URL or wrap the line in extra formatting.

--- a/skills/crow-create-ticket/SKILL.md
+++ b/skills/crow-create-ticket/SKILL.md
@@ -65,8 +65,8 @@ rules above. If there is no usable title, ask the user for one and stop until pr
 The body is the text the user provided (or empty). It MUST end with the Crow
 attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
 a blank line, then
-`[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)`
-(use `Claude Code` if `$CROW_AGENT_DISPLAY_NAME` is unset).
+`[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)`
+(shell applies `Claude Code` when the variable is unset).
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 
@@ -111,7 +111,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -124,7 +124,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -137,10 +137,10 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body pas
 followed by:
 
 ```
-[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
+- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/skills/crow-create-ticket/SKILL.md
+++ b/skills/crow-create-ticket/SKILL.md
@@ -63,8 +63,10 @@ Extract the title (required) and optional body from `$ARGUMENTS` per the **Argum
 rules above. If there is no usable title, ask the user for one and stop until provided.
 
 The body is the text the user provided (or empty). It MUST end with the Crow
-attribution footer (see **Step 4b**): a blank line, then exactly
-`[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)`.
+attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
+a blank line, then
+`[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)`
+(use `Claude Code` if `$CROW_AGENT_DISPLAY_NAME` is unset).
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 
@@ -109,7 +111,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -122,7 +124,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -130,14 +132,15 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
 
 ### Step 4b: Attribution (REQUIRED)
 
-The body passed to `gh issue create --body` / `glab issue create --description` MUST
-end with a blank line followed by exactly this line:
+See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body passed to
+`gh issue create --body` / `glab issue create --description` MUST end with a blank line
+followed by:
 
 ```
-[🐦‍⬛ Created with Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
 ```
 
-- Do not modify the link text.
+- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -131,18 +131,19 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
 
-The review body passed to `gh pr review --body` MUST end with a blank line followed by exactly this line:
+See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review body passed to
+`gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via Claude Code](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
 ```
 
-- Do not modify the link text.
+- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -140,10 +140,10 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 `gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `$CROW_AGENT_DISPLAY_NAME` from the environment (Crow injects it per session). Fall back to `Claude Code` if unset.
+- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via $CROW_AGENT_DISPLAY_NAME](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)


### PR DESCRIPTION
Closes #443

## Summary

- Inject `CROW_AGENT_KIND` and `CROW_AGENT_DISPLAY_NAME` into every managed terminal at tmux window creation so skills and agents know which agent produced an artifact.
- Centralize footer formatting in `CrowAttribution` (Swift helpers, `expandSkillBody`, shared `FOOTER.md` scaffolded to `.claude/skills/crow-attribution/`).
- Update `crow-create-ticket` and `crow-review-pr` skills to use `$CROW_AGENT_DISPLAY_NAME` (fall back to `Claude Code` when unset); Cursor review prompts expand `{{CROW_AGENT_DISPLAY_NAME}}` inline.

## Test plan

- [x] `swift test --filter CrowAttribution` in `Packages/CrowCore`
- [ ] Create an issue from a Cursor session — footer reads `via Cursor`
- [ ] Post a PR review from a Cursor review session — footer reads `via Cursor`
- [ ] Verify Claude Code sessions still default to `via Claude Code` when env is absent

Made with [Cursor](https://cursor.com)