### PR TITLE
Fix Ghostty terminal selection clearing on mouse-up

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -371,15 +371,22 @@ public final class GhosttySurfaceView: NSView {
 
     public override func mouseDown(with event: NSEvent) {
         guard let surface else { return }
+        sendMousePosition(for: event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, translateMods(event.modifierFlags))
     }
 
     public override func mouseUp(with event: NSEvent) {
         guard let surface else { return }
+        sendMousePosition(for: event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, translateMods(event.modifierFlags))
     }
 
     public override func mouseMoved(with event: NSEvent) {
+        guard let surface else { return }
+        sendMousePosition(for: event)
+    }
+
+    private func sendMousePosition(for event: NSEvent) {
         guard let surface else { return }
         let pos = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, pos.x, frame.height - pos.y, translateMods(event.modifierFlags))

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -23,9 +23,12 @@ set -gs default-terminal screen-256color
 # this, tmux steals one cell row from the Ghostty surface.
 set -gs status off
 
-# Mouse selection / scroll, since users will use Ghostty's mouse handlers
-# rather than tmux's prefix-driven copy mode.
-set -gs mouse on
+# Leave mouse off so Ghostty owns selection, scroll, and clipboard. With
+# mouse on, tmux captures every mouse event and enables terminal mouse
+# reporting; libghostty then clears the selection on mouse-up (#445).
+# Apps that need mouse (vim, htop, etc.) still enable it via the usual
+# xterm mouse protocol while running.
+set -gs mouse off
 
 # Crow owns the keyboard namespace. Drop every default binding; actions
 # are driven from Swift via `tmux <subcommand>` calls.

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
@@ -72,7 +72,9 @@ public struct TerminalSurfaceView: NSViewRepresentable {
                 Self.attach(surface: surface, to: container)
             }
             try? TmuxBackend.shared.makeActive(id: id)
-            if let window = container.window, surface.window === window {
+            if let window = container.window,
+               surface.window === window,
+               window.firstResponder !== surface {
                 window.makeFirstResponder(surface)
             }
         }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -46,7 +46,7 @@ struct BundledResourcesTests {
         // libghostty clear selection on mouse-up (#445).
         let url = try #require(BundledResources.tmuxConfURL)
         let body = try String(contentsOf: url, encoding: .utf8)
-        #expect(body.contains("mouse off"))
-        #expect(!body.contains("mouse on"))
+        #expect(body.contains("set -gs mouse off"))
+        #expect(!body.contains("set -gs mouse on"))
     }
 }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -40,4 +40,13 @@ struct BundledResourcesTests {
         let body = try String(contentsOf: url, encoding: .utf8)
         #expect(body.contains("status off"))
     }
+
+    @Test func tmuxConfDisablesMouse() throws {
+        // tmux mouse on enables terminal mouse reporting, which makes
+        // libghostty clear selection on mouse-up (#445).
+        let url = try #require(BundledResources.tmuxConfURL)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        #expect(body.contains("mouse off"))
+        #expect(!body.contains("mouse on"))
+    }
 }


### PR DESCRIPTION
Closes #445

## Summary

- Disable tmux mouse capture in `crow-tmux.conf` so Ghostty handles native text selection, scroll, and clipboard. With `mouse on`, tmux enables terminal mouse reporting and libghostty intentionally clears selection on every mouse button release.
- Sync cursor position before mouse button events so press/release use the correct cell.
- Skip redundant `makeFirstResponder` calls during SwiftUI `updateNSView` to reduce focus churn.

## Test plan

- [ ] Open a session terminal, drag-select text, release mouse — selection stays highlighted
- [ ] Cmd+C copies selected text to the clipboard
- [ ] Selection clears on click elsewhere, typing, or Escape
- [ ] `vim` with `set mouse=a` and `htop` still receive mouse events when those apps enable xterm mouse reporting
- [ ] Restart tmux server (or restart Crow) so existing cockpit sessions pick up the new `mouse off` setting


Made with [Cursor](https://cursor.com)