### PR TITLE
Fix attribution footer shell-expansion leak (#447)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -86,13 +86,16 @@ public enum CrowAttribution {
     public static let sharedFooterInstructions: String = """
     # Crow Attribution Footers
 
-    Crow injects these environment variables into every managed terminal:
+    Every skill body Crow writes to disk goes through a substitution pass that
+    replaces `{{CROW_AGENT_DISPLAY_NAME}}` with the session's resolved agent name
+    (`Claude Code`, `Cursor`, `OpenAI Codex`, …). The agent reads literal text — no
+    shell parameter expansion is involved, so footers survive every quoting form
+    (single-quoted heredocs, JSON files, Swift string literals).
 
-    - `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
-    - `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
-
-    **Always** use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in attribution footers inside
-    double-quoted `gh`/`glab` arguments so the shell applies the default when unset.
+    **Do not** reintroduce `${CROW_AGENT_DISPLAY_NAME:-…}` or any other shell
+    expression in attribution footers. Use the literal name Crow already wrote
+    into your skill, or `{{CROW_AGENT_DISPLAY_NAME}}` if you are authoring a new
+    template.
 
     The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -101,6 +104,6 @@ public enum CrowAttribution {
     | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
     | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-    Replace `<agent>` with `${CROW_AGENT_DISPLAY_NAME:-Claude Code}`. Do not change the URL or wrap the line in extra formatting.
+    Replace `<agent>` with the literal name (or `{{CROW_AGENT_DISPLAY_NAME}}` in source templates). Do not change the URL or wrap the line in extra formatting.
     """
 }

--- a/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
+++ b/Packages/CrowCore/Sources/CrowCore/CrowAttribution.swift
@@ -83,19 +83,24 @@ public enum CrowAttribution {
     }
 
     /// Shared attribution rules copied into `.claude/skills/crow-attribution/FOOTER.md`.
+    ///
+    /// Crow runs this body through `expandSkillBody` before writing it to disk, so
+    /// the prose must read sensibly **after** every `{{CROW_AGENT_DISPLAY_NAME}}` /
+    /// `$CROW_AGENT_DISPLAY_NAME` / `via Claude Code` occurrence has been rewritten
+    /// to the resolved agent name (#447 review). Describe the substitution model
+    /// at a higher level than naming the sentinel literally.
     public static let sharedFooterInstructions: String = """
     # Crow Attribution Footers
 
-    Every skill body Crow writes to disk goes through a substitution pass that
-    replaces `{{CROW_AGENT_DISPLAY_NAME}}` with the session's resolved agent name
-    (`Claude Code`, `Cursor`, `OpenAI Codex`, …). The agent reads literal text — no
-    shell parameter expansion is involved, so footers survive every quoting form
-    (single-quoted heredocs, JSON files, Swift string literals).
+    This file is what your skill sees on disk. The footer lines below already contain
+    the literal agent name for this session (`Claude Code`, `Cursor`, `OpenAI Codex`, …) —
+    Crow substituted it in when scaffolding. Copy each line verbatim into the body you
+    pass to `gh`/`glab` (or your commit). No shell parameter expansion is needed and the
+    line survives every quoting form (single-quoted heredocs, JSON files, Swift literals).
 
     **Do not** reintroduce `${CROW_AGENT_DISPLAY_NAME:-…}` or any other shell
-    expression in attribution footers. Use the literal name Crow already wrote
-    into your skill, or `{{CROW_AGENT_DISPLAY_NAME}}` if you are authoring a new
-    template.
+    expression in attribution footers. The shell silently fails to expand it inside
+    single-quoted heredocs and the literal text leaks into the artifact (#447).
 
     The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -104,6 +109,8 @@ public enum CrowAttribution {
     | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
     | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-    Replace `<agent>` with the literal name (or `{{CROW_AGENT_DISPLAY_NAME}}` in source templates). Do not change the URL or wrap the line in extra formatting.
+    `<agent>` above is just a placeholder for *this document* — in the real footer lines
+    your skill receives, the agent name is already filled in. Do not change the URL or
+    wrap the line in extra formatting.
     """
 }

--- a/Resources/crow-attribution-FOOTER.md.template
+++ b/Resources/crow-attribution-FOOTER.md.template
@@ -1,15 +1,14 @@
 # Crow Attribution Footers
 
-Every skill body Crow writes to disk goes through a substitution pass that
-replaces `{{CROW_AGENT_DISPLAY_NAME}}` with the session's resolved agent name
-(`Claude Code`, `Cursor`, `OpenAI Codex`, …). The agent reads literal text — no
-shell parameter expansion is involved, so footers survive every quoting form
-(single-quoted heredocs, JSON files, Swift string literals).
+This file is what your skill sees on disk. The footer lines below already contain
+the literal agent name for this session (`Claude Code`, `Cursor`, `OpenAI Codex`, …) —
+Crow substituted it in when scaffolding. Copy each line verbatim into the body you
+pass to `gh`/`glab` (or your commit). No shell parameter expansion is needed and the
+line survives every quoting form (single-quoted heredocs, JSON files, Swift literals).
 
 **Do not** reintroduce `${CROW_AGENT_DISPLAY_NAME:-…}` or any other shell
