### PR TITLE
Restore tmux mouse, keep selection via copy-pipe-no-clear

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -23,16 +23,25 @@ set -gs default-terminal screen-256color
 # this, tmux steals one cell row from the Ghostty surface.
 set -gs status off
 
-# Leave mouse off so Ghostty owns selection, scroll, and clipboard. With
-# mouse on, tmux captures every mouse event and enables terminal mouse
-# reporting; libghostty then clears the selection on mouse-up (#445).
-# Apps that need mouse (vim, htop, etc.) still enable it via the usual
-# xterm mouse protocol while running.
-set -gs mouse off
+# Mouse on so wheel scrolls tmux pane history. Selection-clear on
+# mouse-up (#445) is fixed by the bindings below, not by disabling mouse
+# entirely — that broke wheel scrollback (#452). Apps that need mouse
+# (vim, htop, etc.) enable the xterm mouse protocol at runtime, which
+# still works alongside this.
+set -gs mouse on
 
 # Crow owns the keyboard namespace. Drop every default binding; actions
-# are driven from Swift via `tmux <subcommand>` calls.
+# are driven from Swift via `tmux <subcommand>` calls. `-a` clears the
+# root tables only — copy-mode / copy-mode-vi bindings below survive.
 unbind-key -a
+
+# Default MouseDragEnd1Pane is `send-keys -X copy-pipe-and-cancel`; the
+# -and-cancel exits copy mode after copying, which wipes the visual
+# selection. -no-clear keeps the selection highlighted AND copies to the
+# macOS pasteboard. Bound in both copy-mode tables since either may be
+# active depending on the user's `mode-keys` setting.
+bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"
 
 # Default history-limit is 2000 lines per pane. Phase 3 §2 (the spike)
 # measured 5 windows × 10k lines as a 400kB RSS delta, so we have plenty

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -30,9 +30,12 @@ set -gs status off
 # still works alongside this.
 set -gs mouse on
 
-# Crow owns the keyboard namespace. Drop every default binding; actions
-# are driven from Swift via `tmux <subcommand>` calls. `-a` clears the
-# root tables only — copy-mode / copy-mode-vi bindings below survive.
+# Crow owns the keyboard namespace. `unbind-key -a` (no `-T`) clears the
+# `prefix` table only — `root`, `copy-mode`, and `copy-mode-vi` are left
+# intact (use `-a -T <table>` to clear a non-prefix table). That's
+# load-bearing here: the mouse fix depends on the root-table defaults
+# (`WheelUpPane`, `MouseDrag1Pane`, …) surviving — wiping root with
+# `unbind-key -a -T root` would re-break #452 wheel scrollback.
 unbind-key -a
 
 # Default MouseDragEnd1Pane is `send-keys -X copy-pipe-and-cancel`; the
@@ -42,6 +45,17 @@ unbind-key -a
 # active depending on the user's `mode-keys` setting.
 bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"
+
+# Same fix for double-click (select-word) and triple-click (select-line)
+# on the root table — the defaults also end in `copy-pipe-and-cancel`
+# and would otherwise clear the highlight after copying, inconsistent
+# with the drag behavior above. The nested if-shell wrappers match the
+# tmux defaults: forward the mouse event to the inner app if it's
+# captured mouse (`mouse_any_flag`), or to copy-mode if a pane is
+# already in a mode; otherwise enter copy mode, select word/line, and
+# copy without clearing.
+bind -T root DoubleClick1Pane select-pane -t = \; if -F -t = "#{mouse_any_flag}" "send-keys -M" { if -F -t = "#{pane_in_mode}" "send-keys -M" { copy-mode -H ; send-keys -X select-word ; run -d0.3 ; send-keys -X copy-pipe-no-clear "pbcopy" } }
+bind -T root TripleClick1Pane select-pane -t = \; if -F -t = "#{mouse_any_flag}" "send-keys -M" { if -F -t = "#{pane_in_mode}" "send-keys -M" { copy-mode -H ; send-keys -X select-line ; run -d0.3 ; send-keys -X copy-pipe-no-clear "pbcopy" } }
 
 # Default history-limit is 2000 lines per pane. Phase 3 §2 (the spike)
 # measured 5 windows × 10k lines as a 400kB RSS delta, so we have plenty

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -41,12 +41,19 @@ struct BundledResourcesTests {
         #expect(body.contains("status off"))
     }
 
-    @Test func tmuxConfDisablesMouse() throws {
-        // tmux mouse on enables terminal mouse reporting, which makes
-        // libghostty clear selection on mouse-up (#445).
+    @Test func tmuxConfEnablesMouseWithCopyPipeNoClear() throws {
+        // Mouse must be on so the wheel drives tmux pane scrollback (#452 —
+        // turning mouse off to fix the #445 selection-clear killed wheel
+        // scrollback under tmux). Selection-clear is instead handled by
+        // overriding MouseDragEnd1Pane in both copy-mode tables to use
+        // `copy-pipe-no-clear`, which copies to the macOS pasteboard
+        // without exiting copy mode (the default `copy-pipe-and-cancel`
+        // is what wiped the highlight).
         let url = try #require(BundledResources.tmuxConfURL)
         let body = try String(contentsOf: url, encoding: .utf8)
-        #expect(body.contains("set -gs mouse off"))
-        #expect(!body.contains("set -gs mouse on"))
+        #expect(body.contains("set -gs mouse on"))
+        #expect(!body.contains("set -gs mouse off"))
+        #expect(body.contains(#"bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy""#))
+        #expect(body.contains(#"bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy""#))
     }
 }

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -45,15 +45,21 @@ struct BundledResourcesTests {
         // Mouse must be on so the wheel drives tmux pane scrollback (#452 —
         // turning mouse off to fix the #445 selection-clear killed wheel
         // scrollback under tmux). Selection-clear is instead handled by
-        // overriding MouseDragEnd1Pane in both copy-mode tables to use
-        // `copy-pipe-no-clear`, which copies to the macOS pasteboard
-        // without exiting copy mode (the default `copy-pipe-and-cancel`
-        // is what wiped the highlight).
+        // overriding the copy bindings to use `copy-pipe-no-clear`, which
+        // copies to the macOS pasteboard without exiting copy mode (the
+        // default `copy-pipe-and-cancel` is what wiped the highlight).
+        // Drag is overridden in both copy-mode tables; double/triple
+        // click are overridden in root so word/line selection is
+        // consistent with the drag behavior.
         let url = try #require(BundledResources.tmuxConfURL)
         let body = try String(contentsOf: url, encoding: .utf8)
         #expect(body.contains("set -gs mouse on"))
         #expect(!body.contains("set -gs mouse off"))
         #expect(body.contains(#"bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy""#))
         #expect(body.contains(#"bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy""#))
+        #expect(body.contains("bind -T root DoubleClick1Pane"))
+        #expect(body.contains("bind -T root TripleClick1Pane"))
+        #expect(body.contains(#"send-keys -X select-word ; run -d0.3 ; send-keys -X copy-pipe-no-clear "pbcopy""#))
+        #expect(body.contains(#"send-keys -X select-line ; run -d0.3 ; send-keys -X copy-pipe-no-clear "pbcopy""#))
     }
 }


### PR DESCRIPTION
## Summary

- PR #446 fixed the Ghostty selection-clear from #445 by setting `mouse off` in `crow-tmux.conf`. Live verification showed this re-introduces a worse bug: **wheel-scrollback through tmux pane history stops working** because tmux no longer captures wheel events, and Ghostty's own scrollback is unusable under tmux (constant redraw).
- Restore `mouse on` and override `MouseDragEnd1Pane` in both `copy-mode` and `copy-mode-vi` tables to use `copy-pipe-no-clear "pbcopy"` instead of the default `copy-pipe-and-cancel`. The `-and-cancel` is what exits copy mode after copy and clears the selection — `-no-clear` keeps the highlight while still copying to the macOS pasteboard.
- Update `BundledResourcesTests` to enforce the new contract (mouse on, mouse off absent, both `MouseDragEnd1Pane` bindings present with `copy-pipe-no-clear`).

## Test plan

- [x] `swift test --arch arm64 --filter BundledResourcesTests` — all 6 tests pass, including the rewritten `tmuxConfEnablesMouseWithCopyPipeNoClear`.
- [ ] Manual smoke on a freshly-started tmux server (see #450 for reload caveat):
  - [ ] Drag-select text → release → selection stays highlighted.
  - [ ] Cmd+V into another app pastes the selected text.
  - [ ] Wheel-up scrolls tmux pane history.
  - [ ] `vim` / `htop` mouse still works (they enable xterm mouse protocol at runtime, independent of `mouse on`).

Closes #452.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow