### PR TITLE
Reconcile stale bundled tmux conf on attach (CROW-450)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -488,13 +488,70 @@ public final class TmuxBackend {
             socketPath: socketPath,
             sessionName: TmuxBackend.cockpitSessionName
         )
-        let confPath = BundledResources.tmuxConfURL?.path
-        if confPath == nil {
+        guard let confURL = BundledResources.tmuxConfURL else {
             throw TmuxBackendError.bundledResourceMissing("crow-tmux.conf")
         }
-        try Self.ensureCockpitSession(ctrl, configPath: confPath)
+        // The cockpit session may already be live from a prior Crow launch
+        // (#330 stable socket). If so, the bundled conf the server loaded at
+        // `-f` time may now be stale relative to the file on disk (#450) —
+        // capture the pre-attach state so we can reconcile below.
+        let serverWasAlreadyLive = ctrl.hasSession()
+        try Self.ensureCockpitSession(ctrl, configPath: confURL.path)
         controller = ctrl
+        if serverWasAlreadyLive {
+            Self.reconcileBundledConfigIfStale(controller: ctrl, configURL: confURL)
+        }
         return ctrl
+    }
+
+    // MARK: - Stale-config reconciliation (#450)
+
+    /// Re-source the bundled tmux conf on a live server iff the file on disk
+    /// has been modified since the server started. Non-destructive: existing
+    /// windows/sessions survive a `source-file` — server-scoped options
+    /// (mouse, status, escape-time, …) update in place. Failures are logged
+    /// and swallowed; a stale conf is not worth aborting startup over.
+    ///
+    /// Caveat: the bundled conf includes `set -gas terminal-features ',…'`
+    /// which re-appends on each source-file. tmux tolerates duplicate feature
+    /// flags (merged by name) so the duplication is benign.
+    nonisolated static func reconcileBundledConfigIfStale(
+        controller: TmuxController,
+        configURL: URL
+    ) {
+        let confPath = configURL.path
+        let confMTime = (try? FileManager.default.attributesOfItem(atPath: confPath))?[.modificationDate] as? Date
+        let serverStart = serverStartTime(controller: controller)
+
+        guard shouldReconcile(configMTime: confMTime, serverStartTime: serverStart) else {
+            NSLog("[CrowTelemetry tmux:config_reconcile_skipped reason=fresh]")
+            return
+        }
+
+        do {
+            try controller.run(["source-file", confPath])
+            NSLog("[CrowTelemetry tmux:config_reconciled path=\(confPath)]")
+        } catch {
+            NSLog("[CrowTelemetry tmux:config_reconcile_failed error=\"\(error)\"]")
+        }
+    }
+
+    /// Pure policy: reconcile when either timestamp is missing (conservative
+    /// — a redundant `source-file` is cheap) or when the conf is newer than
+    /// the running server.
+    nonisolated static func shouldReconcile(configMTime: Date?, serverStartTime: Date?) -> Bool {
+        guard let configMTime, let serverStartTime else { return true }
+        return configMTime > serverStartTime
+    }
+
+    /// `tmux display -p '#{start_time}'` → Unix epoch as a string. Returns
+    /// nil on any IO/parse failure; callers treat nil as "unknown — reconcile
+    /// to be safe".
+    nonisolated static func serverStartTime(controller: TmuxController) -> Date? {
+        guard let raw = try? controller.run(["display", "-p", "#{start_time}"]) else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let epoch = TimeInterval(trimmed) else { return nil }
+        return Date(timeIntervalSince1970: epoch)
     }
 
     /// Ensure the cockpit session is live, adopting an existing one if a

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/TmuxBackendTests.swift
@@ -448,4 +448,138 @@ struct TmuxBackendTests {
 
         #expect(bareShells.isEmpty)
     }
+
+    // MARK: - #450 stale-config reconciliation
+
+    /// Integration regression for #450: when Crow attaches to a tmux server
+    /// that loaded an older bundled conf, source-file the on-disk version on
+    /// the live server so server-scoped options catch up — without touching
+    /// existing windows.
+    @Test func staleConfIsReconciledOnAttach() throws {
+        let socket = sharedSocketPath()
+        let dir = NSTemporaryDirectory() as NSString
+        let confPath = dir.appendingPathComponent("crow-test-conf-\(UUID().uuidString.prefix(8)).conf")
+        defer { try? FileManager.default.removeItem(atPath: confPath) }
+
+        // Conf A: status on. Back-date the file so its mtime is clearly older
+        // than the server we're about to start.
+        try "set -gs status on\n".write(toFile: confPath, atomically: true, encoding: .utf8)
+        let oldMTime = Date(timeIntervalSinceNow: -3600)
+        try FileManager.default.setAttributes(
+            [.modificationDate: oldMTime], ofItemAtPath: confPath
+        )
+
+        let ctrl = TmuxController(
+            tmuxBinary: discoveredTmuxBinary!,
+            socketPath: socket,
+            sessionName: TmuxBackend.cockpitSessionName
+        )
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: socket)
+        }
+        try ctrl.newSessionDetached(
+            configPath: confPath,
+            command: "/usr/bin/tail -f /dev/null"
+        )
+        let beforeWindows = try ctrl.listWindowIndices()
+        let statusBefore = try ctrl.run(["show", "-gv", "status"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(statusBefore == "on")
+
+        // Conf B: status off. mtime defaults to now → clearly newer than the
+        // server's start time.
+        try "set -gs status off\n".write(toFile: confPath, atomically: true, encoding: .utf8)
+
+        TmuxBackend.reconcileBundledConfigIfStale(
+            controller: ctrl,
+            configURL: URL(fileURLWithPath: confPath)
+        )
+
+        let statusAfter = try ctrl.run(["show", "-gv", "status"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(statusAfter == "off")
+
+        // Existing windows survive.
+        let afterWindows = try ctrl.listWindowIndices()
+        #expect(afterWindows == beforeWindows)
+    }
+
+    /// When the conf is older than the server start, reconciliation is a
+    /// no-op — the running settings stay as-is.
+    @Test func freshConfIsNotReconciled() throws {
+        let socket = sharedSocketPath()
+        let dir = NSTemporaryDirectory() as NSString
+        let confPath = dir.appendingPathComponent("crow-test-conf-\(UUID().uuidString.prefix(8)).conf")
+        defer { try? FileManager.default.removeItem(atPath: confPath) }
+
+        // Conf seeds status=on at server start.
+        try "set -gs status on\n".write(toFile: confPath, atomically: true, encoding: .utf8)
+        let ctrl = TmuxController(
+            tmuxBinary: discoveredTmuxBinary!,
+            socketPath: socket,
+            sessionName: TmuxBackend.cockpitSessionName
+        )
+        defer {
+            ctrl.killServer()
+            try? FileManager.default.removeItem(atPath: socket)
+        }
+        try ctrl.newSessionDetached(
+            configPath: confPath,
+            command: "/usr/bin/tail -f /dev/null"
+        )
+
+        // Rewrite the file content but back-date mtime so it predates server
+        // start. Reconciler must skip and the running value must not change.
+        try "set -gs status off\n".write(toFile: confPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3600)],
+            ofItemAtPath: confPath
+        )
+
+        TmuxBackend.reconcileBundledConfigIfStale(
+            controller: ctrl,
+            configURL: URL(fileURLWithPath: confPath)
+        )
+
+        let status = try ctrl.run(["show", "-gv", "status"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(status == "on")
+    }
+}
+
+/// Pure-policy tests for `shouldReconcile`. No tmux required, so the suite is
+/// always enabled (unlike the integration suite above).
+@Suite("TmuxBackend stale-config policy")
+struct TmuxBackendConfigPolicyTests {
+    @Test func reconcileWhenConfNewer() {
+        let server = Date(timeIntervalSince1970: 1_000)
+        let conf = Date(timeIntervalSince1970: 2_000)
+        #expect(TmuxBackend.shouldReconcile(configMTime: conf, serverStartTime: server))
+    }
+
+    @Test func skipWhenConfOlder() {
+        let server = Date(timeIntervalSince1970: 2_000)
+        let conf = Date(timeIntervalSince1970: 1_000)
+        #expect(!TmuxBackend.shouldReconcile(configMTime: conf, serverStartTime: server))
+    }
+
+    @Test func skipWhenConfEqualsServerStart() {
+        let same = Date(timeIntervalSince1970: 1_500)
+        #expect(!TmuxBackend.shouldReconcile(configMTime: same, serverStartTime: same))
+    }
+
+    @Test func reconcileWhenServerStartUnknown() {
+        let conf = Date(timeIntervalSince1970: 1_000)
+        #expect(TmuxBackend.shouldReconcile(configMTime: conf, serverStartTime: nil))
+    }
+
+    @Test func reconcileWhenConfMTimeUnknown() {
+        let server = Date(timeIntervalSince1970: 1_000)
+        #expect(TmuxBackend.shouldReconcile(configMTime: nil, serverStartTime: server))
+    }
+
+    @Test func reconcileWhenBothUnknown() {
+        #expect(TmuxBackend.shouldReconcile(configMTime: nil, serverStartTime: nil))
+    }
 }


### PR DESCRIPTION
## Summary

- When `TmuxBackend.ensureRunningServer` adopts a cockpit session that was already live before this Crow process attached, run `tmux source-file <bundled-conf>` on the live server if the on-disk conf is newer than `#{start_time}`.
- This applies server-scoped options (`mouse`, `status`, `escape-time`, …) without touching existing windows. Newly created servers skip reconciliation because they just loaded the conf via `-f`.
- Closes #450.

## Why

Since #330, the bundled tmux server outlives a clean Crow quit and is re-attached on the next launch. tmux only reads `-f <conf>` once at server start, so fixes shipped through `crow-tmux.conf` (e.g. #446's `mouse off`) never reach users whose server predates the update. The reporter's server had run 13 days while the fix had been on disk 2 days; `tmux show -gv mouse` still reported `on`.

## Approach

- `shouldReconcile(configMTime:serverStartTime:)` — pure policy: reconcile if conf > server start, or if either timestamp is unreadable (conservative; `source-file` is cheap).
- `serverStartTime(controller:)` — wraps `tmux display -p '#{start_time}'`.
- `reconcileBundledConfigIfStale(controller:configURL:)` — the orchestrator; logs `[CrowTelemetry tmux:config_reconciled path=…]` or `[CrowTelemetry tmux:config_reconcile_skipped reason=fresh]`.
- Gate at the `ensureRunningServer` hook: capture `ctrl.hasSession()` BEFORE `ensureCockpitSession` so we only reconcile servers we attached to, never servers we just created.

Chose `source-file` over a parsed per-option diff because the conf is small, source-file is exactly what tmux runs on `-f`, and the only non-perfect-idempotency wart (`set -gas terminal-features ',…'` re-appends) is benign — tmux merges feature flags by name.

## Test plan

- [x] Added pure-policy unit tests (`TmuxBackendConfigPolicyTests`) covering both-known/older/newer/equal/either-nil cases.
- [x] Added integration regression `staleConfIsReconciledOnAttach`: write conf A with `status on`, start server, replace with conf B (`status off`) with fresh mtime, call reconciler, assert `tmux show -gv status` flips to `off` AND existing windows survive.
- [x] Added integration regression `freshConfIsNotReconciled`: back-dated newer-content conf is NOT applied (gate works).
- [x] `swift test --package-path Packages/CrowTerminal --filter TmuxBackend` → 23/23 pass.
- [ ] Manual repro: `touch Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf`, quit + relaunch Crow, observe `tmux:config_reconciled` log line and `tmux show -gv mouse` reports `off`.

Closes #450