-expression in attribution footers. Use the literal name Crow already wrote
-into your skill, or `{{CROW_AGENT_DISPLAY_NAME}}` if you are authoring a new
-template.
+expression in attribution footers. The shell silently fails to expand it inside
+single-quoted heredocs and the literal text leaks into the artifact (#447).
 
 The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -18,4 +17,6 @@ The link target is always `https://github.com/radiusmethod/crow` — never a for
 | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
 | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-Replace `<agent>` with the literal name (or `{{CROW_AGENT_DISPLAY_NAME}}` in source templates). Do not change the URL or wrap the line in extra formatting.
+`<agent>` above is just a placeholder for *this document* — in the real footer lines
+your skill receives, the agent name is already filled in. Do not change the URL or
+wrap the line in extra formatting.

--- a/Resources/crow-attribution-FOOTER.md.template
+++ b/Resources/crow-attribution-FOOTER.md.template
@@ -1,12 +1,15 @@
 # Crow Attribution Footers
 
-Crow injects these environment variables into every managed terminal:
+Every skill body Crow writes to disk goes through a substitution pass that
+replaces `{{CROW_AGENT_DISPLAY_NAME}}` with the session's resolved agent name
+(`Claude Code`, `Cursor`, `OpenAI Codex`, …). The agent reads literal text — no
+shell parameter expansion is involved, so footers survive every quoting form
+(single-quoted heredocs, JSON files, Swift string literals).
 
-- `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
-- `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
-
-**Always** use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in attribution footers inside
-double-quoted `gh`/`glab` arguments so the shell applies the default when unset.
+**Do not** reintroduce `${CROW_AGENT_DISPLAY_NAME:-…}` or any other shell
+expression in attribution footers. Use the literal name Crow already wrote
+into your skill, or `{{CROW_AGENT_DISPLAY_NAME}}` if you are authoring a new
+template.
 
 The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -15,4 +18,4 @@ The link target is always `https://github.com/radiusmethod/crow` — never a for
 | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
 | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-Replace `<agent>` with `${CROW_AGENT_DISPLAY_NAME:-Claude Code}`. Do not change the URL or wrap the line in extra formatting.
+Replace `<agent>` with the literal name (or `{{CROW_AGENT_DISPLAY_NAME}}` in source templates). Do not change the URL or wrap the line in extra formatting.

--- a/Resources/crow-create-ticket-SKILL.md.template
+++ b/Resources/crow-create-ticket-SKILL.md.template
@@ -64,10 +64,9 @@ rules above. If there is no usable title, ask the user for one and stop until pr
 
 The body is the text the user provided (or empty). It MUST end with the Crow
 attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
-a blank line, then
-`[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)`
-(Crow has already substituted the literal agent name into this file before you
-read it — copy the line as-is).
+a blank line, then the literal attribution line shown in **Step 4** below.
+Crow has already filled in the agent name for this session — copy the line
+as-is into the body.
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 
@@ -141,7 +140,7 @@ followed by:
 [🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
+- Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the issue body).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/Resources/crow-create-ticket-SKILL.md.template
+++ b/Resources/crow-create-ticket-SKILL.md.template
@@ -65,8 +65,9 @@ rules above. If there is no usable title, ask the user for one and stop until pr
 The body is the text the user provided (or empty). It MUST end with the Crow
 attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
 a blank line, then
-`[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)`
-(shell applies `Claude Code` when the variable is unset).
+`[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)`
+(Crow has already substituted the literal agent name into this file before you
+read it — copy the line as-is).
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 
@@ -111,7 +112,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -124,7 +125,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -137,10 +138,10 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body pas
 followed by:
 
 ```
-[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
+- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -140,10 +140,10 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 `gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
+- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/Resources/crow-review-pr-SKILL.md.template
+++ b/Resources/crow-review-pr-SKILL.md.template
@@ -143,7 +143,7 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 [🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
+- Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the review body).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -41,6 +41,7 @@ PRIMARY=false
 SKIP_LAUNCH=false
 SKIP_ASSIGN=false
 SKIP_PROJECT_STATUS=false
+BASE_BRANCH=""
 
 # Runtime state
 TERMINAL_ID=""
@@ -57,17 +58,45 @@ json_val() {
   tr -d '\n' | sed 's/[[:space:]]*:[[:space:]]*/:/g' | grep -o "\"$key\":\"[^\"]*\"" | cut -d'"' -f4 | head -1
 }
 
-die() {
-  local step="$1" msg="$2"
-  local partial=""
-  if [[ -n "$SESSION_ID" ]]; then
-    partial=", \"partial\": {\"session_id\": \"$SESSION_ID\"}"
+# Extract the `readiness` of a specific terminal id from `crow list-terminals`
+# JSON. Walks the flat per-terminal objects, finds the one carrying our id, and
+# reads its readiness field. Usage: terminal_readiness "$tid" "$json"
+terminal_readiness() {
+  local tid="$1" json="$2"
+  printf '%s' "$json" | tr -d '\n' | grep -o '{[^{}]*}' | grep "\"$tid\"" \
+    | grep -o '"readiness":"[^"]*"' | cut -d'"' -f4 | head -1
+}
+
+# POSIX single-quote an arg so it's safe to interpolate into a shell command.
+# Mirrors Swift's shellQuote() in ClaudeLaunchArgs: wraps value in '...' and
+# escapes embedded single-quotes as '\''.
+posix_quote() {
+  local s=${1//\'/\'\\\'\'}
+  printf "'%s'" "$s"
+}
+
+# Read the global remoteControlEnabled flag from {devRoot}/.claude/config.json.
+# Returns 0 if true, 1 otherwise. Missing file / malformed JSON / missing
+# key all default to 1 (off), matching AppConfig's decodeIfPresent behavior.
+is_remote_control_enabled() {
+  local config_path="$DEV_ROOT/.claude/config.json"
+  [[ -f "$config_path" ]] || return 1
+  tr -d '\n' < "$config_path" \
+    | grep -qE '"remoteControlEnabled"[[:space:]]*:[[:space:]]*true'
+}
+
+# Read the attributionTrailers flag from {devRoot}/.claude/config.json.
+# Defaults to 0 (on) when the file is missing, malformed, or the key is
+# absent — matches AppConfig's decodeIfPresent default. Returns 1 only
+# when the key is explicitly set to false.
+is_attribution_trailers_enabled() {
+  local config_path="$DEV_ROOT/.claude/config.json"
+  [[ -f "$config_path" ]] || return 0
+  if tr -d '\n' < "$config_path" \
+    | grep -qE '"attributionTrailers"[[:space:]]*:[[:space:]]*false'; then
+    return 1
   fi
-  printf '{"status":"error","step":"%s","message":"%s"%s}\n' \
-    "$step" \
-    "$(echo "$msg" | sed 's/"/\\"/g' | tr '\n' ' ')" \
-    "$partial"
-  exit 1
+  return 0
 }
 
 # Resolve the agent kind for a given SessionKind raw value, mirroring
@@ -82,6 +111,7 @@ read_agent_kind_from_config() {
   local flat
   flat=$(tr -d '\n' < "$cfg")
 
+  # agentsByKind["<kind>"]: find the agentsByKind object body, then the key.
   local override
   override=$(printf '%s' "$flat" \
     | grep -oE "\"agentsByKind\"[[:space:]]*:[[:space:]]*\{[^}]*\}" \
@@ -89,11 +119,39 @@ read_agent_kind_from_config() {
     | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
   if [[ -n "$override" ]]; then echo "$override"; return; fi
 
+  # Fall back to defaultAgentKind.
   local def
   def=$(printf '%s' "$flat" \
     | grep -oE "\"defaultAgentKind\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" \
     | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
   echo "${def:-claude-code}"
+}
+
+# Map an AGENT_KIND raw value to its human-readable display name. Mirrors
+# CrowAttribution.knownDisplayNames in Packages/CrowCore. Used by
+# write_settings_local to bake the resolved name into `attribution.commit`
+# as a literal string — Claude Code's settings.local.json is JSON, not a
+# shell context, so shell parameter expansion never fires there (#447).
+agent_display_name() {
+  case "${1:-claude-code}" in
+    claude-code) echo "Claude Code" ;;
+    cursor)      echo "Cursor" ;;
+    codex)       echo "OpenAI Codex" ;;
+    *)           echo "Claude Code" ;;
+  esac
+}
+
+die() {
+  local step="$1" msg="$2"
+  local partial=""
+  if [[ -n "$SESSION_ID" ]]; then
+    partial=", \"partial\": {\"session_id\": \"$SESSION_ID\"}"
+  fi
+  printf '{"status":"error","step":"%s","message":"%s"%s}\n' \
+    "$step" \
+    "$(echo "$msg" | sed 's/"/\\"/g' | tr '\n' ' ')" \
+    "$partial"
+  exit 1
 }
 
 # ─── Argument Parsing ────────────────────────────────────────────────────────
@@ -131,6 +189,7 @@ Optional:
   --claude-binary <path>     [deprecated alias] Same as --agent-binary; only
                              honored when the resolved agent is claude-code.
   --session-id <uuid>        Existing session ID (for secondary repos)
+  --base-branch <branch>     Default base branch (auto-detected from origin/HEAD if omitted)
   --primary                  Mark worktree as primary
   --skip-launch              Skip agent launch
   --skip-assign              Skip auto-assign
@@ -165,6 +224,7 @@ parse_args() {
       --agent-binary)      AGENT_BINARY="$2"; shift 2 ;;
       --claude-binary)     CLAUDE_BINARY="$2"; shift 2 ;;
       --session-id)        SESSION_ID="$2"; shift 2 ;;
+      --base-branch)       BASE_BRANCH="$2"; shift 2 ;;
       --primary)           PRIMARY=true; shift ;;
       --skip-launch)       SKIP_LAUNCH=true; shift ;;
       --skip-assign)       SKIP_ASSIGN=true; shift ;;
@@ -213,16 +273,42 @@ preflight() {
 
 # ─── Git Worktree ────────────────────────────────────────────────────────────
 
+# Resolve BASE_BRANCH: explicit --base-branch flag wins, otherwise probe
+# origin/HEAD locally (set by `git clone` for most repos), otherwise ask the
+# remote, otherwise warn loudly and fall back to "main".
+resolve_base_branch() {
+  if [[ -n "$BASE_BRANCH" ]]; then
+    log "Using base branch from --base-branch: $BASE_BRANCH"
+    return
+  fi
+  local detected
+  detected=$(git -C "$REPO_PATH" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || true
+  detected="${detected#origin/}"
+  if [[ -z "$detected" ]]; then
+    detected=$(git -C "$REPO_PATH" ls-remote --symref origin HEAD 2>/dev/null \
+      | awk '/^ref:/ { sub("refs/heads/", "", $2); print $2; exit }') || true
+  fi
+  if [[ -n "$detected" ]]; then
+    BASE_BRANCH="$detected"
+    log "Auto-detected base branch from origin/HEAD: $BASE_BRANCH"
+  else
+    BASE_BRANCH="main"
+    log "WARNING: could not detect default branch for $REPO_PATH; falling back to 'main'"
+  fi
+}
+
 setup_worktree() {
   log "Fetching origin..."
   if ! git -C "$REPO_PATH" fetch origin >&2 2>&1; then
     die "git_fetch" "git fetch origin failed"
   fi
 
+  resolve_base_branch
+
   # Determine which branch and tracking mode to use
   local use_branch="$BRANCH"
   local track_flag="--no-track"
-  local base_ref="origin/main"
+  local base_ref="origin/$BASE_BRANCH"
 
   if [[ -n "$PR_BRANCH" ]]; then
     # PR branch: track the remote PR branch
@@ -239,7 +325,7 @@ setup_worktree() {
       base_ref="origin/$BRANCH"
       log "Branch $BRANCH exists on remote, will track"
     else
-      log "Creating new branch $BRANCH from origin/main"
+      log "Creating new branch $BRANCH from origin/$BASE_BRANCH"
     fi
   fi
 
@@ -331,6 +417,66 @@ create_session() {
       --url "$PR_URL" \
       --type pr >/dev/null 2>&1 \
       || log "Warning: add-link (PR) failed"
+  fi
+}
+
+# ─── Per-Worktree Settings (attribution trailer) ─────────────────────────────
+
+# Write a per-worktree .claude/settings.local.json that overrides Claude Code's
+# attribution.commit so commits include a `Crow-Session: <uuid>` trailer
+# alongside the standard `Co-Authored-By: Claude` line. Runs for every
+# worktree (primary and secondary) regardless of --skip-launch, so any worktree
+# the user later opens with Claude Code picks up the override.
+write_settings_local() {
+  if ! is_attribution_trailers_enabled; then
+    log "Attribution trailers disabled via config; skipping settings.local.json"
+    return
+  fi
+
+  if [[ -z "$SESSION_ID" ]]; then
+    log "Warning: SESSION_ID not set, skipping settings.local.json"
+    return
+  fi
+
+  local settings_dir="$WORKTREE_PATH/.claude"
+  local settings_path="$settings_dir/settings.local.json"
+  mkdir -p "$settings_dir"
+
+  # Resolve the agent display name so it lands in the JSON as a literal string.
+  # Claude Code's settings.local.json is parsed as JSON, not by a shell, so any
+  # ${VAR:-default} expression would survive verbatim and leak into commits
+  # (#447). Fall back to read_agent_kind_from_config when --agent-kind wasn't
+  # provided, matching launch_agent's resolution order.
+  local resolved_kind="$AGENT_KIND"
+  if [[ -z "$resolved_kind" ]]; then
+    resolved_kind=$(read_agent_kind_from_config "work")
+  fi
+  local display_name
+  display_name=$(agent_display_name "$resolved_kind")
+
+  # The newlines inside the "commit" string are literal \n escapes in JSON;
+  # the heredoc passes them through to the file as the two-character sequence.
+  # Heredoc is unquoted so bash expands $display_name and $SESSION_ID.
+  cat > "$settings_path" <<EOF
+{
+  "attribution": {
+    "commit": "🐦‍⬛ Generated with $display_name, orchestrated by Crow\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>\\nCrow-Session: $SESSION_ID"
+  }
+}
+EOF
+  log "Wrote attribution settings to $settings_path (agent: $display_name)"
+
+  # Belt-and-suspenders: add the file to the per-worktree git exclude so it
+  # is never accidentally committed even if the repo's .gitignore does not
+  # already cover .claude/settings.local.json. For worktrees, this lives at
+  # .git/worktrees/<name>/info/exclude — `git rev-parse --git-path` resolves it.
+  local exclude_file
+  exclude_file="$(git -C "$WORKTREE_PATH" rev-parse --git-path info/exclude 2>/dev/null)" || return 0
+  [[ -n "$exclude_file" ]] || return 0
+  mkdir -p "$(dirname "$exclude_file")"
+  touch "$exclude_file"
+  if ! grep -qxF '.claude/settings.local.json' "$exclude_file" 2>/dev/null; then
+    printf '\n# Added by crow setup.sh\n.claude/settings.local.json\n' >> "$exclude_file"
   fi
 }
 
@@ -471,11 +617,16 @@ write_prompt() {
 
 # ─── Launch Agent ───────────────────────────────────────────────────────────
 #
-# Dispatcher + per-agent launchers. Each sub-launcher knows its own binary,
-# flags, and terminal name; the shared create_agent_terminal helper creates
-# the terminal, waits for the shell, and pastes the launch command. Mirrors
-# the corresponding Swift CodingAgent.autoLaunchCommand for each kind.
+# Dispatcher + per-agent launchers. The dispatcher resolves the agent kind
+# (--agent-kind flag, then config.json, then claude-code default), invokes the
+# matching launch_<kind> sub-launcher to build the --command string and create
+# the terminal, then polls readiness centrally. Each sub-launcher mirrors the
+# corresponding Swift `CodingAgent.autoLaunchCommand` in Packages/Crow{Claude,
+# Cursor,Codex} so the skill and the in-app launch paths stay in agreement.
 
+# Search a list of candidate paths and PATH for the first executable matching
+# $token (or full path). Echoes the resolved path, or empty on failure.
+# Usage: resolve_binary <token> <candidate1> [candidate2 ...]
 resolve_binary() {
   local token="$1"; shift
   local p
@@ -487,44 +638,9 @@ resolve_binary() {
   return 1
 }
 
-# Shared terminal creation + send-launch path. Sets TERMINAL_ID.
-create_agent_terminal() {
-  local terminal_name="$1"
-  local send_text="$2"
-
-  log "Creating terminal '$terminal_name'..."
-  local term_result
-  if ! term_result=$(crow new-terminal --session "$SESSION_ID" \
-    --cwd "$WORKTREE_PATH" \
-    --name "$terminal_name" \
-    --managed 2>&1); then
-    die "new_terminal" "crow new-terminal failed: $term_result"
-  fi
-
-  TERMINAL_ID=$(json_val "terminal_id" <<< "$term_result")
-  if [[ -z "$TERMINAL_ID" ]]; then
-    die "new_terminal" "Could not parse terminal_id from: $term_result"
-  fi
-  log "Terminal created: $TERMINAL_ID"
-
-  # Select session
-  crow select-session --session "$SESSION_ID" >/dev/null 2>&1 \
-    || log "Warning: select-session failed"
-
-  # Wait for the shell to initialize in the new terminal.
-  log "Waiting for shell to initialize..."
-  sleep 3
-
-  log "Launching $terminal_name..."
-  if ! crow send --session "$SESSION_ID" --terminal "$TERMINAL_ID" "$send_text" >/dev/null 2>&1; then
-    die "send_launch" "crow send failed"
-  fi
-  log "$terminal_name launched"
-}
-
 launch_claude_code() {
   local prompt_path="$1"
-  local override_bin="$2"
+  local override_bin="$2"   # from --agent-binary or legacy --claude-binary
   local bin
   if [[ -n "$override_bin" ]]; then
     bin="$override_bin"
@@ -536,8 +652,27 @@ launch_claude_code() {
       die "launch_agent" "claude binary not found at PATH or known locations; provide --agent-binary"
   fi
   log "Resolved claude-code binary: $bin"
-  local send_text="cd $WORKTREE_PATH && $bin --permission-mode plan \"\$(cat $prompt_path)\"\\n"
-  create_agent_terminal "Claude Code" "$send_text"
+
+  # Build the agent launch command and hand it to crow at terminal-creation
+  # time via --command. Crow holds the command and pastes it only once the
+  # shell's line editor is live (the .shellReady sentinel), which is the
+  # race-free replacement for the old `sleep 3` + `crow send` handshake that
+  # intermittently dropped the launch into a not-yet-ready shell, leaving a
+  # bare zsh with no agent (#408).
+  #
+  # The prompt stays in its file — `"$(cat $prompt_path)"` is expanded by the
+  # TARGET shell at paste time, so the command sent over the socket is small
+  # (no ARG_MAX / payload concern).
+  local rc_args=""
+  if is_remote_control_enabled; then
+    # Keep building --rc here: crow's resolveClaudeInCommand only injects
+    # remote-control flags for a bare `claude …` command, NOT a
+    # `cd … && claude …` form, so setup.sh remains the source of truth.
+    rc_args=" --rc --name $(posix_quote "$SESSION_NAME")"
+    log "Remote control enabled — launching with --rc --name '$SESSION_NAME'"
+  fi
+  local launch_cmd="cd $WORKTREE_PATH && $bin --permission-mode plan$rc_args \"\$(cat $prompt_path)\""
+  create_agent_terminal "Claude Code" "$launch_cmd"
 }
 
 launch_cursor() {
@@ -547,7 +682,8 @@ launch_cursor() {
   if [[ -n "$override_bin" ]]; then
     bin="$override_bin"
   else
-    # Cursor's CLI binary is named `agent`, not `cursor`.
+    # Cursor's CLI binary is named `agent`, not `cursor`. Candidate paths
+    # mirror CursorAgent.cursorBinaryCandidates in CrowCursor.
     bin=$(resolve_binary "agent" \
       "/opt/homebrew/bin/agent" \
       "/usr/local/bin/agent" \
@@ -555,8 +691,13 @@ launch_cursor() {
       die "launch_agent" "cursor binary not found at PATH or known locations; provide --agent-binary"
   fi
   log "Resolved cursor binary: $bin"
-  local send_text="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\"\\n"
-  create_agent_terminal "Cursor" "$send_text"
+  # Cursor: no --permission-mode, no --rc; pass the prompt as argv.
+  # This intentionally uses CursorAgent's .job/.review first-launch argv
+  # form (NOT the .work bare-`agent` form) so the unattended skill flow
+  # feeds the prompt at launch — same divergence-from-Swift-.work
+  # rationale that launch_claude_code uses for its prompt-argv form.
+  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
+  create_agent_terminal "Cursor" "$launch_cmd"
 }
 
 launch_codex() {
@@ -573,9 +714,72 @@ launch_codex() {
       die "launch_agent" "codex binary not found at PATH or known locations; provide --agent-binary"
   fi
   log "Resolved codex binary: $bin"
+  # Codex has no prompt-argv form (matches OpenAICodexAgent.autoLaunchCommand
+  # — bare `codex` only). The prompt file is still written; the user can
+  # paste from it into the TUI.
   log "Note: Codex has no prompt-argv form; prompt file is at $prompt_path (paste manually if needed)."
-  local send_text="cd $WORKTREE_PATH && $bin\\n"
-  create_agent_terminal "OpenAI Codex" "$send_text"
+  local launch_cmd="cd $WORKTREE_PATH && $bin"
+  create_agent_terminal "OpenAI Codex" "$launch_cmd"
+}
+
+# Shared terminal creation + readiness polling, used by every launch_<kind>.
+# Sets TERMINAL_ID on success. Polls `crow list-terminals` for up to 15s.
+create_agent_terminal() {
+  local terminal_name="$1"
+  local launch_cmd="$2"
+
+  log "Creating terminal '$terminal_name' (deferred agent launch via --command)..."
+  local term_result
+  if ! term_result=$(crow new-terminal --session "$SESSION_ID" \
+    --cwd "$WORKTREE_PATH" \
+    --name "$terminal_name" \
+    --managed \
+    --command "$launch_cmd" 2>&1); then
+    die "new_terminal" "crow new-terminal failed: $term_result"
+  fi
+
+  # The RPC reports launch_failed when the tmux window could not be created
+  # (e.g. new-window timed out under load) — don't pretend it launched.
+  if grep -qE '"launch_failed"[[:space:]]*:[[:space:]]*true' <<< "$term_result"; then
+    die "new_terminal" "crow could not create the terminal window: $term_result"
+  fi
+
+  TERMINAL_ID=$(json_val "terminal_id" <<< "$term_result")
+  if [[ -z "$TERMINAL_ID" ]]; then
+    die "new_terminal" "Could not parse terminal_id from: $term_result"
+  fi
+  log "Terminal created: $TERMINAL_ID"
+
+  # Select session
+  crow select-session --session "$SESSION_ID" >/dev/null 2>&1 \
+    || log "Warning: select-session failed"
+
+  # Verify the agent actually started rather than assuming success. Poll the
+  # terminal's readiness (exposed on `crow list-terminals`) until it reaches
+  # agentLaunched/shellReady. This is a warning, NOT a hard failure: the
+  # workspace (worktree/session/metadata) is already set up, and crow's UI
+  # shows a Retry affordance if the agent didn't start (#408).
+  log "Waiting for the agent to launch..."
+  local readiness="" attempt
+  for attempt in $(seq 1 15); do
+    local lt_result
+    lt_result=$(crow list-terminals --session "$SESSION_ID" 2>/dev/null) || true
+    readiness=$(terminal_readiness "$TERMINAL_ID" "$lt_result")
+    case "$readiness" in
+      agentLaunched|shellReady)
+        log "$terminal_name launched (readiness=$readiness)"
+        return
+        ;;
+      failed|timedOut)
+        log "WARNING: agent did not start (readiness=$readiness). The terminal" \
+            "is up but the agent isn't running — use Retry in the Crow UI."
+        return
+        ;;
+    esac
+    sleep 1
+  done
+  log "WARNING: agent launch not confirmed after 15s (last readiness='${readiness:-unknown}')." \
+      "The workspace is set up; check the Crow terminal and use Retry if needed."
 }
 
 launch_agent() {
@@ -584,7 +788,8 @@ launch_agent() {
     return
   fi
 
-  # Resolve agent kind: --agent-kind > config > claude-code fallback.
+  # Resolve agent kind: explicit flag > config.json (agentsByKind["work"]
+  # then defaultAgentKind) > claude-code fallback.
   local kind="$AGENT_KIND"
   if [[ -z "$kind" ]]; then
     kind=$(read_agent_kind_from_config "work")
@@ -593,6 +798,8 @@ launch_agent() {
     log "Using agent kind from --agent-kind flag: $kind"
   fi
 
+  # Pick the binary override. --agent-binary applies to any kind. The legacy
+  # --claude-binary alias only applies when the resolved kind is claude-code.
   local override_bin="$AGENT_BINARY"
   if [[ -z "$override_bin" && "$kind" == "claude-code" && -n "$CLAUDE_BINARY" ]]; then
     override_bin="$CLAUDE_BINARY"
@@ -631,6 +838,7 @@ main() {
 
   setup_worktree
   create_session
+  write_settings_local
   github_ops
   write_prompt
   launch_agent

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -300,7 +300,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             // Scaffold directory structure
             let scaffolder = Scaffolder(devRoot: devRoot)
-            try scaffolder.scaffold(workspaceNames: config.workspaces.map(\.name))
+            try scaffolder.scaffold(
+                workspaceNames: config.workspaces.map(\.name),
+                managerAgentKind: config.agentKind(for: .manager)
+            )
 
             // Save config
             try ConfigStore.saveConfig(config, devRoot: devRoot)
@@ -395,7 +398,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Update skills and CLAUDE.md on every launch
         let scaffolder = Scaffolder(devRoot: devRoot)
         do {
-            try scaffolder.scaffold(workspaceNames: config.workspaces.map(\.name))
+            try scaffolder.scaffold(
+                workspaceNames: config.workspaces.map(\.name),
+                managerAgentKind: config.agentKind(for: .manager)
+            )
         } catch {
             NSLog("[Crow] Scaffold update failed: %@", error.localizedDescription)
         }
@@ -1045,7 +1051,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             },
             onRescaffold: { [weak self] devRoot in
                 let scaffolder = Scaffolder(devRoot: devRoot)
-                try? scaffolder.scaffold(workspaceNames: self?.appConfig?.workspaces.map(\.name) ?? [])
+                let cfg = self?.appConfig
+                try? scaffolder.scaffold(
+                    workspaceNames: cfg?.workspaces.map(\.name) ?? [],
+                    managerAgentKind: cfg?.agentKind(for: .manager) ?? .claudeCode
+                )
             }
         )
 

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -6,7 +6,11 @@ struct Scaffolder {
     let devRoot: String
 
     /// Create the full workspace scaffold.
-    func scaffold(workspaceNames: [String]) throws {
+    ///
+    /// `managerAgentKind` drives `{{CROW_AGENT_DISPLAY_NAME}}` substitution in the
+    /// dev-root skill bodies (issue #447). The Manager session is the consumer of
+    /// these files, so its agent kind is the right one to bake in.
+    func scaffold(workspaceNames: [String], managerAgentKind: AgentKind = .claudeCode) throws {
         let fm = FileManager.default
 
         // Create devRoot
@@ -68,7 +72,8 @@ struct Scaffolder {
         // Always overwrite the skill with the latest version from the app
         let skillPath = (skillsDir as NSString).appendingPathComponent("SKILL.md")
         let skillTemplate = Self.bundledSkill()
-        try skillTemplate.write(toFile: skillPath, atomically: true, encoding: .utf8)
+        try CrowAttribution.expandSkillBody(skillTemplate, agentKind: managerAgentKind)
+            .write(toFile: skillPath, atomically: true, encoding: .utf8)
 
         // Always overwrite setup.sh with the latest version and make executable
         let setupScriptPath = (skillsDir as NSString).appendingPathComponent("setup.sh")
@@ -79,21 +84,26 @@ struct Scaffolder {
         // Always overwrite the review-pr skill with the latest version
         let reviewSkillPath = (reviewSkillsDir as NSString).appendingPathComponent("SKILL.md")
         let reviewSkillTemplate = Self.bundledReviewSkill()
-        try reviewSkillTemplate.write(toFile: reviewSkillPath, atomically: true, encoding: .utf8)
+        try CrowAttribution.expandSkillBody(reviewSkillTemplate, agentKind: managerAgentKind)
+            .write(toFile: reviewSkillPath, atomically: true, encoding: .utf8)
 
         // Always overwrite the batch-workspace skill with the latest version
         let batchSkillPath = (batchSkillsDir as NSString).appendingPathComponent("SKILL.md")
         let batchSkillTemplate = Self.bundledBatchSkill()
-        try batchSkillTemplate.write(toFile: batchSkillPath, atomically: true, encoding: .utf8)
+        try CrowAttribution.expandSkillBody(batchSkillTemplate, agentKind: managerAgentKind)
+            .write(toFile: batchSkillPath, atomically: true, encoding: .utf8)
 
         // Always overwrite the create-ticket skill with the latest version
         let createTicketSkillPath = (createTicketSkillsDir as NSString).appendingPathComponent("SKILL.md")
         let createTicketSkillTemplate = Self.bundledCreateTicketSkill()
-        try createTicketSkillTemplate.write(toFile: createTicketSkillPath, atomically: true, encoding: .utf8)
+        try CrowAttribution.expandSkillBody(createTicketSkillTemplate, agentKind: managerAgentKind)
+            .write(toFile: createTicketSkillPath, atomically: true, encoding: .utf8)
 
         // Shared attribution footer rules (issue #443)
         let attributionFooterPath = (attributionSkillsDir as NSString).appendingPathComponent("FOOTER.md")
-        try Self.bundledAttributionFooter().write(toFile: attributionFooterPath, atomically: true, encoding: .utf8)
+        let attributionFooter = Self.bundledAttributionFooter()
+        try CrowAttribution.expandSkillBody(attributionFooter, agentKind: managerAgentKind)
+            .write(toFile: attributionFooterPath, atomically: true, encoding: .utf8)
 
         // Always overwrite settings.json (permissions for crow, gh, git commands)
         let settingsPath = (claudeDir as NSString).appendingPathComponent("settings.json")

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1688,11 +1688,15 @@ final class SessionService {
             )
         }
 
-        // Copy the crow-review-pr skill into the clone's .claude/skills/ so Claude Code can find it
+        // Copy the crow-review-pr skill into the clone's .claude/skills/ so Claude Code can find it.
+        // Substitute `{{CROW_AGENT_DISPLAY_NAME}}` before writing so the attribution footer is a
+        // literal string regardless of how the agent quotes the body (issue #447 — single-quoted
+        // heredocs in gh/glab calls don't expand shell variables).
         let cloneSkillsDir = (clonePath as NSString).appendingPathComponent(".claude/skills/crow-review-pr")
         try? fm.createDirectory(atPath: cloneSkillsDir, withIntermediateDirectories: true)
         let skillContent = Scaffolder.bundledReviewSkill()
-        try? skillContent.write(
+        let resolvedSkillContent = CrowAttribution.expandSkillBody(skillContent, agentKind: reviewAgentKind)
+        try? resolvedSkillContent.write(
             toFile: (cloneSkillsDir as NSString).appendingPathComponent("SKILL.md"),
             atomically: true, encoding: .utf8
         )

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -164,10 +164,16 @@ struct AttributionSkillTests {
 
     @Test func sharedFooterDocumentsSubstitutionAndCanonicalURL() throws {
         let footer = try Self.liveAttributionFooter()
-        // #447: FOOTER documents the substitution model — the sentinel must be
-        // named and the canonical URL must be present.
-        #expect(footer.contains(Self.agentPlaceholder))
+        // #447 review: FOOTER prose must read sensibly post-substitution, so it
+        // deliberately does NOT spell `{{CROW_AGENT_DISPLAY_NAME}}` literally
+        // (`expandSkillBody` would otherwise rewrite the explanatory sentences
+        // and produce self-contradictory deployed docs). Guard the canonical
+        // URL and the no-sentinel constraint together.
         #expect(footer.contains(Self.canonicalRepoURL))
+        #expect(!footer.contains(Self.agentPlaceholder),
+                "FOOTER.md prose must not contain {{CROW_AGENT_DISPLAY_NAME}} — expandSkillBody runs over this file and would rewrite the explanation. Describe the model without naming the sentinel literally.")
+        #expect(!footer.contains("$\(CrowAttribution.agentDisplayNameEnvironmentKey)"),
+                "FOOTER.md prose must not contain a bare $CROW_AGENT_DISPLAY_NAME token — expandSkillBody would rewrite it too.")
     }
 
     @Test func liveAttributionFooterAndBundledTemplateAreByteIdentical() throws {
@@ -189,6 +195,32 @@ struct AttributionSkillTests {
     }
 
     // MARK: - Substitution behavior (#447)
+
+    /// Regression guard for the #447 review feedback: the prose explaining the
+    /// substitution model must not contain a literal `{{CROW_AGENT_DISPLAY_NAME}}`
+    /// token, because `expandSkillBody` will rewrite the explanation along with
+    /// the real footer and produce self-contradictory deployed docs (e.g.
+    /// "replaces `Cursor` with the session's resolved agent name"). The only
+    /// valid home for the sentinel is the operative footer line itself, which
+    /// is recognizable by also containing the canonical repo URL.
+    private static func assertSentinelOnlyInFooterLines(_ body: String, file: StaticString = #file) {
+        for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+            if line.contains(Self.agentPlaceholder) {
+                #expect(
+                    line.contains(Self.canonicalRepoURL),
+                    "Line contains `{{CROW_AGENT_DISPLAY_NAME}}` outside an attribution footer (no canonical URL on the line). `expandSkillBody` will rewrite this and likely produce self-contradictory prose post-scaffold. Reword to describe the model without spelling the sentinel.\nLine: \(line)"
+                )
+            }
+        }
+    }
+
+    @Test func liveReviewSkillKeepsSentinelOnlyInFooterLines() throws {
+        try Self.assertSentinelOnlyInFooterLines(Self.liveSkill())
+    }
+
+    @Test func liveTicketSkillKeepsSentinelOnlyInFooterLines() throws {
+        try Self.assertSentinelOnlyInFooterLines(Self.liveTicketSkill())
+    }
 
     /// Confirm the substitution pass walks every footer occurrence in a real
     /// skill body. Reads the live SKILL.md directly (rather than going through

--- a/Tests/CrowTests/AttributionSkillTests.swift
+++ b/Tests/CrowTests/AttributionSkillTests.swift
@@ -3,9 +3,14 @@ import Foundation
 import Testing
 @testable import Crow
 
-/// Snapshot tests for Crow skill attribution instructions (issue #443).
+/// Snapshot tests for Crow skill attribution instructions (issues #443, #447).
 ///
-/// Skills reference `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in footers. The unit tests in
+/// Skill source files reference `{{CROW_AGENT_DISPLAY_NAME}}` as the canonical
+/// placeholder; Crow substitutes it with the resolved agent name at file-write
+/// time (Scaffolder, SessionService). The earlier `${CROW_AGENT_DISPLAY_NAME:-…}`
+/// shell expression silently failed inside single-quoted heredocs and leaked
+/// literal text into commits / issues / PR bodies — these tests guard against
+/// regressing to that form. The unit tests in
 /// `Packages/CrowCore/Tests/CrowCoreTests/CrowAttributionTests.swift` verify the
 /// Swift helpers and default Claude Code footers.
 @Suite("Review attribution snapshot")
@@ -67,17 +72,20 @@ struct AttributionSkillTests {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
-    @Test func liveSkillReferencesAgentDisplayNameEnv() throws {
+    @Test func liveSkillUsesAgentPlaceholderNotShellExpression() throws {
         let content = try Self.liveSkill()
-        #expect(content.contains(Self.shellAgentExpression))
-        #expect(!content.contains(Self.agentPlaceholder))
+        // #447: source templates must use the literal {{…}} sentinel that
+        // Crow substitutes at write-time. The old shell expression silently
+        // failed inside single-quoted heredocs and leaked into review bodies.
+        #expect(content.contains(Self.agentPlaceholder))
+        #expect(!content.contains(Self.shellAgentExpression))
         #expect(content.contains(Self.canonicalRepoURL))
     }
 
-    @Test func bundledTemplateReferencesAgentDisplayNameEnv() throws {
+    @Test func bundledTemplateUsesAgentPlaceholderNotShellExpression() throws {
         let content = try Self.bundledTemplate()
-        #expect(content.contains(Self.shellAgentExpression))
-        #expect(!content.contains(Self.agentPlaceholder))
+        #expect(content.contains(Self.agentPlaceholder))
+        #expect(!content.contains(Self.shellAgentExpression))
     }
 
     @Test func liveSkillAndBundledTemplateAreByteIdentical() throws {
@@ -117,16 +125,18 @@ struct AttributionSkillTests {
         }
     }
 
-    @Test func liveTicketSkillReferencesAgentDisplayNameEnv() throws {
+    @Test func liveTicketSkillUsesAgentPlaceholderNotShellExpression() throws {
         let content = try Self.liveTicketSkill()
-        #expect(content.contains(Self.shellAgentExpression))
+        #expect(content.contains(Self.agentPlaceholder))
+        #expect(!content.contains(Self.shellAgentExpression))
         #expect(content.contains(Self.canonicalRepoURL))
         #expect(!content.contains("Do not modify the link text"))
     }
 
-    @Test func bundledTicketTemplateReferencesAgentDisplayNameEnv() throws {
+    @Test func bundledTicketTemplateUsesAgentPlaceholderNotShellExpression() throws {
         let content = try Self.bundledTicketTemplate()
-        #expect(content.contains(Self.shellAgentExpression))
+        #expect(content.contains(Self.agentPlaceholder))
+        #expect(!content.contains(Self.shellAgentExpression))
     }
 
     @Test func liveTicketSkillAndBundledTemplateAreByteIdentical() throws {
@@ -152,10 +162,11 @@ struct AttributionSkillTests {
         }
     }
 
-    @Test func sharedFooterDocumentsAgentEnvVars() throws {
+    @Test func sharedFooterDocumentsSubstitutionAndCanonicalURL() throws {
         let footer = try Self.liveAttributionFooter()
-        #expect(footer.contains("CROW_AGENT_KIND"))
-        #expect(footer.contains("CROW_AGENT_DISPLAY_NAME"))
+        // #447: FOOTER documents the substitution model — the sentinel must be
+        // named and the canonical URL must be present.
+        #expect(footer.contains(Self.agentPlaceholder))
         #expect(footer.contains(Self.canonicalRepoURL))
     }
 
@@ -175,5 +186,36 @@ struct AttributionSkillTests {
         while swiftTrimmed.hasSuffix("\n") || swiftTrimmed.hasSuffix("\r") { swiftTrimmed.removeLast() }
         #expect(trimmed + "\n" == swiftTrimmed + "\n",
                 "skills/crow-attribution/FOOTER.md must match CrowAttribution.sharedFooterInstructions — the constant is Scaffolder's final fallback.")
+    }
+
+    // MARK: - Substitution behavior (#447)
+
+    /// Confirm the substitution pass walks every footer occurrence in a real
+    /// skill body. Reads the live SKILL.md directly (rather than going through
+    /// `Scaffolder.bundledReviewSkill()`) so the test doesn't depend on the
+    /// bundled loader's runtime file-resolution heuristic, which falls back to
+    /// a trivial stub in the test runner. The live file is the source of truth
+    /// the scaffold writes from — exercising it here mirrors the dev-root
+    /// behavior end-to-end.
+    @Test func expandSkillBodyReplacesEveryReviewFooterOccurrence() throws {
+        let body = try Self.liveSkill()
+        #expect(body.contains(Self.agentPlaceholder),
+                "precondition: live review skill must contain the placeholder before substitution")
+        let expanded = CrowAttribution.expandSkillBody(body, agentKind: .cursor)
+        #expect(!expanded.contains(Self.agentPlaceholder),
+                "expandSkillBody must replace every {{CROW_AGENT_DISPLAY_NAME}} occurrence in the live review skill.")
+        #expect(!expanded.contains(Self.shellAgentExpression),
+                "expandSkillBody must also strip any legacy shell expression that snuck in.")
+        #expect(expanded.contains("Reviewed by Crow via Cursor"),
+                "the substituted footer must read the resolved agent name literally.")
+    }
+
+    @Test func expandSkillBodyReplacesEveryTicketFooterOccurrence() throws {
+        let body = try Self.liveTicketSkill()
+        #expect(body.contains(Self.agentPlaceholder))
+        let expanded = CrowAttribution.expandSkillBody(body, agentKind: .codex)
+        #expect(!expanded.contains(Self.agentPlaceholder))
+        #expect(!expanded.contains(Self.shellAgentExpression))
+        #expect(expanded.contains("Created with Crow via OpenAI Codex"))
     }
 }

--- a/skills/crow-attribution/FOOTER.md
+++ b/skills/crow-attribution/FOOTER.md
@@ -1,15 +1,14 @@
 # Crow Attribution Footers
 
-Every skill body Crow writes to disk goes through a substitution pass that
-replaces `{{CROW_AGENT_DISPLAY_NAME}}` with the session's resolved agent name
-(`Claude Code`, `Cursor`, `OpenAI Codex`, …). The agent reads literal text — no
-shell parameter expansion is involved, so footers survive every quoting form
-(single-quoted heredocs, JSON files, Swift string literals).
+This file is what your skill sees on disk. The footer lines below already contain
+the literal agent name for this session (`Claude Code`, `Cursor`, `OpenAI Codex`, …) —
+Crow substituted it in when scaffolding. Copy each line verbatim into the body you
+pass to `gh`/`glab` (or your commit). No shell parameter expansion is needed and the
+line survives every quoting form (single-quoted heredocs, JSON files, Swift literals).
 
 **Do not** reintroduce `${CROW_AGENT_DISPLAY_NAME:-…}` or any other shell
-expression in attribution footers. Use the literal name Crow already wrote
-into your skill, or `{{CROW_AGENT_DISPLAY_NAME}}` if you are authoring a new
-template.
+expression in attribution footers. The shell silently fails to expand it inside
+single-quoted heredocs and the literal text leaks into the artifact (#447).
 
 The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -18,4 +17,6 @@ The link target is always `https://github.com/radiusmethod/crow` — never a for
 | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
 | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-Replace `<agent>` with the literal name (or `{{CROW_AGENT_DISPLAY_NAME}}` in source templates). Do not change the URL or wrap the line in extra formatting.
+`<agent>` above is just a placeholder for *this document* — in the real footer lines
+your skill receives, the agent name is already filled in. Do not change the URL or
+wrap the line in extra formatting.

--- a/skills/crow-attribution/FOOTER.md
+++ b/skills/crow-attribution/FOOTER.md
@@ -1,12 +1,15 @@
 # Crow Attribution Footers
 
-Crow injects these environment variables into every managed terminal:
+Every skill body Crow writes to disk goes through a substitution pass that
+replaces `{{CROW_AGENT_DISPLAY_NAME}}` with the session's resolved agent name
+(`Claude Code`, `Cursor`, `OpenAI Codex`, …). The agent reads literal text — no
+shell parameter expansion is involved, so footers survive every quoting form
+(single-quoted heredocs, JSON files, Swift string literals).
 
-- `CROW_AGENT_KIND` — raw agent id (`claude-code`, `cursor`, `codex`, …)
-- `CROW_AGENT_DISPLAY_NAME` — human label (`Claude Code`, `Cursor`, `OpenAI Codex`, …)
-
-**Always** use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` in attribution footers inside
-double-quoted `gh`/`glab` arguments so the shell applies the default when unset.
+**Do not** reintroduce `${CROW_AGENT_DISPLAY_NAME:-…}` or any other shell
+expression in attribution footers. Use the literal name Crow already wrote
+into your skill, or `{{CROW_AGENT_DISPLAY_NAME}}` if you are authoring a new
+template.
 
 The link target is always `https://github.com/radiusmethod/crow` — never a fork or a value from the local git remote.
 
@@ -15,4 +18,4 @@ The link target is always `https://github.com/radiusmethod/crow` — never a for
 | Created (issues, PR descriptions, etc.) | `[🐦‍⬛ Created with Crow via <agent>](https://github.com/radiusmethod/crow)` |
 | Reviewed | `[🐦‍⬛ Reviewed by Crow via <agent>](https://github.com/radiusmethod/crow)` |
 
-Replace `<agent>` with `${CROW_AGENT_DISPLAY_NAME:-Claude Code}`. Do not change the URL or wrap the line in extra formatting.
+Replace `<agent>` with the literal name (or `{{CROW_AGENT_DISPLAY_NAME}}` in source templates). Do not change the URL or wrap the line in extra formatting.

--- a/skills/crow-create-ticket/SKILL.md
+++ b/skills/crow-create-ticket/SKILL.md
@@ -64,10 +64,9 @@ rules above. If there is no usable title, ask the user for one and stop until pr
 
 The body is the text the user provided (or empty). It MUST end with the Crow
 attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
-a blank line, then
-`[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)`
-(Crow has already substituted the literal agent name into this file before you
-read it — copy the line as-is).
+a blank line, then the literal attribution line shown in **Step 4** below.
+Crow has already filled in the agent name for this session — copy the line
+as-is into the body.
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 
@@ -141,7 +140,7 @@ followed by:
 [🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
+- Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the issue body).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/skills/crow-create-ticket/SKILL.md
+++ b/skills/crow-create-ticket/SKILL.md
@@ -65,8 +65,9 @@ rules above. If there is no usable title, ask the user for one and stop until pr
 The body is the text the user provided (or empty). It MUST end with the Crow
 attribution footer (see **Step 4b** and `.claude/skills/crow-attribution/FOOTER.md`):
 a blank line, then
-`[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)`
-(shell applies `Claude Code` when the variable is unset).
+`[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)`
+(Crow has already substituted the literal agent name into this file before you
+read it — copy the line as-is).
 Do NOT add any other footer — no "Generated with Claude Code" line and no co-author
 trailer. The Crow attribution is the only footer.
 
@@ -111,7 +112,7 @@ gh issue create --repo OWNER/REPO \
   --title "TITLE" \
   --body "BODY
 
-[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
   --assignee "{login}" \
   --label "crow:auto"
 ```
@@ -124,7 +125,7 @@ GITLAB_HOST={host} glab issue create --repo {org/repo} \
   --title "TITLE" \
   --description "BODY
 
-[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)" \
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)" \
   --assignee "{username}" \
   --label "crow:auto" \
   --yes
@@ -137,10 +138,10 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The body pas
 followed by:
 
 ```
-[🐦‍⬛ Created with Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Created with Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
+- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every issue body, whether GitHub or GitLab, and whether or not the user supplied any body text.

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -131,7 +131,7 @@ Use this format for the review:
 
 ---
 
-[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
 ### Step 5b: Attribution (REQUIRED)
@@ -140,10 +140,10 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 `gh pr review --body` MUST end with a blank line followed by:
 
 ```
-[🐦‍⬛ Reviewed by Crow via ${CROW_AGENT_DISPLAY_NAME:-Claude Code}](https://github.com/radiusmethod/crow)
+[🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Use `${CROW_AGENT_DISPLAY_NAME:-Claude Code}` so the shell applies the default when the variable is unset (Crow injects it per session).
+- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/skills/crow-review-pr/SKILL.md
+++ b/skills/crow-review-pr/SKILL.md
@@ -143,7 +143,7 @@ See `.claude/skills/crow-attribution/FOOTER.md` for the full rules. The review b
 [🐦‍⬛ Reviewed by Crow via {{CROW_AGENT_DISPLAY_NAME}}](https://github.com/radiusmethod/crow)
 ```
 
-- Crow rewrites `{{CROW_AGENT_DISPLAY_NAME}}` to the session's resolved agent name (`Claude Code`, `Cursor`, `OpenAI Codex`, …) **before** this skill reaches you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs).
+- Crow filled in the agent name for this session before this skill reached you — paste the line literally; do not re-introduce `${…}` shell parameter expansion of your own (it silently fails inside single-quoted heredocs and the literal text leaks into the review body).
 - Do not modify the URL — the link target is always `https://github.com/radiusmethod/crow`, never a fork or a derived value from the local git remote.
 - Do not wrap the line in additional formatting (no blockquote, no extra brackets, no surrounding text).
 - This line MUST appear in every review body, regardless of whether you used `--approve` or `--request-changes`.

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -127,6 +127,20 @@ read_agent_kind_from_config() {
   echo "${def:-claude-code}"
 }
 
+# Map an AGENT_KIND raw value to its human-readable display name. Mirrors
+# CrowAttribution.knownDisplayNames in Packages/CrowCore. Used by
+# write_settings_local to bake the resolved name into `attribution.commit`
+# as a literal string — Claude Code's settings.local.json is JSON, not a
+# shell context, so shell parameter expansion never fires there (#447).
+agent_display_name() {
+  case "${1:-claude-code}" in
+    claude-code) echo "Claude Code" ;;
+    cursor)      echo "Cursor" ;;
+    codex)       echo "OpenAI Codex" ;;
+    *)           echo "Claude Code" ;;
+  esac
+}
+
 die() {
   local step="$1" msg="$2"
   local partial=""
@@ -428,16 +442,29 @@ write_settings_local() {
   local settings_path="$settings_dir/settings.local.json"
   mkdir -p "$settings_dir"
 
+  # Resolve the agent display name so it lands in the JSON as a literal string.
+  # Claude Code's settings.local.json is parsed as JSON, not by a shell, so any
+  # ${VAR:-default} expression would survive verbatim and leak into commits
+  # (#447). Fall back to read_agent_kind_from_config when --agent-kind wasn't
+  # provided, matching launch_agent's resolution order.
+  local resolved_kind="$AGENT_KIND"
+  if [[ -z "$resolved_kind" ]]; then
+    resolved_kind=$(read_agent_kind_from_config "work")
+  fi
+  local display_name
+  display_name=$(agent_display_name "$resolved_kind")
+
   # The newlines inside the "commit" string are literal \n escapes in JSON;
   # the heredoc passes them through to the file as the two-character sequence.
+  # Heredoc is unquoted so bash expands $display_name and $SESSION_ID.
   cat > "$settings_path" <<EOF
 {
   "attribution": {
-    "commit": "🐦‍⬛ Generated with Claude Code, orchestrated by Crow\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>\\nCrow-Session: $SESSION_ID"
+    "commit": "🐦‍⬛ Generated with $display_name, orchestrated by Crow\\n\\nCo-Authored-By: Claude <noreply@anthropic.com>\\nCrow-Session: $SESSION_ID"
   }
 }
 EOF
-  log "Wrote attribution settings to $settings_path"
+  log "Wrote attribution settings to $settings_path (agent: $display_name)"
 
   # Belt-and-suspenders: add the file to the per-worktree git exclude so it
   # is never accidentally committed even if the repo's .gitignore does not


### PR DESCRIPTION
## Summary

Closes #447.

PR #443 swapped the hardcoded `Claude Code` attribution string for the bash parameter expansion `\${CROW_AGENT_DISPLAY_NAME:-Claude Code}`. The expansion silently fails inside single-quoted heredocs (`<<'EOF'` — the form CLAUDE.md tells agents to use for `gh pr create --body`), single-quoted strings, and JSON written into files, so the literal placeholder text has been leaking into commits, issue bodies, and PR descriptions ever since.

This change implements Option 1 from the ticket: resolve the agent display name to a literal string **at the moment the file is written**, before any shell ever sees it.

## Approach

- **Canonical placeholder** in skill source templates is now `{{CROW_AGENT_DISPLAY_NAME}}` (the existing in-code sentinel), not a shell expression. Quoting context can no longer break it.
- **`Scaffolder.scaffold`** now takes a `managerAgentKind` parameter and runs every skill body + the FOOTER through `CrowAttribution.expandSkillBody` before writing into the dev-root `.claude/skills/`. Propagated from the three `AppDelegate` call sites via `config.agentKind(for: .manager)`.
- **`SessionService.setupReviewClonePrep`** expands the review skill body with `reviewAgentKind` before copying into the per-PR clone — Cursor was already covered via `cursorReviewPrompt`; this catches Claude Code and any future review-capable agent.
- **`skills/crow-workspace/setup.sh`** gains an `agent_display_name` bash helper (mirrors `CrowAttribution.knownDisplayNames`) and uses it to bake the resolved name into Claude Code's `attribution.commit` JSON, replacing the previous hardcoded \"Claude Code\".
- **Skill source files and `CrowAttribution.sharedFooterInstructions`** are rewritten to document the substitution model and explicitly forbid reintroducing shell parameter expansion.
- **`CrowAttribution.expandSkillBody`** keeps its backward-compatible handling of `\${…:-…}`, bare `\$VAR`, and `{{…}}`, so legacy `.claude/` trees on disk get cleaned up on next scaffold.

## Drift cleanup (incidental)

The pair-sync drove `Resources/crow-workspace-setup.sh.template` back into byte-for-byte alignment with `skills/crow-workspace/setup.sh`. The template had fallen significantly behind the live file; this PR re-syncs them. No behavior change for users on dev builds; .app users get the up-to-date bundled fallback.

## Test plan

- [x] `swift test --arch arm64` — 184 tests pass; updated `AttributionSkillTests` assertions invert (now expects `{{…}}` sentinel; shell expression must not appear).
- [ ] Manual create-ticket repro: in a Manager session, `/crow-create-ticket \"Test\"` — issue body footer reads `[🐦‍⬛ Created with Crow via Claude Code](...)` (or `Cursor` / `OpenAI Codex` per session config), never the `\${…}` literal.
- [ ] Manual review-pr repro: trigger a review session, post a `--request-changes`; review body footer reads the literal agent name.
- [ ] Manual commit repro: in a new worktree, make any commit; trailer reads `🐦‍⬛ Generated with <Agent Name>, orchestrated by Crow` matching the worktree's resolved agent.
- [ ] `rg '\\\${CROW_AGENT_DISPLAY_NAME' skills/ Resources/` returns only the explicit \"do not reintroduce\" warning lines in FOOTER.md.

## Backfill

None needed. Pre-fix commits will still contain the leaked literal — reviewers should ignore that text in history.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow