### PR TITLE
Complete TaskBackend/CodeBackend migration (#454)

### DIFF
--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -168,11 +168,23 @@ public struct AssignedListing: Sendable {
     public let closed: [AssignedIssue]
     /// GitHub-only; nil for GitLab.
     public let rateLimit: GitHubRateLimit?
+    /// When non-nil, the backend completed the call but had to degrade the
+    /// response because the OAuth token was missing this scope (e.g.
+    /// `read:project` on GitHub). Callers should surface a UI warning so the
+    /// user knows to refresh their token. The successful path returns the
+    /// best-effort data alongside the scope marker; no error is thrown.
+    public let missingScope: String?
 
-    public init(open: [AssignedIssue], closed: [AssignedIssue], rateLimit: GitHubRateLimit? = nil) {
+    public init(
+        open: [AssignedIssue],
+        closed: [AssignedIssue],
+        rateLimit: GitHubRateLimit? = nil,
+        missingScope: String? = nil
+    ) {
         self.open = open
         self.closed = closed
         self.rateLimit = rateLimit
+        self.missingScope = missingScope
     }
 }
 

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -1,0 +1,193 @@
+import Foundation
+import CrowCore
+
+/// Identifies a single PR by its repo coordinates and number.
+///
+/// Used as the key for batched PR-state lookups (see `CodeBackend.prStates`).
+/// `owner` and `repo` together form the GitHub `org/repo` slug; on GitLab they
+/// form the path before the `-/merge_requests/{iid}` segment.
+public struct PRRef: Sendable, Hashable {
+    public let owner: String
+    public let repo: String
+    public let number: Int
+
+    public init(owner: String, repo: String, number: Int) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+    }
+
+    public var slug: String { "\(owner)/\(repo)" }
+}
+
+/// Rich PR/MR record. Mirrors the union of fields needed across:
+///
+/// - the viewer's own open PRs (`CodeBackend.listMonitoredPRs`)
+/// - stale-PR follow-up (`CodeBackend.prStates`)
+/// - reconcile branch matches (`CodeBackend.findRecentPRsForBranches`)
+///
+/// Not every field is populated by every call — for example, `prStates` skips
+/// labels/checks because the stale-PR query doesn't fetch them. Callers merge
+/// records by URL using the `merge` helper to fill in gaps as more data
+/// arrives.
+public struct PRRecord: Sendable {
+    public let number: Int
+    public let url: String
+    public let state: String              // OPEN / MERGED / CLOSED (GitHub); normalized same for GitLab
+    public let mergeable: String          // MERGEABLE / CONFLICTING / UNKNOWN
+    public let mergeStateStatus: String   // BEHIND / BLOCKED / CLEAN / DIRTY / DRAFT / HAS_HOOKS / UNKNOWN / UNSTABLE
+    public let reviewDecision: String     // APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED / ""
+    public let isDraft: Bool
+    public let headRefName: String
+    public let headRefOid: String         // commit SHA, "" if unavailable
+    public let baseRefName: String
+    public let repoNameWithOwner: String
+    public let labels: [LabelInfo]
+    public let linkedIssueReferences: [LinkedIssueRef]
+    public let checksState: String        // SUCCESS / FAILURE / PENDING / EXPECTED / ERROR / ""
+    public let failedCheckNames: [String]
+    public let latestReviewStates: [String]
+    /// Used by reconcile tie-breaking when multiple non-OPEN PRs exist on the same branch.
+    public let updatedAt: Date?
+
+    public init(
+        number: Int,
+        url: String,
+        state: String,
+        mergeable: String = "UNKNOWN",
+        mergeStateStatus: String = "UNKNOWN",
+        reviewDecision: String = "",
+        isDraft: Bool = false,
+        headRefName: String = "",
+        headRefOid: String = "",
+        baseRefName: String = "",
+        repoNameWithOwner: String = "",
+        labels: [LabelInfo] = [],
+        linkedIssueReferences: [LinkedIssueRef] = [],
+        checksState: String = "",
+        failedCheckNames: [String] = [],
+        latestReviewStates: [String] = [],
+        updatedAt: Date? = nil
+    ) {
+        self.number = number
+        self.url = url
+        self.state = state
+        self.mergeable = mergeable
+        self.mergeStateStatus = mergeStateStatus
+        self.reviewDecision = reviewDecision
+        self.isDraft = isDraft
+        self.headRefName = headRefName
+        self.headRefOid = headRefOid
+        self.baseRefName = baseRefName
+        self.repoNameWithOwner = repoNameWithOwner
+        self.labels = labels
+        self.linkedIssueReferences = linkedIssueReferences
+        self.checksState = checksState
+        self.failedCheckNames = failedCheckNames
+        self.latestReviewStates = latestReviewStates
+        self.updatedAt = updatedAt
+    }
+}
+
+/// An issue reference linked from a PR/MR via "closes #N" or equivalent.
+public struct LinkedIssueRef: Sendable {
+    public let number: Int
+    public let repo: String
+
+    public init(number: Int, repo: String) {
+        self.number = number
+        self.repo = repo
+    }
+}
+
+/// A single commit on a PR/MR, used for Crow-author detection.
+public struct CommitInfo: Sendable {
+    public let sha: String
+    public let message: String
+
+    public init(sha: String, message: String) {
+        self.sha = sha
+        self.message = message
+    }
+}
+
+/// Input to `CodeBackend.findRecentPRsForBranches` — one (repo, branch) tuple.
+public struct BranchCandidate: Sendable, Hashable {
+    public let repoSlug: String
+    public let branch: String
+
+    public init(repoSlug: String, branch: String) {
+        self.repoSlug = repoSlug
+        self.branch = branch
+    }
+}
+
+/// One PR match returned from `findRecentPRsForBranches`, tagged with which
+/// candidate it came from so callers can route the result back to the right
+/// session.
+public struct BranchPRMatch: Sendable {
+    public let candidate: BranchCandidate
+    public let number: Int
+    public let url: String
+    public let state: String       // "OPEN" / "MERGED" / "CLOSED"
+    public let updatedAt: Date?
+
+    public init(candidate: BranchCandidate, number: Int, url: String, state: String, updatedAt: Date?) {
+        self.candidate = candidate
+        self.number = number
+        self.url = url
+        self.state = state
+        self.updatedAt = updatedAt
+    }
+}
+
+/// PR metadata returned from `CodeBackend.fetchPRMetadata` — the subset
+/// SessionService needs to prep a review clone.
+public struct PRMetadata: Sendable {
+    public let title: String
+    public let number: Int
+    public let headRefName: String
+    public let headRefOid: String
+    public let baseRefName: String
+
+    public init(title: String, number: Int, headRefName: String, headRefOid: String, baseRefName: String) {
+        self.title = title
+        self.number = number
+        self.headRefName = headRefName
+        self.headRefOid = headRefOid
+        self.baseRefName = baseRefName
+    }
+}
+
+/// Open + recently-closed issues assigned to the authenticated user.
+///
+/// Closed issues drive removal detection — IssueTracker diffs the new closed set
+/// against the prior open set to flush issues that left the user's queue.
+public struct AssignedListing: Sendable {
+    public let open: [AssignedIssue]
+    public let closed: [AssignedIssue]
+    /// GitHub-only; nil for GitLab.
+    public let rateLimit: GitHubRateLimit?
+
+    public init(open: [AssignedIssue], closed: [AssignedIssue], rateLimit: GitHubRateLimit? = nil) {
+        self.open = open
+        self.closed = closed
+        self.rateLimit = rateLimit
+    }
+}
+
+/// Viewer's own monitored PRs + review-requested PRs. Returned together because
+/// the GitHub GraphQL surface can fetch both in one batched call.
+public struct MonitoredPRListing: Sendable {
+    public let viewerPRs: [PRRecord]
+    public let reviewRequests: [ReviewRequest]
+    public let viewerLogin: String
+    public let rateLimit: GitHubRateLimit?
+
+    public init(viewerPRs: [PRRecord], reviewRequests: [ReviewRequest], viewerLogin: String, rateLimit: GitHubRateLimit? = nil) {
+        self.viewerPRs = viewerPRs
+        self.reviewRequests = reviewRequests
+        self.viewerLogin = viewerLogin
+        self.rateLimit = rateLimit
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -80,6 +80,15 @@ public struct GitHubCodeBackend: CodeBackend {
 
     // MARK: - prStates
 
+    /// `prStates` and `findRecentPRsForBranches` deliberately omit the
+    /// `rateLimit { remaining limit resetAt cost }` block their pre-migration
+    /// IssueTracker counterparts used to carry. The cycle's main consolidated
+    /// poll (`listAssigned` + `listMonitoredPRs`) already refreshes
+    /// `appState.githubRateLimit` every ~60s, so threading rate-limit out
+    /// of these secondary calls only sharpens the soft-threshold accounting
+    /// by a few requests of granularity. Re-add the block and a return-shape
+    /// tuple if that granularity ever starts mattering.
+
     public func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord] {
         guard !refs.isEmpty else { return [:] }
         var queryParts: [String] = []

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -5,19 +5,28 @@ import CrowCore
 ///
 /// Capabilities:
 /// - `.autoMergeLabel` — supports `gh label create crow:merge`.
-/// - `.batchedPRStates` — could fetch multiple PR states in one GraphQL call.
+/// - `.batchedPRStates` — batches multiple PR states in one GraphQL call.
+/// - `.autoMerge` — supports `gh pr merge --auto --squash --delete-branch`.
+/// - `.updateBranch` — supports `gh pr update-branch`.
 ///
 /// See ADR 0005 for the protocol contract.
 public struct GitHubCodeBackend: CodeBackend {
     public let provider: Provider = .github
     public let cliName: String = "gh"
-    public let capabilities: Set<CodeCapability> = [.autoMergeLabel, .batchedPRStates]
+    public let capabilities: Set<CodeCapability> = [
+        .autoMergeLabel,
+        .batchedPRStates,
+        .autoMerge,
+        .updateBranch
+    ]
 
     private let shellRunner: ShellRunner
 
     public init(shellRunner: ShellRunner) {
         self.shellRunner = shellRunner
     }
+
+    // MARK: - linkedPR / ensureMergeLabel
 
     public func linkedPR(repo: String, branch: String) async throws -> LinkedPR? {
         let output = try await shellRunner.run(
@@ -40,9 +49,6 @@ public struct GitHubCodeBackend: CodeBackend {
     }
 
     public func ensureMergeLabel(repo: String) async throws {
-        // `gh label create` is idempotent-ish: it errors if the label already
-        // exists. Swallow that one error; surface anything else with the
-        // original exit code intact.
         do {
             _ = try await shellRunner.run(
                 "gh", "label", "create", "crow:merge",
@@ -53,5 +59,393 @@ public struct GitHubCodeBackend: CodeBackend {
         } catch ShellRunnerError.nonZeroExit(_, let output) where output.localizedCaseInsensitiveContains("already exists") {
             return
         }
+    }
+
+    // MARK: - listMonitoredPRs
+
+    public func listMonitoredPRs() async throws -> MonitoredPRListing {
+        let reviewQuery = "review-requested:@me state:open type:pr"
+        let output: String
+        do {
+            output = try await shellRunner.run(
+                "gh", "api", "graphql",
+                "-f", "query=\(Self.monitoredPRsQuery)",
+                "-F", "reviewQuery=\(reviewQuery)"
+            )
+        } catch ShellRunnerError.nonZeroExit(_, let stderr) {
+            throw GitHubTaskBackend.classifyGraphQLError(stderr)
+        }
+        return try Self.parseMonitoredPRsResponse(output)
+    }
+
+    // MARK: - prStates
+
+    public func prStates(refs: [PRRef]) async throws -> [String: PRRecord] {
+        guard !refs.isEmpty else { return [:] }
+        var queryParts: [String] = []
+        var args: [String] = ["gh", "api", "graphql"]
+        for (i, ref) in refs.enumerated() {
+            queryParts.append("""
+              pr\(i): repository(owner: $owner\(i), name: $repo\(i)) {
+                pullRequest(number: $num\(i)) {
+                  number url state mergeable mergeStateStatus reviewDecision isDraft
+                  headRefName headRefOid baseRefName
+                  repository { nameWithOwner }
+                }
+              }
+            """)
+            args.append(contentsOf: ["-F", "owner\(i)=\(ref.owner)"])
+            args.append(contentsOf: ["-F", "repo\(i)=\(ref.repo)"])
+            args.append(contentsOf: ["-F", "num\(i)=\(ref.number)"])
+        }
+        var varDecls: [String] = []
+        for i in 0..<refs.count {
+            varDecls.append("$owner\(i): String!, $repo\(i): String!, $num\(i): Int!")
+        }
+        let query = """
+        query(\(varDecls.joined(separator: ", "))) {
+        \(queryParts.joined(separator: "\n"))
+          rateLimit { remaining limit resetAt cost }
+        }
+        """
+        args.insert(contentsOf: ["-f", "query=\(query)"], at: 3)
+
+        let output: String
+        do {
+            output = try await shellRunner.run(args: args, env: [:], cwd: nil)
+        } catch ShellRunnerError.nonZeroExit(_, let stderr) {
+            throw GitHubTaskBackend.classifyGraphQLError(stderr)
+        }
+        return Self.parseStalePRResponse(output, count: refs.count)
+    }
+
+    // MARK: - fetchCrowAuthoredCommits
+
+    public func fetchCrowAuthoredCommits(prURL: String, repoSlug: String, prNumber: Int) async throws -> [CommitInfo] {
+        let endpoint = "/repos/\(repoSlug)/pulls/\(prNumber)/commits"
+        let output = try await shellRunner.run(args: ["gh", "api", endpoint], env: [:], cwd: nil)
+        guard let data = output.data(using: .utf8),
+              let nodes = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+        return nodes.compactMap { node -> CommitInfo? in
+            guard let commit = node["commit"] as? [String: Any],
+                  let message = commit["message"] as? String else { return nil }
+            let sha = (node["sha"] as? String) ?? ""
+            return CommitInfo(sha: sha, message: message)
+        }
+    }
+
+    // MARK: - findRecentPRsForBranches
+
+    public func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch] {
+        var parsed: [(idx: Int, cand: BranchCandidate, owner: String, repo: String)] = []
+        for (i, c) in candidates.enumerated() {
+            let parts = c.repoSlug.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true)
+            guard parts.count == 2 else { continue }
+            parsed.append((i, c, String(parts[0]), String(parts[1])))
+        }
+        guard !parsed.isEmpty else { return [] }
+
+        var queryParts: [String] = []
+        var args: [String] = ["gh", "api", "graphql"]
+        for p in parsed {
+            queryParts.append("""
+              pr\(p.idx): repository(owner: $owner\(p.idx), name: $repo\(p.idx)) {
+                pullRequests(headRefName: $branch\(p.idx), first: 5, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                  nodes { number url state updatedAt headRefName }
+                }
+              }
+            """)
+            args.append(contentsOf: ["-F", "owner\(p.idx)=\(p.owner)"])
+            args.append(contentsOf: ["-F", "repo\(p.idx)=\(p.repo)"])
+            args.append(contentsOf: ["-F", "branch\(p.idx)=\(p.cand.branch)"])
+        }
+        var varDecls: [String] = []
+        for p in parsed {
+            varDecls.append("$owner\(p.idx): String!, $repo\(p.idx): String!, $branch\(p.idx): String!")
+        }
+        let query = """
+        query(\(varDecls.joined(separator: ", "))) {
+        \(queryParts.joined(separator: "\n"))
+          rateLimit { remaining limit resetAt cost }
+        }
+        """
+        args.insert(contentsOf: ["-f", "query=\(query)"], at: 3)
+
+        let output: String
+        do {
+            output = try await shellRunner.run(args: args, env: [:], cwd: nil)
+        } catch ShellRunnerError.nonZeroExit(_, let stderr) {
+            throw GitHubTaskBackend.classifyGraphQLError(stderr)
+        }
+        return Self.parseRecentPRsResponse(output, parsed: parsed)
+    }
+
+    // MARK: - enableAutoMerge / updateBranch
+
+    public func enableAutoMerge(prURL: String) async throws {
+        // Run inside $TMPDIR so gh doesn't pick up the cwd's git config when
+        // detecting the repo. Sub-shells let us hand gh the URL directly.
+        let cmd = #"cd "$TMPDIR" && gh pr merge \#(prURL) --auto --squash --delete-branch"#
+        _ = try await shellRunner.run(args: ["sh", "-c", cmd], env: [:], cwd: nil)
+    }
+
+    public func updateBranch(prURL: String) async throws {
+        let cmd = #"cd "$TMPDIR" && gh pr update-branch \#(prURL)"#
+        _ = try await shellRunner.run(args: ["sh", "-c", cmd], env: [:], cwd: nil)
+    }
+
+    // MARK: - fetchPRMetadata
+
+    public func fetchPRMetadata(prURL: String) async throws -> PRMetadata {
+        let output = try await shellRunner.run(
+            "gh", "pr", "view", prURL,
+            "--json", "title,headRefName,headRefOid,baseRefName,number"
+        )
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ProviderError.commandFailed("fetchPRMetadata: failed to parse `gh pr view` output")
+        }
+        return PRMetadata(
+            title: (json["title"] as? String) ?? "",
+            number: (json["number"] as? Int) ?? 0,
+            headRefName: (json["headRefName"] as? String) ?? "",
+            headRefOid: (json["headRefOid"] as? String) ?? "",
+            baseRefName: (json["baseRefName"] as? String) ?? ""
+        )
+    }
+
+    // MARK: - Queries + parsers
+
+    static let monitoredPRsQuery = """
+    query($reviewQuery: String!) {
+      viewerPRs: viewer {
+        pullRequests(first: 50, states: [OPEN], orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            number url state mergeable mergeStateStatus reviewDecision isDraft headRefName headRefOid baseRefName
+            repository { nameWithOwner }
+            labels(first: 20) { nodes { name color } }
+            closingIssuesReferences(first: 5) { nodes { number repository { nameWithOwner } } }
+            statusCheckRollup {
+              state
+              contexts(first: 25) {
+                nodes {
+                  __typename
+                  ... on CheckRun { name conclusion status }
+                  ... on StatusContext { context state }
+                }
+              }
+            }
+            latestReviews(first: 5) { nodes { state } }
+          }
+        }
+      }
+      reviewPRs: search(type: ISSUE, query: $reviewQuery, first: 50) {
+        nodes {
+          ... on PullRequest {
+            number title url isDraft updatedAt headRefName headRefOid baseRefName state
+            author { login }
+            repository { nameWithOwner }
+            labels(first: 20) { nodes { name color } }
+            reviews(last: 20) { nodes { author { login } submittedAt state } }
+          }
+        }
+      }
+      viewer { login }
+      rateLimit { remaining limit resetAt cost }
+    }
+    """
+
+    static func parseMonitoredPRsResponse(_ output: String) throws -> MonitoredPRListing {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any] else {
+            throw ProviderError.commandFailed("listMonitoredPRs: failed to parse GraphQL response")
+        }
+        let dateFmt = ISO8601DateFormatter()
+        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let viewerLogin = (dataObj["viewer"] as? [String: Any])?["login"] as? String ?? ""
+        let viewerPRs = parseViewerPRs(dataObj["viewerPRs"] as? [String: Any])
+        let reviewRequests = parseReviewRequests(
+            dataObj["reviewPRs"] as? [String: Any],
+            dateFormatter: dateFmt,
+            viewerLogin: viewerLogin.isEmpty ? nil : viewerLogin
+        )
+        let rate = GitHubTaskBackend.parseRateLimit(dataObj["rateLimit"] as? [String: Any])
+        return MonitoredPRListing(
+            viewerPRs: viewerPRs,
+            reviewRequests: reviewRequests,
+            viewerLogin: viewerLogin,
+            rateLimit: rate
+        )
+    }
+
+    static func parseViewerPRs(_ viewerObj: [String: Any]?) -> [PRRecord] {
+        guard let pullRequests = viewerObj?["pullRequests"] as? [String: Any],
+              let nodes = pullRequests["nodes"] as? [[String: Any]] else { return [] }
+        return nodes.compactMap { parsePRNode($0) }
+    }
+
+    static func parsePRNode(_ node: [String: Any]) -> PRRecord? {
+        guard let number = node["number"] as? Int,
+              let url = node["url"] as? String,
+              let state = node["state"] as? String else { return nil }
+        let mergeable = (node["mergeable"] as? String) ?? "UNKNOWN"
+        let mergeStateStatus = (node["mergeStateStatus"] as? String) ?? "UNKNOWN"
+        let reviewDecision = (node["reviewDecision"] as? String) ?? ""
+        let isDraft = (node["isDraft"] as? Bool) ?? false
+        let headRefName = (node["headRefName"] as? String) ?? ""
+        let headRefOid = (node["headRefOid"] as? String) ?? ""
+        let baseRefName = (node["baseRefName"] as? String) ?? ""
+        let repoName = (node["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
+        let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+            .compactMap { labelNode -> LabelInfo? in
+                guard let name = labelNode["name"] as? String else { return nil }
+                return LabelInfo(name: name, color: labelNode["color"] as? String)
+            } ?? []
+        let linkedNodes = (node["closingIssuesReferences"] as? [String: Any])?["nodes"] as? [[String: Any]] ?? []
+        let linkedRefs: [LinkedIssueRef] = linkedNodes.compactMap { ref in
+            guard let n = ref["number"] as? Int else { return nil }
+            let r = (ref["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
+            return LinkedIssueRef(number: n, repo: r)
+        }
+        let rollup = node["statusCheckRollup"] as? [String: Any]
+        let checksState = (rollup?["state"] as? String) ?? ""
+        let contextNodes = ((rollup?["contexts"] as? [String: Any])?["nodes"] as? [[String: Any]]) ?? []
+        let failedCheckNames: [String] = contextNodes.compactMap { ctx in
+            if let conclusion = ctx["conclusion"] as? String, conclusion == "FAILURE" {
+                return ctx["name"] as? String
+            }
+            if let st = ctx["state"] as? String, st == "FAILURE" || st == "ERROR" {
+                return ctx["context"] as? String
+            }
+            return nil
+        }
+        let latestReviewNodes = (node["latestReviews"] as? [String: Any])?["nodes"] as? [[String: Any]] ?? []
+        let reviewStates = latestReviewNodes.compactMap { $0["state"] as? String }
+        return PRRecord(
+            number: number,
+            url: url,
+            state: state,
+            mergeable: mergeable,
+            mergeStateStatus: mergeStateStatus,
+            reviewDecision: reviewDecision,
+            isDraft: isDraft,
+            headRefName: headRefName,
+            headRefOid: headRefOid,
+            baseRefName: baseRefName,
+            repoNameWithOwner: repoName,
+            labels: labels,
+            linkedIssueReferences: linkedRefs,
+            checksState: checksState,
+            failedCheckNames: failedCheckNames,
+            latestReviewStates: reviewStates
+        )
+    }
+
+    static func parseReviewRequests(
+        _ searchObj: [String: Any]?,
+        dateFormatter: ISO8601DateFormatter,
+        viewerLogin: String?
+    ) -> [ReviewRequest] {
+        guard let nodes = searchObj?["nodes"] as? [[String: Any]] else { return [] }
+        let satisfyingStates: Set<String> = ["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]
+        var requests: [ReviewRequest] = []
+        for node in nodes {
+            guard let number = node["number"] as? Int,
+                  let title = node["title"] as? String,
+                  let url = node["url"] as? String else { continue }
+            let repoName = (node["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
+            let authorLogin = (node["author"] as? [String: Any])?["login"] as? String ?? ""
+            let isDraft = (node["isDraft"] as? Bool) ?? false
+            let headBranch = (node["headRefName"] as? String) ?? ""
+            let headRefOid = node["headRefOid"] as? String
+            let baseBranch = (node["baseRefName"] as? String) ?? ""
+            let updatedAt = (node["updatedAt"] as? String).flatMap { dateFormatter.date(from: $0) }
+            let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+                .compactMap { labelNode -> LabelInfo? in
+                    guard let name = labelNode["name"] as? String else { return nil }
+                    return LabelInfo(name: name, color: labelNode["color"] as? String)
+                } ?? []
+            var viewerLastReviewedAt: Date?
+            if let viewerLogin,
+               let reviewNodes = ((node["reviews"] as? [String: Any])?["nodes"]) as? [[String: Any]] {
+                for review in reviewNodes {
+                    guard let author = (review["author"] as? [String: Any])?["login"] as? String,
+                          author == viewerLogin,
+                          let state = review["state"] as? String,
+                          satisfyingStates.contains(state),
+                          let submittedAtStr = review["submittedAt"] as? String,
+                          let submittedAt = dateFormatter.date(from: submittedAtStr) else { continue }
+                    if viewerLastReviewedAt == nil || submittedAt > viewerLastReviewedAt! {
+                        viewerLastReviewedAt = submittedAt
+                    }
+                }
+            }
+            requests.append(ReviewRequest(
+                id: "github:\(repoName)#\(number)",
+                prNumber: number,
+                title: title,
+                url: url,
+                repo: repoName,
+                author: authorLogin,
+                headBranch: headBranch,
+                baseBranch: baseBranch,
+                isDraft: isDraft,
+                requestedAt: updatedAt,
+                labels: labels,
+                provider: .github,
+                headRefOid: headRefOid,
+                viewerLastReviewedAt: viewerLastReviewedAt
+            ))
+        }
+        return requests.sorted { ($0.requestedAt ?? .distantPast) > ($1.requestedAt ?? .distantPast) }
+    }
+
+    static func parseStalePRResponse(_ output: String, count: Int) -> [String: PRRecord] {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any] else { return [:] }
+        var out: [String: PRRecord] = [:]
+        for i in 0..<count {
+            guard let repoObj = dataObj["pr\(i)"] as? [String: Any],
+                  let prObj = repoObj["pullRequest"] as? [String: Any],
+                  let url = prObj["url"] as? String,
+                  let rec = parsePRNode(prObj) else { continue }
+            out[url] = rec
+        }
+        return out
+    }
+
+    static func parseRecentPRsResponse(
+        _ output: String,
+        parsed: [(idx: Int, cand: BranchCandidate, owner: String, repo: String)]
+    ) -> [BranchPRMatch] {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any] else { return [] }
+        let dateFmt = ISO8601DateFormatter()
+        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var matches: [BranchPRMatch] = []
+        for p in parsed {
+            guard let repoObj = dataObj["pr\(p.idx)"] as? [String: Any],
+                  let prs = repoObj["pullRequests"] as? [String: Any],
+                  let nodes = prs["nodes"] as? [[String: Any]] else { continue }
+            for node in nodes {
+                guard let number = node["number"] as? Int,
+                      let url = node["url"] as? String,
+                      let state = node["state"] as? String else { continue }
+                let updatedAt = (node["updatedAt"] as? String).flatMap { dateFmt.date(from: $0) }
+                matches.append(BranchPRMatch(
+                    candidate: p.cand,
+                    number: number,
+                    url: url,
+                    state: state,
+                    updatedAt: updatedAt
+                ))
+            }
+        }
+        return matches
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -80,7 +80,7 @@ public struct GitHubCodeBackend: CodeBackend {
 
     // MARK: - prStates
 
-    public func prStates(refs: [PRRef]) async throws -> [String: PRRecord] {
+    public func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord] {
         guard !refs.isEmpty else { return [:] }
         var queryParts: [String] = []
         var args: [String] = ["gh", "api", "graphql"]
@@ -105,7 +105,6 @@ public struct GitHubCodeBackend: CodeBackend {
         let query = """
         query(\(varDecls.joined(separator: ", "))) {
         \(queryParts.joined(separator: "\n"))
-          rateLimit { remaining limit resetAt cost }
         }
         """
         args.insert(contentsOf: ["-f", "query=\(query)"], at: 3)
@@ -116,7 +115,7 @@ public struct GitHubCodeBackend: CodeBackend {
         } catch ShellRunnerError.nonZeroExit(_, let stderr) {
             throw GitHubTaskBackend.classifyGraphQLError(stderr)
         }
-        return Self.parseStalePRResponse(output, count: refs.count)
+        return Self.parseStalePRResponse(output, refs: refs)
     }
 
     // MARK: - fetchCrowAuthoredCommits
@@ -168,7 +167,6 @@ public struct GitHubCodeBackend: CodeBackend {
         let query = """
         query(\(varDecls.joined(separator: ", "))) {
         \(queryParts.joined(separator: "\n"))
-          rateLimit { remaining limit resetAt cost }
         }
         """
         args.insert(contentsOf: ["-f", "query=\(query)"], at: 3)
@@ -186,14 +184,21 @@ public struct GitHubCodeBackend: CodeBackend {
 
     public func enableAutoMerge(prURL: String) async throws {
         // Run inside $TMPDIR so gh doesn't pick up the cwd's git config when
-        // detecting the repo. Sub-shells let us hand gh the URL directly.
-        let cmd = #"cd "$TMPDIR" && gh pr merge \#(prURL) --auto --squash --delete-branch"#
-        _ = try await shellRunner.run(args: ["sh", "-c", cmd], env: [:], cwd: nil)
+        // detecting the repo. Direct argv (not `sh -c`) eliminates any shell
+        // interpolation surface around `prURL`.
+        _ = try await shellRunner.run(
+            args: ["gh", "pr", "merge", prURL, "--auto", "--squash", "--delete-branch"],
+            env: [:],
+            cwd: NSTemporaryDirectory()
+        )
     }
 
     public func updateBranch(prURL: String) async throws {
-        let cmd = #"cd "$TMPDIR" && gh pr update-branch \#(prURL)"#
-        _ = try await shellRunner.run(args: ["sh", "-c", cmd], env: [:], cwd: nil)
+        _ = try await shellRunner.run(
+            args: ["gh", "pr", "update-branch", prURL],
+            env: [:],
+            cwd: NSTemporaryDirectory()
+        )
     }
 
     // MARK: - fetchPRMetadata
@@ -403,17 +408,16 @@ public struct GitHubCodeBackend: CodeBackend {
         return requests.sorted { ($0.requestedAt ?? .distantPast) > ($1.requestedAt ?? .distantPast) }
     }
 
-    static func parseStalePRResponse(_ output: String, count: Int) -> [String: PRRecord] {
+    static func parseStalePRResponse(_ output: String, refs: [PRRef]) -> [PRRef: PRRecord] {
         guard let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataObj = json["data"] as? [String: Any] else { return [:] }
-        var out: [String: PRRecord] = [:]
-        for i in 0..<count {
+        var out: [PRRef: PRRecord] = [:]
+        for (i, ref) in refs.enumerated() {
             guard let repoObj = dataObj["pr\(i)"] as? [String: Any],
                   let prObj = repoObj["pullRequest"] as? [String: Any],
-                  let url = prObj["url"] as? String,
                   let rec = parsePRNode(prObj) else { continue }
-            out[url] = rec
+            out[ref] = rec
         }
         return out
     }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -132,7 +132,7 @@ public struct GitHubTaskBackend: TaskBackend {
             throw Self.classifyGraphQLError(output)
         }
 
-        guard let resolved = Self.resolveProjectFieldOption(queryOut, target: status.rawValue) else {
+        guard let resolved = Self.resolveProjectFieldOption(queryOut, target: status) else {
             // No project board attached to the issue, OR no matching option
             // for the requested status. Treat as unimplemented so callers can
             // distinguish "feature genuinely not available here" from "shell
@@ -236,9 +236,12 @@ public struct GitHubTaskBackend: TaskBackend {
     }
 
     /// Walk the project-item lookup response and find the (itemID, projectID,
-    /// fieldID, optionID) tuple matching `target` (case-insensitive). Returns
-    /// `nil` if the issue has no project board or no matching option.
-    static func resolveProjectFieldOption(_ output: String, target: String) -> (itemID: String, projectID: String, fieldID: String, optionID: String)? {
+    /// fieldID, optionID) tuple matching `target`. Matching goes through
+    /// `TicketStatus(projectBoardName:)` so column aliases like bare "Review"
+    /// (rather than literal "In Review") map correctly — the column-name
+    /// vocabulary the rest of the app accepts. Returns `nil` if the issue has
+    /// no project board or no aliased match.
+    static func resolveProjectFieldOption(_ output: String, target: TicketStatus) -> (itemID: String, projectID: String, fieldID: String, optionID: String)? {
         guard let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataObj = json["data"] as? [String: Any],
@@ -248,7 +251,6 @@ public struct GitHubTaskBackend: TaskBackend {
               let nodes = projectItems["nodes"] as? [[String: Any]] else {
             return nil
         }
-        let targetLower = target.lowercased()
         for node in nodes {
             guard let itemID = node["id"] as? String,
                   let project = node["project"] as? [String: Any],
@@ -258,9 +260,12 @@ public struct GitHubTaskBackend: TaskBackend {
                   let fieldID = field["id"] as? String,
                   let options = field["options"] as? [[String: Any]] else { continue }
             for option in options {
-                if let name = option["name"] as? String,
-                   name.lowercased() == targetLower,
-                   let optionID = option["id"] as? String {
+                guard let name = option["name"] as? String,
+                      let optionID = option["id"] as? String else { continue }
+                // Route through the aliasing constructor so e.g. "Review",
+                // "in review", or any future synonym in TicketStatus.init
+                // still resolves to .inReview.
+                if TicketStatus(projectBoardName: name) == target {
                     return (itemID, projectID, fieldID, optionID)
                 }
             }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -44,32 +44,41 @@ public struct GitHubTaskBackend: TaskBackend {
         )
     }
 
-    public func listAssigned() async throws -> AssignedListing {
+    public func listAssigned(includeClosed: Bool) async throws -> AssignedListing {
         let openQuery = "assignee:@me state:open type:issue"
         let closedQuery = "assignee:@me state:closed closed:>=\(Self.closedSinceString()) type:issue"
 
-        // First attempt: full query including projectItems for status. On
-        // INSUFFICIENT_SCOPES, retry without projectItems so the assigned-issue
-        // panel still renders (the status badge degrades to .unknown) and
-        // surface a `missingScope` marker on the result so callers can keep
-        // their scope-warning UI lit instead of clearing it on the next
-        // poll. On RATE_LIMITED, surface as ProviderError.rateLimited so
-        // callers can skip the cycle.
+        // GitHub batches open + closed into one GraphQL call regardless of
+        // `includeClosed` — there's no per-half network cost to save. When
+        // `includeClosed` is false we drop the closedIssues from the parsed
+        // result. The retry-without-projectItems path mirrors the same
+        // shape so the missing-scope semantics stay consistent.
         do {
             let output = try await runIssuesQuery(
                 query: Self.consolidatedIssuesQuery,
                 openQuery: openQuery,
                 closedQuery: closedQuery
             )
-            return try Self.parseIssuesResponse(output, missingScope: nil)
+            let listing = try Self.parseIssuesResponse(output, missingScope: nil)
+            return includeClosed ? listing : Self.stripClosed(listing)
         } catch ProviderError.insufficientScope(let scope) {
             let output = try await runIssuesQuery(
                 query: Self.consolidatedIssuesQueryNoProjects,
                 openQuery: openQuery,
                 closedQuery: closedQuery
             )
-            return try Self.parseIssuesResponse(output, missingScope: scope)
+            let listing = try Self.parseIssuesResponse(output, missingScope: scope)
+            return includeClosed ? listing : Self.stripClosed(listing)
         }
+    }
+
+    private static func stripClosed(_ listing: AssignedListing) -> AssignedListing {
+        AssignedListing(
+            open: listing.open,
+            closed: [],
+            rateLimit: listing.rateLimit,
+            missingScope: listing.missingScope
+        )
     }
 
     public func setLabels(url: String, add: [String], remove: [String]) async throws {

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -50,23 +50,25 @@ public struct GitHubTaskBackend: TaskBackend {
 
         // First attempt: full query including projectItems for status. On
         // INSUFFICIENT_SCOPES, retry without projectItems so the assigned-issue
-        // panel still renders (the status badge degrades to .unknown). On
-        // RATE_LIMITED, surface as ProviderError.rateLimited so callers can
-        // skip the cycle.
+        // panel still renders (the status badge degrades to .unknown) and
+        // surface a `missingScope` marker on the result so callers can keep
+        // their scope-warning UI lit instead of clearing it on the next
+        // poll. On RATE_LIMITED, surface as ProviderError.rateLimited so
+        // callers can skip the cycle.
         do {
             let output = try await runIssuesQuery(
                 query: Self.consolidatedIssuesQuery,
                 openQuery: openQuery,
                 closedQuery: closedQuery
             )
-            return try Self.parseIssuesResponse(output)
-        } catch ProviderError.insufficientScope {
+            return try Self.parseIssuesResponse(output, missingScope: nil)
+        } catch ProviderError.insufficientScope(let scope) {
             let output = try await runIssuesQuery(
                 query: Self.consolidatedIssuesQueryNoProjects,
                 openQuery: openQuery,
                 closedQuery: closedQuery
             )
-            return try Self.parseIssuesResponse(output)
+            return try Self.parseIssuesResponse(output, missingScope: scope)
         }
     }
 
@@ -341,7 +343,7 @@ public struct GitHubTaskBackend: TaskBackend {
     }
     """
 
-    static func parseIssuesResponse(_ output: String) throws -> AssignedListing {
+    static func parseIssuesResponse(_ output: String, missingScope: String?) throws -> AssignedListing {
         guard let data = output.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataObj = json["data"] as? [String: Any] else {
@@ -361,7 +363,7 @@ public struct GitHubTaskBackend: TaskBackend {
             projectStatusOverride: .done
         )
         let rate = parseRateLimit(dataObj["rateLimit"] as? [String: Any])
-        return AssignedListing(open: open, closed: closed, rateLimit: rate)
+        return AssignedListing(open: open, closed: closed, rateLimit: rate, missingScope: missingScope)
     }
 
     static func parseIssueNodes(

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -4,18 +4,14 @@ import CrowCore
 /// `TaskBackend` implementation for GitHub. Wraps the `gh` CLI.
 ///
 /// Capabilities declared:
-/// - `.batchedQuery` — `listAssigned`-style fetches use one GraphQL call.
-/// - `.projectBoardStatus` — GitHub Projects v2 is the UI surface this
-///   capability gates. The `setTaskStatus` GraphQL migration is still
-///   pending; the legacy `IssueTracker.markInReview` path (see
-///   `IssueTracker.swift:2549`) executes the mutation today via the
-///   `onMarkInReview` closure, so calling `setTaskStatus` on this backend
-///   directly still throws `.unimplemented`. UI guards branch on this
-///   capability instead of `provider == .github` (see ADR 0005); execution
-///   falls through to the legacy path until the migration lands.
+/// - `.batchedQuery` — `listAssigned` fetches open + closed issues in one
+///   GraphQL call.
+/// - `.projectBoardStatus` — GitHub Projects v2. After the #454 migration this
+///   is a real implementation: `setTaskStatus` performs the project-item
+///   lookup + `updateProjectV2ItemFieldValue` mutation. The legacy
+///   `IssueTracker.markInReview` escape-hatch is gone.
 ///
-/// See ADR 0005 for the protocol contract and its Context section for why
-/// task ops are separate from code ops.
+/// See ADR 0005.
 public struct GitHubTaskBackend: TaskBackend {
     public let provider: Provider = .github
     public let capabilities: Set<TaskCapability> = [.batchedQuery, .projectBoardStatus]
@@ -32,9 +28,6 @@ public struct GitHubTaskBackend: TaskBackend {
         guard let parsed = ProviderManager.parseTicketURLComponents(url) else {
             throw ProviderError.invalidURL(url)
         }
-        // fetchTask is issue-only by contract; if the URL is a PR the caller
-        // should be using CodeBackend. Reject here rather than silently fetching
-        // a PR — the asymmetry would invite latent bugs.
         if parsed.isMR {
             throw ProviderError.invalidURL("fetchTask received a pull request URL: \(url)")
         }
@@ -49,6 +42,32 @@ public struct GitHubTaskBackend: TaskBackend {
             provider: .github,
             isMR: false
         )
+    }
+
+    public func listAssigned() async throws -> AssignedListing {
+        let openQuery = "assignee:@me state:open type:issue"
+        let closedQuery = "assignee:@me state:closed closed:>=\(Self.closedSinceString()) type:issue"
+
+        // First attempt: full query including projectItems for status. On
+        // INSUFFICIENT_SCOPES, retry without projectItems so the assigned-issue
+        // panel still renders (the status badge degrades to .unknown). On
+        // RATE_LIMITED, surface as ProviderError.rateLimited so callers can
+        // skip the cycle.
+        do {
+            let output = try await runIssuesQuery(
+                query: Self.consolidatedIssuesQuery,
+                openQuery: openQuery,
+                closedQuery: closedQuery
+            )
+            return try Self.parseIssuesResponse(output)
+        } catch ProviderError.insufficientScope {
+            let output = try await runIssuesQuery(
+                query: Self.consolidatedIssuesQueryNoProjects,
+                openQuery: openQuery,
+                closedQuery: closedQuery
+            )
+            return try Self.parseIssuesResponse(output)
+        }
     }
 
     public func setLabels(url: String, add: [String], remove: [String]) async throws {
@@ -66,19 +85,186 @@ public struct GitHubTaskBackend: TaskBackend {
     }
 
     public func setTaskStatus(url: String, status: TicketStatus) async throws {
-        // Real implementation requires the GraphQL project-item lookup + mutation
-        // sequence currently inlined at IssueTracker.swift:2549. That migration is
-        // deferred to a follow-up PR — see ADR 0005 references.
-        // UI guards key off `.projectBoardStatus` (declared above); execution
-        // currently routes through `IssueTracker.markInReview` via the
-        // `onMarkInReview` closure rather than through this method, so the
-        // throw is unreached on the live path until the migration lands.
-        throw ProviderError.unimplemented(
-            "GitHubTaskBackend.setTaskStatus: migration of markInReview project-board mutation pending"
+        guard let parsed = ProviderManager.parseTicketURLComponents(url) else {
+            throw ProviderError.invalidURL(url)
+        }
+        // Step 1: look up the issue's project item, project, Status field, and
+        // available options. Two-step because the option ID we need to set
+        // lives on the field, not on the item.
+        let query = """
+        query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              projectItems(first: 10) {
+                nodes {
+                  id
+                  project { id }
+                  fieldValueByName(name: "Status") {
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                      field {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+
+        let queryOut: String
+        do {
+            queryOut = try await shellRunner.run(
+                "gh", "api", "graphql",
+                "-f", "query=\(query)",
+                "-F", "owner=\(parsed.org)",
+                "-F", "repo=\(parsed.repo)",
+                "-F", "number=\(parsed.number)"
+            )
+        } catch ShellRunnerError.nonZeroExit(_, let output) {
+            throw Self.classifyGraphQLError(output)
+        }
+
+        guard let resolved = Self.resolveProjectFieldOption(queryOut, target: status.rawValue) else {
+            // No project board attached to the issue, OR no matching option
+            // for the requested status. Treat as unimplemented so callers can
+            // distinguish "feature genuinely not available here" from "shell
+            // failed".
+            throw ProviderError.unimplemented(
+                "GitHubTaskBackend.setTaskStatus: issue has no project board or no '\(status.rawValue)' status option"
+            )
+        }
+
+        let mutation = """
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { singleSelectOptionId: $optionId }
+          }) {
+            projectV2Item { id }
+          }
+        }
+        """
+
+        do {
+            _ = try await shellRunner.run(
+                "gh", "api", "graphql",
+                "-f", "query=\(mutation)",
+                "-F", "projectId=\(resolved.projectID)",
+                "-F", "itemId=\(resolved.itemID)",
+                "-F", "fieldId=\(resolved.fieldID)",
+                "-F", "optionId=\(resolved.optionID)"
+            )
+        } catch ShellRunnerError.nonZeroExit(_, let output) {
+            throw Self.classifyGraphQLError(output)
+        }
+    }
+
+    public func assign(url: String, to login: String) async throws {
+        _ = try await shellRunner.run(
+            "gh", "issue", "edit", url, "--add-assignee", login
+        )
+    }
+
+    public func createTask(repo: String, title: String, body: String, labels: [String]) async throws -> TicketInfo {
+        var args: [String] = [
+            "gh", "issue", "create",
+            "--repo", repo,
+            "--title", title,
+            "--body", body
+        ]
+        for label in labels {
+            args.append("--label")
+            args.append(label)
+        }
+        let output = try await shellRunner.run(args: args, env: [:], cwd: nil)
+        // `gh issue create` prints the new issue URL on stdout. Pluck it.
+        let url = output
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { $0.hasPrefix("https://") } ?? ""
+        guard !url.isEmpty,
+              let parsed = ProviderManager.parseTicketURLComponents(url) else {
+            throw ProviderError.commandFailed("gh issue create did not return a parseable URL; got: \(output)")
+        }
+        return TicketInfo(
+            number: parsed.number,
+            title: title,
+            repo: parsed.repo,
+            org: parsed.org,
+            url: url,
+            provider: .github,
+            isMR: false
         )
     }
 
     // MARK: - Helpers
+
+    private func runIssuesQuery(query: String, openQuery: String, closedQuery: String) async throws -> String {
+        do {
+            return try await shellRunner.run(
+                "gh", "api", "graphql",
+                "-f", "query=\(query)",
+                "-F", "openQuery=\(openQuery)",
+                "-F", "closedQuery=\(closedQuery)"
+            )
+        } catch ShellRunnerError.nonZeroExit(_, let output) {
+            throw Self.classifyGraphQLError(output)
+        }
+    }
+
+    /// Classify a `gh api graphql` stderr blob into a typed error. Rate-limit
+    /// and scope failures get their own cases so callers can route them to
+    /// dedicated UI; everything else collapses to `.commandFailed`.
+    static func classifyGraphQLError(_ stderr: String) -> ProviderError {
+        if stderr.contains("RATE_LIMITED") || stderr.contains("API rate limit exceeded") {
+            return .rateLimited(stderr)
+        }
+        if stderr.contains("INSUFFICIENT_SCOPES") || stderr.contains("read:project") {
+            return .insufficientScope("read:project")
+        }
+        return .commandFailed(stderr)
+    }
+
+    /// Walk the project-item lookup response and find the (itemID, projectID,
+    /// fieldID, optionID) tuple matching `target` (case-insensitive). Returns
+    /// `nil` if the issue has no project board or no matching option.
+    static func resolveProjectFieldOption(_ output: String, target: String) -> (itemID: String, projectID: String, fieldID: String, optionID: String)? {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any],
+              let repo = dataObj["repository"] as? [String: Any],
+              let issue = repo["issue"] as? [String: Any],
+              let projectItems = issue["projectItems"] as? [String: Any],
+              let nodes = projectItems["nodes"] as? [[String: Any]] else {
+            return nil
+        }
+        let targetLower = target.lowercased()
+        for node in nodes {
+            guard let itemID = node["id"] as? String,
+                  let project = node["project"] as? [String: Any],
+                  let projectID = project["id"] as? String,
+                  let fv = node["fieldValueByName"] as? [String: Any],
+                  let field = fv["field"] as? [String: Any],
+                  let fieldID = field["id"] as? String,
+                  let options = field["options"] as? [[String: Any]] else { continue }
+            for option in options {
+                if let name = option["name"] as? String,
+                   name.lowercased() == targetLower,
+                   let optionID = option["id"] as? String {
+                    return (itemID, projectID, fieldID, optionID)
+                }
+            }
+        }
+        return nil
+    }
 
     private static func extractTitle(from output: String) -> String? {
         if let data = output.data(using: .utf8),
@@ -87,5 +273,163 @@ public struct GitHubTaskBackend: TaskBackend {
             return title
         }
         return output.components(separatedBy: .newlines).first
+    }
+
+    /// GraphQL `search` only accepts date-only for `closed:>=`. Use yesterday
+    /// (UTC) so closed-issue diffing has a 24h trailing window.
+    private static func closedSinceString() -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.timeZone = TimeZone(identifier: "UTC")
+        return fmt.string(from: Date().addingTimeInterval(-86400))
+    }
+
+    // MARK: - Query bodies + parsing
+
+    static let consolidatedIssuesQuery = """
+    query($openQuery: String!, $closedQuery: String!) {
+      openIssues: search(type: ISSUE, query: $openQuery, first: 100) {
+        nodes {
+          ... on Issue {
+            number title url state updatedAt
+            repository { nameWithOwner }
+            labels(first: 20) { nodes { name color } }
+            projectItems(first: 10) {
+              nodes {
+                fieldValueByName(name: "Status") {
+                  ... on ProjectV2ItemFieldSingleSelectValue { name }
+                }
+              }
+            }
+          }
+        }
+      }
+      closedIssues: search(type: ISSUE, query: $closedQuery, first: 50) {
+        nodes {
+          ... on Issue {
+            number title url state updatedAt
+            repository { nameWithOwner }
+            labels(first: 20) { nodes { name color } }
+          }
+        }
+      }
+      rateLimit { remaining limit resetAt cost }
+    }
+    """
+
+    static let consolidatedIssuesQueryNoProjects = """
+    query($openQuery: String!, $closedQuery: String!) {
+      openIssues: search(type: ISSUE, query: $openQuery, first: 100) {
+        nodes {
+          ... on Issue {
+            number title url state updatedAt
+            repository { nameWithOwner }
+            labels(first: 20) { nodes { name color } }
+          }
+        }
+      }
+      closedIssues: search(type: ISSUE, query: $closedQuery, first: 50) {
+        nodes {
+          ... on Issue {
+            number title url state updatedAt
+            repository { nameWithOwner }
+            labels(first: 20) { nodes { name color } }
+          }
+        }
+      }
+      rateLimit { remaining limit resetAt cost }
+    }
+    """
+
+    static func parseIssuesResponse(_ output: String) throws -> AssignedListing {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any] else {
+            throw ProviderError.commandFailed("listAssigned: failed to parse GraphQL response")
+        }
+        let dateFmt = ISO8601DateFormatter()
+        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let open = parseIssueNodes(
+            dataObj["openIssues"] as? [String: Any],
+            defaultState: "open",
+            dateFormatter: dateFmt
+        )
+        let closed = parseIssueNodes(
+            dataObj["closedIssues"] as? [String: Any],
+            defaultState: "closed",
+            dateFormatter: dateFmt,
+            projectStatusOverride: .done
+        )
+        let rate = parseRateLimit(dataObj["rateLimit"] as? [String: Any])
+        return AssignedListing(open: open, closed: closed, rateLimit: rate)
+    }
+
+    static func parseIssueNodes(
+        _ searchObj: [String: Any]?,
+        defaultState: String,
+        dateFormatter: ISO8601DateFormatter,
+        projectStatusOverride: TicketStatus? = nil
+    ) -> [AssignedIssue] {
+        guard let nodes = searchObj?["nodes"] as? [[String: Any]] else { return [] }
+        return nodes.compactMap { node -> AssignedIssue? in
+            guard let number = node["number"] as? Int,
+                  let title = node["title"] as? String,
+                  let url = node["url"] as? String else { return nil }
+            let state = (node["state"] as? String ?? defaultState).lowercased()
+            let repoName = (node["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
+            let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+                .compactMap { labelNode -> LabelInfo? in
+                    guard let name = labelNode["name"] as? String else { return nil }
+                    return LabelInfo(name: name, color: labelNode["color"] as? String)
+                } ?? []
+            var updatedAt: Date?
+            if let dateStr = node["updatedAt"] as? String {
+                updatedAt = dateFormatter.date(from: dateStr)
+            }
+            var projectStatus: TicketStatus = projectStatusOverride ?? .unknown
+            if projectStatusOverride == nil,
+               let projectItems = node["projectItems"] as? [String: Any],
+               let itemNodes = projectItems["nodes"] as? [[String: Any]] {
+                for item in itemNodes {
+                    if let fv = item["fieldValueByName"] as? [String: Any],
+                       let statusName = fv["name"] as? String {
+                        projectStatus = TicketStatus(projectBoardName: statusName)
+                        break
+                    }
+                }
+            }
+            return AssignedIssue(
+                id: "github:\(repoName)#\(number)",
+                number: number,
+                title: title,
+                state: state,
+                url: url,
+                repo: repoName,
+                labels: labels,
+                provider: .github,
+                updatedAt: updatedAt,
+                projectStatus: projectStatus
+            )
+        }
+    }
+
+    static func parseRateLimit(_ obj: [String: Any]?) -> GitHubRateLimit? {
+        guard let obj,
+              let remaining = obj["remaining"] as? Int,
+              let limit = obj["limit"] as? Int,
+              let cost = obj["cost"] as? Int,
+              let resetAtStr = obj["resetAt"] as? String else { return nil }
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let resetAt = fmt.date(from: resetAtStr)
+            ?? ISO8601DateFormatter().date(from: resetAtStr)
+            ?? Date().addingTimeInterval(60 * 60)
+        return GitHubRateLimit(
+            remaining: remaining,
+            limit: limit,
+            resetAt: resetAt,
+            cost: cost,
+            observedAt: Date()
+        )
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
@@ -68,9 +68,9 @@ public struct GitLabCodeBackend: CodeBackend {
         return MonitoredPRListing(viewerPRs: [], reviewRequests: reviewRequests, viewerLogin: "")
     }
 
-    public func prStates(refs: [PRRef]) async throws -> [String: PRRecord] {
+    public func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord] {
         // GitLab REST has no batching; one call per MR.
-        var out: [String: PRRecord] = [:]
+        var out: [PRRef: PRRecord] = [:]
         for ref in refs {
             let slug = ref.slug
             let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? slug
@@ -85,28 +85,45 @@ public struct GitLabCodeBackend: CodeBackend {
             } catch {
                 continue
             }
-            guard let data = output.data(using: .utf8),
-                  let item = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let number = item["iid"] as? Int else { continue }
-            let url = (item["web_url"] as? String) ?? ""
-            let rawState = (item["state"] as? String) ?? ""
-            let state = Self.normalizeState(rawState)
-            let headRefName = (item["source_branch"] as? String) ?? ""
-            let baseRefName = (item["target_branch"] as? String) ?? ""
-            let headRefOid = (item["sha"] as? String) ?? ""
-            let isDraft = (item["draft"] as? Bool) ?? (item["work_in_progress"] as? Bool) ?? false
-            out[url] = PRRecord(
-                number: number,
-                url: url,
-                state: state,
-                isDraft: isDraft,
-                headRefName: headRefName,
-                headRefOid: headRefOid,
-                baseRefName: baseRefName,
-                repoNameWithOwner: slug
-            )
+            guard let rec = Self.parseStaleMRResponse(
+                output,
+                fallbackURL: "",
+                fallbackSlug: slug
+            ) else { continue }
+            out[ref] = rec
         }
         return out
+    }
+
+    /// Parse a single `projects/{slug}/merge_requests/{iid}` REST response
+    /// into a `PRRecord`. State is normalized to GitHub's
+    /// `OPEN|MERGED|CLOSED` vocabulary so downstream code stays
+    /// provider-agnostic. Returns nil if the JSON shape doesn't match.
+    public static func parseStaleMRResponse(
+        _ output: String,
+        fallbackURL: String,
+        fallbackSlug: String
+    ) -> PRRecord? {
+        guard let data = output.data(using: .utf8),
+              let item = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let number = item["iid"] as? Int else { return nil }
+        let url = (item["web_url"] as? String) ?? fallbackURL
+        let rawState = (item["state"] as? String) ?? ""
+        let state = normalizeState(rawState)
+        let headRefName = (item["source_branch"] as? String) ?? ""
+        let baseRefName = (item["target_branch"] as? String) ?? ""
+        let headRefOid = (item["sha"] as? String) ?? ""
+        let isDraft = (item["draft"] as? Bool) ?? (item["work_in_progress"] as? Bool) ?? false
+        return PRRecord(
+            number: number,
+            url: url,
+            state: state,
+            isDraft: isDraft,
+            headRefName: headRefName,
+            headRefOid: headRefOid,
+            baseRefName: baseRefName,
+            repoNameWithOwner: fallbackSlug
+        )
     }
 
     public func fetchCrowAuthoredCommits(prURL: String, repoSlug: String, prNumber: Int) async throws -> [CommitInfo] {
@@ -209,7 +226,7 @@ public struct GitLabCodeBackend: CodeBackend {
         return ["GITLAB_HOST": host]
     }
 
-    static func normalizeState(_ raw: String) -> String {
+    public static func normalizeState(_ raw: String) -> String {
         switch raw {
         case "opened": return "OPEN"
         case "merged": return "MERGED"

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabCodeBackend.swift
@@ -3,9 +3,9 @@ import CrowCore
 
 /// `CodeBackend` implementation for GitLab. Wraps the `glab` CLI.
 ///
-/// Capabilities: none in v1. The merge-label flow at IssueTracker.swift:2037 is
-/// GitHub-specific today; once GitLab gets equivalent CI gating, declare `.autoMergeLabel`
-/// and implement `ensureMergeLabel`.
+/// Capabilities: none in v1. The merge-label flow, auto-merge enable, and
+/// update-branch are all GitHub-only today; once GitLab gets equivalent CI
+/// gating, declare the matching capability and implement the method.
 ///
 /// See ADR 0005.
 public struct GitLabCodeBackend: CodeBackend {
@@ -22,9 +22,6 @@ public struct GitLabCodeBackend: CodeBackend {
     }
 
     public func linkedPR(repo: String, branch: String) async throws -> LinkedPR? {
-        let env = self.env()
-        // `glab mr list` returns plain-text by default; ask for JSON via API.
-        // Pattern: list MRs whose source branch matches; pick first.
         let output = try await shellRunner.run(
             args: [
                 "glab", "mr", "list",
@@ -33,7 +30,7 @@ public struct GitLabCodeBackend: CodeBackend {
                 "--all",
                 "-F", "json"
             ],
-            env: env,
+            env: env(),
             cwd: NSHomeDirectory()
         )
         guard let data = output.data(using: .utf8),
@@ -48,13 +45,214 @@ public struct GitLabCodeBackend: CodeBackend {
     }
 
     public func ensureMergeLabel(repo: String) async throws {
-        // No `.autoMergeLabel` capability declared. Capability-gated callers
-        // skip this; a direct call is a programming error.
         throw ProviderError.unimplemented("GitLabCodeBackend.ensureMergeLabel: no autoMergeLabel capability")
     }
+
+    public func listMonitoredPRs() async throws -> MonitoredPRListing {
+        // Best-effort: GitLab assigns the viewer as either author OR reviewer
+        // depending on the workflow. Use the REST API's
+        // `merge_requests?scope=assigned_to_me` for review-requested-like MRs.
+        // The CLI doesn't surface "viewer's own monitored PRs" the same way
+        // GitHub does — we leave viewerPRs empty rather than fabricate it.
+        let output: String
+        do {
+            output = try await shellRunner.run(
+                args: ["glab", "api", "merge_requests?scope=assigned_to_me&state=opened&per_page=50"],
+                env: env(),
+                cwd: NSHomeDirectory()
+            )
+        } catch {
+            return MonitoredPRListing(viewerPRs: [], reviewRequests: [], viewerLogin: "")
+        }
+        let reviewRequests = Self.parseReviewMRs(output, host: host ?? "")
+        return MonitoredPRListing(viewerPRs: [], reviewRequests: reviewRequests, viewerLogin: "")
+    }
+
+    public func prStates(refs: [PRRef]) async throws -> [String: PRRecord] {
+        // GitLab REST has no batching; one call per MR.
+        var out: [String: PRRecord] = [:]
+        for ref in refs {
+            let slug = ref.slug
+            let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? slug
+            let endpoint = "projects/\(encodedSlug)/merge_requests/\(ref.number)"
+            let output: String
+            do {
+                output = try await shellRunner.run(
+                    args: ["glab", "api", endpoint],
+                    env: env(),
+                    cwd: NSHomeDirectory()
+                )
+            } catch {
+                continue
+            }
+            guard let data = output.data(using: .utf8),
+                  let item = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let number = item["iid"] as? Int else { continue }
+            let url = (item["web_url"] as? String) ?? ""
+            let rawState = (item["state"] as? String) ?? ""
+            let state = Self.normalizeState(rawState)
+            let headRefName = (item["source_branch"] as? String) ?? ""
+            let baseRefName = (item["target_branch"] as? String) ?? ""
+            let headRefOid = (item["sha"] as? String) ?? ""
+            let isDraft = (item["draft"] as? Bool) ?? (item["work_in_progress"] as? Bool) ?? false
+            out[url] = PRRecord(
+                number: number,
+                url: url,
+                state: state,
+                isDraft: isDraft,
+                headRefName: headRefName,
+                headRefOid: headRefOid,
+                baseRefName: baseRefName,
+                repoNameWithOwner: slug
+            )
+        }
+        return out
+    }
+
+    public func fetchCrowAuthoredCommits(prURL: String, repoSlug: String, prNumber: Int) async throws -> [CommitInfo] {
+        let encodedSlug = repoSlug.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? repoSlug
+        let endpoint = "projects/\(encodedSlug)/merge_requests/\(prNumber)/commits"
+        let output = try await shellRunner.run(
+            args: ["glab", "api", endpoint],
+            env: env(),
+            cwd: NSHomeDirectory()
+        )
+        guard let data = output.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+        return arr.compactMap { item -> CommitInfo? in
+            guard let message = item["message"] as? String else { return nil }
+            let sha = (item["id"] as? String) ?? ""
+            return CommitInfo(sha: sha, message: message)
+        }
+    }
+
+    public func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch] {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var matches: [BranchPRMatch] = []
+        for candidate in candidates {
+            let encodedSlug = candidate.repoSlug.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? candidate.repoSlug
+            let encodedBranch = candidate.branch.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? candidate.branch
+            let endpoint = "projects/\(encodedSlug)/merge_requests?source_branch=\(encodedBranch)&state=all&per_page=5&order_by=updated_at"
+            let output: String
+            do {
+                output = try await shellRunner.run(
+                    args: ["glab", "api", endpoint],
+                    env: env(),
+                    cwd: NSHomeDirectory()
+                )
+            } catch {
+                continue
+            }
+            guard let data = output.data(using: .utf8),
+                  let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+                continue
+            }
+            for item in items {
+                guard let number = item["iid"] as? Int,
+                      let url = item["web_url"] as? String else { continue }
+                let rawState = (item["state"] as? String) ?? ""
+                let normalized = Self.normalizeState(rawState)
+                let updatedAt = (item["updated_at"] as? String).flatMap { dateFormatter.date(from: $0) }
+                matches.append(BranchPRMatch(
+                    candidate: candidate,
+                    number: number,
+                    url: url,
+                    state: normalized,
+                    updatedAt: updatedAt
+                ))
+            }
+        }
+        return matches
+    }
+
+    public func enableAutoMerge(prURL: String) async throws {
+        throw ProviderError.unimplemented("GitLabCodeBackend.enableAutoMerge: no autoMerge capability")
+    }
+
+    public func updateBranch(prURL: String) async throws {
+        throw ProviderError.unimplemented("GitLabCodeBackend.updateBranch: no updateBranch capability")
+    }
+
+    public func fetchPRMetadata(prURL: String) async throws -> PRMetadata {
+        // Reuse the global URL parser to find slug + IID; then hit `glab api`.
+        guard let parsed = ProviderManager.parseTicketURLComponents(prURL) else {
+            throw ProviderError.invalidURL(prURL)
+        }
+        let slug = "\(parsed.org)/\(parsed.repo)"
+        let encodedSlug = slug.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? slug
+        let endpoint = "projects/\(encodedSlug)/merge_requests/\(parsed.number)"
+        let output = try await shellRunner.run(
+            args: ["glab", "api", endpoint],
+            env: env(),
+            cwd: NSHomeDirectory()
+        )
+        guard let data = output.data(using: .utf8),
+              let item = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ProviderError.commandFailed("fetchPRMetadata: failed to parse glab MR response")
+        }
+        return PRMetadata(
+            title: (item["title"] as? String) ?? "",
+            number: (item["iid"] as? Int) ?? parsed.number,
+            headRefName: (item["source_branch"] as? String) ?? "",
+            headRefOid: (item["sha"] as? String) ?? "",
+            baseRefName: (item["target_branch"] as? String) ?? ""
+        )
+    }
+
+    // MARK: - Helpers
 
     private func env() -> [String: String] {
         guard let host else { return [:] }
         return ["GITLAB_HOST": host]
+    }
+
+    static func normalizeState(_ raw: String) -> String {
+        switch raw {
+        case "opened": return "OPEN"
+        case "merged": return "MERGED"
+        case "closed": return "CLOSED"
+        default: return raw.uppercased()
+        }
+    }
+
+    static func parseReviewMRs(_ output: String, host: String) -> [ReviewRequest] {
+        guard let data = output.data(using: .utf8),
+              let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+        let dateFmt = ISO8601DateFormatter()
+        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return items.compactMap { item -> ReviewRequest? in
+            guard let number = item["iid"] as? Int,
+                  let title = item["title"] as? String,
+                  let url = item["web_url"] as? String else { return nil }
+            let refs = item["references"] as? [String: Any]
+            let fullRef = (refs?["full"] as? String) ?? ""
+            let author = ((item["author"] as? [String: Any])?["username"] as? String) ?? ""
+            let headBranch = (item["source_branch"] as? String) ?? ""
+            let baseBranch = (item["target_branch"] as? String) ?? ""
+            let draft = (item["draft"] as? Bool) ?? (item["work_in_progress"] as? Bool) ?? false
+            let labels = (item["labels"] as? [String] ?? []).map { LabelInfo(name: $0) }
+            let updatedAt = (item["updated_at"] as? String).flatMap { dateFmt.date(from: $0) }
+            let headRefOid = item["sha"] as? String
+            return ReviewRequest(
+                id: "gitlab:\(host):\(fullRef)",
+                prNumber: number,
+                title: title,
+                url: url,
+                repo: fullRef,
+                author: author,
+                headBranch: headBranch,
+                baseBranch: baseBranch,
+                isDraft: draft,
+                requestedAt: updatedAt,
+                labels: labels,
+                provider: .gitlab,
+                headRefOid: headRefOid
+            )
+        }
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
@@ -45,6 +45,40 @@ public struct GitLabTaskBackend: TaskBackend {
         )
     }
 
+    public func listAssigned() async throws -> AssignedListing {
+        // GitLab has no consolidated batched endpoint. Two REST calls: open + closed.
+        // Use `glab api` rather than `glab issue list` — the latter shells out to
+        // `git` even when no repo is involved and aborts with "fatal: not a git
+        // repository" when cwd isn't a git working tree.
+        let openOut: String
+        do {
+            openOut = try await shellRunner.run(
+                args: ["glab", "api", "issues?scope=assigned_to_me&state=opened&per_page=100"],
+                env: env(),
+                cwd: NSHomeDirectory()
+            )
+        } catch {
+            // Match the prior best-effort semantics: return empty rather than throwing.
+            return AssignedListing(open: [], closed: [])
+        }
+        let open = Self.parseIssues(openOut, host: host ?? "", projectStatusOverride: nil)
+
+        let updatedAfter = Self.updatedAfterString()
+        let closedOut: String
+        do {
+            closedOut = try await shellRunner.run(
+                args: ["glab", "api", "issues?scope=assigned_to_me&state=closed&per_page=50&updated_after=\(updatedAfter)"],
+                env: env(),
+                cwd: NSHomeDirectory()
+            )
+        } catch {
+            // If the closed query fails, fall back to whatever open we got.
+            return AssignedListing(open: open, closed: [])
+        }
+        let closed = Self.parseIssues(closedOut, host: host ?? "", projectStatusOverride: .done)
+        return AssignedListing(open: open, closed: closed)
+    }
+
     public func setLabels(url: String, add: [String], remove: [String]) async throws {
         guard !add.isEmpty || !remove.isEmpty else { return }
         guard let parsed = ProviderManager.parseTicketURLComponents(url) else {
@@ -70,8 +104,87 @@ public struct GitLabTaskBackend: TaskBackend {
         throw ProviderError.unimplemented("GitLabTaskBackend.setTaskStatus: no projectBoardStatus capability")
     }
 
+    public func assign(url: String, to login: String) async throws {
+        guard let parsed = ProviderManager.parseTicketURLComponents(url) else {
+            throw ProviderError.invalidURL(url)
+        }
+        let repoSlug = "\(parsed.org)/\(parsed.repo)"
+        _ = try await shellRunner.run(
+            args: ["glab", "issue", "update", "\(parsed.number)", "--repo", repoSlug, "--assignee", login],
+            env: env(),
+            cwd: NSHomeDirectory()
+        )
+    }
+
+    public func createTask(repo: String, title: String, body: String, labels: [String]) async throws -> TicketInfo {
+        var args: [String] = [
+            "glab", "issue", "create",
+            "--repo", repo,
+            "--title", title,
+            "--description", body
+        ]
+        if !labels.isEmpty {
+            args.append("--label")
+            args.append(labels.joined(separator: ","))
+        }
+        let output = try await shellRunner.run(args: args, env: env(), cwd: NSHomeDirectory())
+        // `glab issue create` prints the new issue URL on stdout.
+        let url = output
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { $0.hasPrefix("https://") } ?? ""
+        guard !url.isEmpty,
+              let parsed = ProviderManager.parseTicketURLComponents(url) else {
+            throw ProviderError.commandFailed("glab issue create did not return a parseable URL; got: \(output)")
+        }
+        return TicketInfo(
+            number: parsed.number,
+            title: title,
+            repo: parsed.repo,
+            org: parsed.org,
+            url: url,
+            provider: .gitlab,
+            isMR: false
+        )
+    }
+
+    // MARK: - Helpers
+
     private func env() -> [String: String] {
         guard let host else { return [:] }
         return ["GITLAB_HOST": host]
+    }
+
+    /// GitLab's `updated_after` accepts ISO8601. Use 24h ago to match
+    /// GitHub's `closed:>=YYYY-MM-DD` window for closed-issue diffing.
+    static func updatedAfterString() -> String {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime]
+        return fmt.string(from: Date().addingTimeInterval(-86400))
+    }
+
+    static func parseIssues(_ output: String, host: String, projectStatusOverride: TicketStatus?) -> [AssignedIssue] {
+        guard let data = output.data(using: .utf8),
+              let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        return items.compactMap { item -> AssignedIssue? in
+            guard let number = item["iid"] as? Int,
+                  let title = item["title"] as? String,
+                  let url = item["web_url"] as? String else { return nil }
+            let state = item["state"] as? String ?? "opened"
+            let labels = (item["labels"] as? [String] ?? []).map { LabelInfo(name: $0) }
+            let refs = item["references"] as? [String: Any]
+            let fullRef = refs?["full"] as? String ?? ""
+            return AssignedIssue(
+                id: "gitlab:\(host):\(fullRef)",
+                number: number,
+                title: title,
+                state: state == "opened" ? "open" : state,
+                url: url,
+                repo: fullRef,
+                labels: labels,
+                provider: .gitlab,
+                projectStatus: projectStatusOverride ?? .unknown
+            )
+        }
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitLabTaskBackend.swift
@@ -45,11 +45,15 @@ public struct GitLabTaskBackend: TaskBackend {
         )
     }
 
-    public func listAssigned() async throws -> AssignedListing {
-        // GitLab has no consolidated batched endpoint. Two REST calls: open + closed.
-        // Use `glab api` rather than `glab issue list` — the latter shells out to
-        // `git` even when no repo is involved and aborts with "fatal: not a git
-        // repository" when cwd isn't a git working tree.
+    public func listAssigned(includeClosed: Bool) async throws -> AssignedListing {
+        // GitLab has no consolidated batched endpoint. One REST call for open;
+        // a second only when `includeClosed` is true (the GitHub-driven
+        // closed-issue diff in IssueTracker doesn't consume the GitLab half,
+        // so the default GitLab caller passes false to skip the wasted
+        // round-trip every poll).
+        // Use `glab api` rather than `glab issue list` — the latter shells out
+        // to `git` even when no repo is involved and aborts with "fatal: not
+        // a git repository" when cwd isn't a git working tree.
         let openOut: String
         do {
             openOut = try await shellRunner.run(
@@ -62,6 +66,10 @@ public struct GitLabTaskBackend: TaskBackend {
             return AssignedListing(open: [], closed: [])
         }
         let open = Self.parseIssues(openOut, host: host ?? "", projectStatusOverride: nil)
+
+        guard includeClosed else {
+            return AssignedListing(open: open, closed: [])
+        }
 
         let updatedAfter = Self.updatedAfterString()
         let closedOut: String

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/StubCorveilTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/StubCorveilTaskBackend.swift
@@ -19,11 +19,23 @@ public struct StubCorveilTaskBackend: TaskBackend {
         throw ProviderError.unimplemented("StubCorveilTaskBackend.fetchTask")
     }
 
+    public func listAssigned() async throws -> AssignedListing {
+        throw ProviderError.unimplemented("StubCorveilTaskBackend.listAssigned")
+    }
+
     public func setLabels(url: String, add: [String], remove: [String]) async throws {
         throw ProviderError.unimplemented("StubCorveilTaskBackend.setLabels")
     }
 
     public func setTaskStatus(url: String, status: TicketStatus) async throws {
         throw ProviderError.unimplemented("StubCorveilTaskBackend.setTaskStatus")
+    }
+
+    public func assign(url: String, to login: String) async throws {
+        throw ProviderError.unimplemented("StubCorveilTaskBackend.assign")
+    }
+
+    public func createTask(repo: String, title: String, body: String, labels: [String]) async throws -> TicketInfo {
+        throw ProviderError.unimplemented("StubCorveilTaskBackend.createTask")
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/StubCorveilTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/StubCorveilTaskBackend.swift
@@ -19,7 +19,7 @@ public struct StubCorveilTaskBackend: TaskBackend {
         throw ProviderError.unimplemented("StubCorveilTaskBackend.fetchTask")
     }
 
-    public func listAssigned() async throws -> AssignedListing {
+    public func listAssigned(includeClosed: Bool) async throws -> AssignedListing {
         throw ProviderError.unimplemented("StubCorveilTaskBackend.listAssigned")
     }
 

--- a/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
@@ -32,6 +32,46 @@ public protocol CodeBackend: Sendable {
     /// have different label-management semantics, and a missing capability means
     /// "this provider doesn't need the same setup step").
     func ensureMergeLabel(repo: String) async throws
+
+    /// Fetch the viewer's monitored PRs and review requests in one logical
+    /// operation. GitHub batches both into a single GraphQL call; GitLab issues
+    /// two REST calls. Returned together because IssueTracker consumes them
+    /// together — the GraphQL batching is the original motivation for the
+    /// combined return shape (see ADR 0005's "Migration status" note).
+    func listMonitoredPRs() async throws -> MonitoredPRListing
+
+    /// Batched state fetch for a set of PRs. Backends with `.batchedPRStates`
+    /// issue one call; others fall back to per-PR. Returned keyed by URL so
+    /// callers can merge with other PR-by-URL maps via the standard dedup
+    /// logic.
+    func prStates(refs: [PRRef]) async throws -> [String: PRRecord]
+
+    /// Fetch every commit on the PR identified by `prURL` and `repoSlug` whose
+    /// commit message carries a `Crow-Session:` trailer — these are the commits
+    /// Crow authored on the branch. Used to gate auto-merge/auto-rebase to PRs
+    /// Crow actually contributed to.
+    func fetchCrowAuthoredCommits(prURL: String, repoSlug: String, prNumber: Int) async throws -> [CommitInfo]
+
+    /// For each `(repoSlug, branch)` candidate, fetch up to 5 recently-updated
+    /// PRs whose head matches `branch`. Used by session reconcile to recover
+    /// dropped PR links. Returns one match per (candidate, PR) — callers run
+    /// `decideReconcileLinks` to pick the best PR per candidate.
+    func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch]
+
+    /// Enable auto-merge on the PR at `prURL` (squash + delete branch).
+    /// Capability-gated on `.autoMerge`. Backends without the capability throw
+    /// `ProviderError.unimplemented`.
+    func enableAutoMerge(prURL: String) async throws
+
+    /// Trigger a "Update branch" rebase/merge from the base branch on the PR
+    /// at `prURL`. Capability-gated on `.updateBranch`. Backends without the
+    /// capability throw `ProviderError.unimplemented`.
+    func updateBranch(prURL: String) async throws
+
+    /// Fetch the metadata SessionService needs to prep a review clone:
+    /// title, head/base branch names, head commit SHA, number. Issues one
+    /// `gh pr view` / `glab mr view` call.
+    func fetchPRMetadata(prURL: String) async throws -> PRMetadata
 }
 
 /// Optional capabilities a `CodeBackend` may declare.
@@ -45,6 +85,15 @@ public enum CodeCapability: Sendable, Hashable {
     /// which path was taken. Maintained as a capability so a future GitLab REST
     /// API upgrade can flip this on without rewriting callers.
     case batchedPRStates
+
+    /// Supports `gh pr merge --auto` (or equivalent). Gates `enableAutoMerge`.
+    /// GitHub declares this; GitLab does not (the `glab` CLI doesn't expose an
+    /// equivalent "merge when checks pass" toggle).
+    case autoMerge
+
+    /// Supports `gh pr update-branch` (or equivalent). Gates `updateBranch`.
+    /// GitHub declares this; GitLab does not.
+    case updateBranch
 }
 
 /// Minimal PR/MR identity returned from `CodeBackend.linkedPR`.

--- a/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
@@ -41,15 +41,14 @@ public protocol CodeBackend: Sendable {
     func listMonitoredPRs() async throws -> MonitoredPRListing
 
     /// Batched state fetch for a set of PRs. Backends with `.batchedPRStates`
-    /// issue one call; others fall back to per-PR. Returned keyed by URL so
-    /// callers can merge with other PR-by-URL maps via the standard dedup
-    /// logic.
-    func prStates(refs: [PRRef]) async throws -> [String: PRRecord]
+    /// issue one call; others fall back to per-PR. Returned keyed by `PRRef`
+    /// (not URL) so callers don't have to round-trip through the API's
+    /// canonical URL form to look up their result.
+    func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord]
 
-    /// Fetch every commit on the PR identified by `prURL` and `repoSlug` whose
-    /// commit message carries a `Crow-Session:` trailer — these are the commits
-    /// Crow authored on the branch. Used to gate auto-merge/auto-rebase to PRs
-    /// Crow actually contributed to.
+    /// Fetch every commit on the PR identified by `prURL` and `repoSlug`.
+    /// Returns the full commit list; the caller filters for the
+    /// `Crow-Session:` trailer to identify Crow-authored commits.
     func fetchCrowAuthoredCommits(prURL: String, repoSlug: String, prNumber: Int) async throws -> [CommitInfo]
 
     /// For each `(repoSlug, branch)` candidate, fetch up to 5 recently-updated

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -316,4 +316,12 @@ public enum ProviderError: Error {
     /// A backend method is part of the protocol but not implemented for this provider yet
     /// (e.g. `StubCorveilTaskBackend` — every method throws this; see ADR 0005).
     case unimplemented(String)
+    /// GitHub `INSUFFICIENT_SCOPES` — the OAuth token is missing a required scope
+    /// (typically `read:project`). Surfaced as a typed error so call sites can
+    /// route to the existing scope-warning UI instead of treating it as a hard
+    /// failure. The associated value is the missing scope name.
+    case insufficientScope(String)
+    /// GitHub GraphQL `RATE_LIMITED`. Callers should skip the cycle and retry
+    /// after the documented reset time.
+    case rateLimited(String)
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift
@@ -23,6 +23,12 @@ public protocol TaskBackend: Sendable {
     /// Fetch a single task by URL (issue, not PR — that's `CodeBackend`).
     func fetchTask(url: String) async throws -> TicketInfo
 
+    /// Open + recently-closed issues assigned to the authenticated user.
+    /// Returning both halves in one call lets callers diff the new closed set
+    /// against the prior open set to flush issues that fell off the user's
+    /// queue.
+    func listAssigned() async throws -> AssignedListing
+
     /// Add and/or remove labels on a task by URL.
     /// - Parameters:
     ///   - url: Task URL.
@@ -31,15 +37,20 @@ public protocol TaskBackend: Sendable {
     func setLabels(url: String, add: [String], remove: [String]) async throws
 
     /// Set the project-board status for a task.
-    /// Capability-gated for **UI surfacing**: callers gate the affordance on
-    /// `capabilities.contains(.projectBoardStatus)` (see ADR 0005). The
-    /// capability does *not* guarantee this method is implemented — a backend
-    /// may declare it to surface the UI while routing execution through a
-    /// legacy path (e.g. `GitHubTaskBackend` declares the capability but
-    /// throws here; `IssueTracker.markInReview` performs the mutation until
-    /// the `setTaskStatus` GraphQL migration lands). Calling without the
-    /// capability also throws `ProviderError.unimplemented`.
+    /// Capability-gated on `.projectBoardStatus`. Backends without the
+    /// capability throw `ProviderError.unimplemented`. With the foundation +
+    /// migration of ADR 0005 in place, GitHub now actually runs the GraphQL
+    /// mutation here — no more legacy escape-hatch through IssueTracker.
     func setTaskStatus(url: String, status: TicketStatus) async throws
+
+    /// Assign an issue to `login` (e.g. `@me` for the authenticated user).
+    /// Used by session setup to claim a ticket and by skill flows.
+    func assign(url: String, to login: String) async throws
+
+    /// Create a new task in `repo` ("org/repo" slug). Returns the created
+    /// ticket's identity (number, URL, etc.) so callers can link the new
+    /// session to the new ticket immediately.
+    func createTask(repo: String, title: String, body: String, labels: [String]) async throws -> TicketInfo
 }
 
 /// Optional capabilities a `TaskBackend` may declare.
@@ -50,9 +61,10 @@ public protocol TaskBackend: Sendable {
 public enum TaskCapability: Sendable, Hashable {
     /// Declares that the provider exposes a project-board status concept the
     /// UI should surface (GitHub Projects v2 today). Gates UI affordances such
-    /// as the "Mark as In Review" button. Does **not** guarantee that calling
-    /// `setTaskStatus` succeeds — see `setTaskStatus` for the implementation
-    /// caveat. Backends without this capability hide the affordance entirely.
+    /// as the "Mark as In Review" button **and** guarantees that
+    /// `setTaskStatus` actually performs the mutation (no longer a UI-only
+    /// declaration — the legacy escape-hatch through IssueTracker.markInReview
+    /// was closed in the #454 migration; see ADR 0005).
     case projectBoardStatus
 
     /// Can fulfill `listAssigned`-style queries in a single batched call rather

--- a/Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift
@@ -27,7 +27,11 @@ public protocol TaskBackend: Sendable {
     /// Returning both halves in one call lets callers diff the new closed set
     /// against the prior open set to flush issues that fell off the user's
     /// queue.
-    func listAssigned() async throws -> AssignedListing
+    /// - Parameter includeClosed: When false, the backend skips the closed
+    ///   half. GitHub still issues one batched GraphQL call either way; GitLab
+    ///   avoids a second REST round-trip. The returned `AssignedListing.closed`
+    ///   is empty when false.
+    func listAssigned(includeClosed: Bool) async throws -> AssignedListing
 
     /// Add and/or remove labels on a task by URL.
     /// - Parameters:
@@ -51,6 +55,14 @@ public protocol TaskBackend: Sendable {
     /// ticket's identity (number, URL, etc.) so callers can link the new
     /// session to the new ticket immediately.
     func createTask(repo: String, title: String, body: String, labels: [String]) async throws -> TicketInfo
+}
+
+extension TaskBackend {
+    /// Convenience: fetch both open and recently-closed assigned issues.
+    /// Equivalent to `listAssigned(includeClosed: true)`.
+    public func listAssigned() async throws -> AssignedListing {
+        try await listAssigned(includeClosed: true)
+    }
 }
 
 /// Optional capabilities a `TaskBackend` may declare.

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -169,6 +169,28 @@ final class BackendsTests: XCTestCase {
         }
     }
 
+    func testGitHubTaskBackendSetTaskStatusMatchesBareReviewAlias() async throws {
+        // Regression guard: a project board whose Status column is named just
+        // "Review" (no "In ") must still resolve to .inReview, since
+        // TicketStatus(projectBoardName:) treats them as synonyms.
+        let fake = FakeShellRunner()
+        let lookup = """
+        {"data":{"repository":{"issue":{"projectItems":{"nodes":[
+          {"id":"ITEM_1","project":{"id":"PROJ_1"},
+           "fieldValueByName":{"name":"Backlog",
+             "field":{"id":"FIELD_1","options":[
+               {"id":"OPT_REVIEW","name":"Review"},
+               {"id":"OPT_DONE","name":"Done"}
+             ]}}}
+        ]}}}}}
+        """
+        fake.responses = [.success(lookup), .success(#"{"data":{}}"#)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
+        XCTAssertEqual(fake.calls.count, 2)
+        XCTAssertTrue(fake.calls[1].args.contains("optionId=OPT_REVIEW"))
+    }
+
     func testGitHubTaskBackendAssignInvokesGhIssueEdit() async throws {
         let fake = FakeShellRunner()
         let backend = GitHubTaskBackend(shellRunner: fake)

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -128,6 +128,8 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(listing.open.count, 0)
         // The retry call used the no-projects query — query body differs.
         XCTAssertEqual(fake.calls.count, 2)
+        // Missing-scope is surfaced so callers can keep their warning UI lit.
+        XCTAssertEqual(listing.missingScope, "read:project")
     }
 
     func testGitHubTaskBackendSetTaskStatusRunsMutation() async throws {
@@ -240,9 +242,10 @@ final class BackendsTests: XCTestCase {
         """
         fake.responses = [.success(json)]
         let backend = GitHubCodeBackend(shellRunner: fake)
-        let states = try await backend.prStates(refs: [PRRef(owner: "a", repo: "b", number: 1)])
+        let ref = PRRef(owner: "a", repo: "b", number: 1)
+        let states = try await backend.prStates(refs: [ref])
         XCTAssertEqual(states.count, 1)
-        XCTAssertEqual(states["https://github.com/a/b/pull/1"]?.state, "MERGED")
+        XCTAssertEqual(states[ref]?.state, "MERGED")
         // One batched call, not per-ref.
         XCTAssertEqual(fake.calls.count, 1)
         let args = fake.calls[0].args
@@ -275,9 +278,12 @@ final class BackendsTests: XCTestCase {
         let backend = GitHubCodeBackend(shellRunner: fake)
         try await backend.enableAutoMerge(prURL: "https://github.com/a/b/pull/1")
         XCTAssertEqual(fake.calls.count, 1)
-        // Uses sh -c with the cd $TMPDIR && gh pr merge ... incantation.
-        XCTAssertEqual(fake.calls[0].args[0], "sh")
-        XCTAssertTrue(fake.calls[0].args.contains { $0.contains("gh pr merge") && $0.contains("--auto") })
+        // Direct argv (not sh -c) into NSTemporaryDirectory — no shell
+        // interpolation surface around prURL.
+        XCTAssertEqual(fake.calls[0].args.prefix(3), ArraySlice(["gh", "pr", "merge"]))
+        XCTAssertTrue(fake.calls[0].args.contains("--auto"))
+        XCTAssertTrue(fake.calls[0].args.contains("https://github.com/a/b/pull/1"))
+        XCTAssertEqual(fake.calls[0].cwd, NSTemporaryDirectory())
     }
 
     func testGitHubCodeBackendUpdateBranchRunsGhPrUpdateBranch() async throws {
@@ -285,8 +291,8 @@ final class BackendsTests: XCTestCase {
         let backend = GitHubCodeBackend(shellRunner: fake)
         try await backend.updateBranch(prURL: "https://github.com/a/b/pull/1")
         XCTAssertEqual(fake.calls.count, 1)
-        XCTAssertEqual(fake.calls[0].args[0], "sh")
-        XCTAssertTrue(fake.calls[0].args.contains { $0.contains("gh pr update-branch") })
+        XCTAssertEqual(fake.calls[0].args, ["gh", "pr", "update-branch", "https://github.com/a/b/pull/1"])
+        XCTAssertEqual(fake.calls[0].cwd, NSTemporaryDirectory())
     }
 
     func testGitHubCodeBackendFetchPRMetadataParses() async throws {
@@ -424,9 +430,10 @@ final class BackendsTests: XCTestCase {
         let json = #"{"iid":3,"web_url":"https://gitlab.example.com/g/p/-/merge_requests/3","state":"merged","source_branch":"f","target_branch":"main","sha":"abc"}"#
         fake.responses = [.success(json)]
         let backend = GitLabCodeBackend(shellRunner: fake, host: "gitlab.example.com")
-        let states = try await backend.prStates(refs: [PRRef(owner: "g", repo: "p", number: 3)])
+        let ref = PRRef(owner: "g", repo: "p", number: 3)
+        let states = try await backend.prStates(refs: [ref])
         XCTAssertEqual(states.count, 1)
-        XCTAssertEqual(states["https://gitlab.example.com/g/p/-/merge_requests/3"]?.state, "MERGED")
+        XCTAssertEqual(states[ref]?.state, "MERGED")
         XCTAssertEqual(fake.calls.count, 1)
     }
 

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -32,13 +32,6 @@ final class BackendsTests: XCTestCase {
     func testGitHubTaskBackendDeclaresCapabilities() {
         let backend = GitHubTaskBackend(shellRunner: FakeShellRunner())
         XCTAssertEqual(backend.provider, .github)
-        // `.projectBoardStatus` declares the UI surface (GitHub Projects v2).
-        // The `setTaskStatus` GraphQL migration is still pending — execution
-        // currently routes through IssueTracker.markInReview via the
-        // onMarkInReview closure, so direct `setTaskStatus` calls on this
-        // backend still throw .unimplemented (asserted by
-        // testGitHubTaskBackendSetTaskStatusThrowsUnimplemented). See ADR 0005
-        // and issue crow#413 for the UI guard migration.
         XCTAssertTrue(backend.capabilities.contains(.projectBoardStatus))
         XCTAssertTrue(backend.capabilities.contains(.batchedQuery))
     }
@@ -94,19 +87,117 @@ final class BackendsTests: XCTestCase {
         XCTAssertTrue(fake.calls.isEmpty)
     }
 
-    func testGitHubTaskBackendSetTaskStatusThrowsUnimplemented() async {
-        let backend = GitHubTaskBackend(shellRunner: FakeShellRunner())
+    func testGitHubTaskBackendListAssignedIssuesParses() async throws {
+        let fake = FakeShellRunner()
+        let json = """
+        {"data":{
+          "openIssues":{"nodes":[
+            {"number":1,"title":"Open one","url":"https://github.com/a/b/issues/1","state":"open",
+             "repository":{"nameWithOwner":"a/b"},
+             "labels":{"nodes":[{"name":"bug","color":"red"}]},
+             "projectItems":{"nodes":[{"fieldValueByName":{"name":"In Progress"}}]}}
+          ]},
+          "closedIssues":{"nodes":[
+            {"number":2,"title":"Closed one","url":"https://github.com/a/b/issues/2","state":"closed",
+             "repository":{"nameWithOwner":"a/b"},"labels":{"nodes":[]}}
+          ]},
+          "rateLimit":{"remaining":4999,"limit":5000,"resetAt":"2026-01-01T00:00:00Z","cost":1}
+        }}
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.open.count, 1)
+        XCTAssertEqual(listing.open[0].title, "Open one")
+        XCTAssertEqual(listing.open[0].projectStatus, .inProgress)
+        XCTAssertEqual(listing.closed.count, 1)
+        XCTAssertEqual(listing.closed[0].projectStatus, .done)  // override for closed
+        XCTAssertEqual(listing.rateLimit?.remaining, 4999)
+        XCTAssertEqual(fake.calls.first?.args[0], "gh")
+        XCTAssertTrue(fake.calls.first?.args.contains("graphql") ?? false)
+    }
+
+    func testGitHubTaskBackendListAssignedRetriesWithoutProjectsOnScopeError() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [
+            .failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "GraphQL error: INSUFFICIENT_SCOPES (need read:project)")),
+            .success(#"{"data":{"openIssues":{"nodes":[]},"closedIssues":{"nodes":[]}}}"#)
+        ]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.open.count, 0)
+        // The retry call used the no-projects query — query body differs.
+        XCTAssertEqual(fake.calls.count, 2)
+    }
+
+    func testGitHubTaskBackendSetTaskStatusRunsMutation() async throws {
+        let fake = FakeShellRunner()
+        // First call: lookup. Second call: mutation.
+        let lookup = """
+        {"data":{"repository":{"issue":{"projectItems":{"nodes":[
+          {"id":"ITEM_1","project":{"id":"PROJ_1"},
+           "fieldValueByName":{"name":"Backlog",
+             "field":{"id":"FIELD_1","options":[
+               {"id":"OPT_INREVIEW","name":"In Review"},
+               {"id":"OPT_DONE","name":"Done"}
+             ]}}}
+        ]}}}}}
+        """
+        fake.responses = [.success(lookup), .success(#"{"data":{}}"#)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
+        XCTAssertEqual(fake.calls.count, 2)
+        // Mutation call should reference OPT_INREVIEW.
+        let mutationArgs = fake.calls[1].args
+        XCTAssertTrue(mutationArgs.contains("optionId=OPT_INREVIEW"))
+    }
+
+    func testGitHubTaskBackendSetTaskStatusThrowsWhenOptionMissing() async {
+        let fake = FakeShellRunner()
+        // No matching option.
+        fake.responses = [.success(#"{"data":{"repository":{"issue":{"projectItems":{"nodes":[]}}}}}"#)]
+        let backend = GitHubTaskBackend(shellRunner: fake)
         do {
             try await backend.setTaskStatus(url: "https://github.com/a/b/issues/1", status: .inReview)
             XCTFail("expected throw")
         } catch ProviderError.unimplemented {
-            // expected — see ADR 0005, migration deferred
+            // expected
         } catch {
             XCTFail("unexpected error \(error)")
         }
     }
 
+    func testGitHubTaskBackendAssignInvokesGhIssueEdit() async throws {
+        let fake = FakeShellRunner()
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        try await backend.assign(url: "https://github.com/a/b/issues/1", to: "@me")
+        XCTAssertEqual(fake.calls.count, 1)
+        XCTAssertTrue(fake.calls[0].args.contains("--add-assignee"))
+        XCTAssertTrue(fake.calls[0].args.contains("@me"))
+    }
+
+    func testGitHubTaskBackendCreateTaskReturnsParsedURL() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success("Creating issue in acme/api\n\nhttps://github.com/acme/api/issues/99\n")]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let info = try await backend.createTask(repo: "acme/api", title: "Hi", body: "There", labels: ["bug"])
+        XCTAssertEqual(info.number, 99)
+        XCTAssertEqual(info.org, "acme")
+        XCTAssertEqual(info.repo, "api")
+        XCTAssertEqual(info.url, "https://github.com/acme/api/issues/99")
+        XCTAssertTrue(fake.calls[0].args.contains("--label"))
+        XCTAssertTrue(fake.calls[0].args.contains("bug"))
+    }
+
     // MARK: - GitHubCodeBackend
+
+    func testGitHubCodeBackendDeclaresCapabilities() {
+        let backend = GitHubCodeBackend(shellRunner: FakeShellRunner())
+        XCTAssertTrue(backend.capabilities.contains(.autoMergeLabel))
+        XCTAssertTrue(backend.capabilities.contains(.batchedPRStates))
+        XCTAssertTrue(backend.capabilities.contains(.autoMerge))
+        XCTAssertTrue(backend.capabilities.contains(.updateBranch))
+    }
 
     func testGitHubCodeBackendLinkedPRParsesJSON() async throws {
         let fake = FakeShellRunner()
@@ -137,6 +228,98 @@ final class BackendsTests: XCTestCase {
         try await backend.ensureMergeLabel(repo: "a/b")
     }
 
+    func testGitHubCodeBackendPRStatesBatchesQuery() async throws {
+        let fake = FakeShellRunner()
+        let json = """
+        {"data":{
+          "pr0":{"pullRequest":{"number":1,"url":"https://github.com/a/b/pull/1","state":"MERGED",
+                 "mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","isDraft":false,
+                 "headRefName":"f","headRefOid":"abc","baseRefName":"main",
+                 "repository":{"nameWithOwner":"a/b"}}}
+        }}
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let states = try await backend.prStates(refs: [PRRef(owner: "a", repo: "b", number: 1)])
+        XCTAssertEqual(states.count, 1)
+        XCTAssertEqual(states["https://github.com/a/b/pull/1"]?.state, "MERGED")
+        // One batched call, not per-ref.
+        XCTAssertEqual(fake.calls.count, 1)
+        let args = fake.calls[0].args
+        XCTAssertTrue(args.contains("graphql"))
+    }
+
+    func testGitHubCodeBackendFetchCrowAuthoredCommitsReturnsCommitsWithTrailer() async throws {
+        let fake = FakeShellRunner()
+        let json = """
+        [
+          {"sha":"abc","commit":{"message":"Fix bug\\n\\nCrow-Session: 123"}},
+          {"sha":"def","commit":{"message":"Unrelated change"}}
+        ]
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let commits = try await backend.fetchCrowAuthoredCommits(
+            prURL: "https://github.com/a/b/pull/1",
+            repoSlug: "a/b",
+            prNumber: 1
+        )
+        // Returns ALL commits — caller filters for Crow-Session trailer.
+        XCTAssertEqual(commits.count, 2)
+        XCTAssertEqual(commits[0].sha, "abc")
+        XCTAssertTrue(commits[0].message.contains("Crow-Session"))
+    }
+
+    func testGitHubCodeBackendEnableAutoMergeRunsGhPrMerge() async throws {
+        let fake = FakeShellRunner()
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        try await backend.enableAutoMerge(prURL: "https://github.com/a/b/pull/1")
+        XCTAssertEqual(fake.calls.count, 1)
+        // Uses sh -c with the cd $TMPDIR && gh pr merge ... incantation.
+        XCTAssertEqual(fake.calls[0].args[0], "sh")
+        XCTAssertTrue(fake.calls[0].args.contains { $0.contains("gh pr merge") && $0.contains("--auto") })
+    }
+
+    func testGitHubCodeBackendUpdateBranchRunsGhPrUpdateBranch() async throws {
+        let fake = FakeShellRunner()
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        try await backend.updateBranch(prURL: "https://github.com/a/b/pull/1")
+        XCTAssertEqual(fake.calls.count, 1)
+        XCTAssertEqual(fake.calls[0].args[0], "sh")
+        XCTAssertTrue(fake.calls[0].args.contains { $0.contains("gh pr update-branch") })
+    }
+
+    func testGitHubCodeBackendFetchPRMetadataParses() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"{"title":"PR Title","number":7,"headRefName":"f","headRefOid":"abc","baseRefName":"main"}"#)]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let meta = try await backend.fetchPRMetadata(prURL: "https://github.com/a/b/pull/7")
+        XCTAssertEqual(meta.title, "PR Title")
+        XCTAssertEqual(meta.number, 7)
+        XCTAssertEqual(meta.headRefName, "f")
+        XCTAssertEqual(meta.baseRefName, "main")
+    }
+
+    func testGitHubCodeBackendFindRecentPRsForBranchesParses() async throws {
+        let fake = FakeShellRunner()
+        let json = """
+        {"data":{
+          "pr0":{"pullRequests":{"nodes":[
+            {"number":7,"url":"https://github.com/a/b/pull/7","state":"OPEN","updatedAt":"2026-01-01T00:00:00Z","headRefName":"feature/x"}
+          ]}}
+        }}
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let matches = try await backend.findRecentPRsForBranches([
+            BranchCandidate(repoSlug: "a/b", branch: "feature/x")
+        ])
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(matches[0].number, 7)
+        XCTAssertEqual(matches[0].state, "OPEN")
+        XCTAssertEqual(matches[0].candidate.branch, "feature/x")
+    }
+
     // MARK: - GitLab backends
 
     func testGitLabTaskBackendDeclaresNoCapabilities() {
@@ -157,6 +340,49 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(fake.calls.first?.env["GITLAB_HOST"], "gitlab.internal.io")
     }
 
+    func testGitLabTaskBackendListAssignedIssuesParses() async throws {
+        let fake = FakeShellRunner()
+        let openJSON = """
+        [{"iid":7,"title":"Open MR","web_url":"https://gitlab.example.com/g/p/-/issues/7","state":"opened",
+          "labels":["bug"],"references":{"full":"g/p#7"}}]
+        """
+        let closedJSON = """
+        [{"iid":3,"title":"Closed","web_url":"https://gitlab.example.com/g/p/-/issues/3","state":"closed",
+          "labels":[],"references":{"full":"g/p#3"}}]
+        """
+        fake.responses = [.success(openJSON), .success(closedJSON)]
+        let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.example.com")
+        let listing = try await backend.listAssigned()
+        XCTAssertEqual(listing.open.count, 1)
+        XCTAssertEqual(listing.open[0].title, "Open MR")
+        XCTAssertEqual(listing.open[0].state, "open")
+        XCTAssertEqual(listing.closed.count, 1)
+        XCTAssertEqual(listing.closed[0].projectStatus, .done)
+        XCTAssertNil(listing.rateLimit)  // GitLab doesn't have rate-limit JSON in this shape
+        XCTAssertEqual(fake.calls.count, 2)
+    }
+
+    func testGitLabTaskBackendAssignInvokesGlabIssueUpdate() async throws {
+        let fake = FakeShellRunner()
+        let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.example.com")
+        try await backend.assign(url: "https://gitlab.example.com/g/p/-/issues/7", to: "alice")
+        XCTAssertEqual(fake.calls.count, 1)
+        XCTAssertTrue(fake.calls[0].args.contains("--assignee"))
+        XCTAssertTrue(fake.calls[0].args.contains("alice"))
+    }
+
+    func testGitLabTaskBackendSetTaskStatusThrowsUnimplemented() async {
+        let backend = GitLabTaskBackend(shellRunner: FakeShellRunner(), host: nil)
+        do {
+            try await backend.setTaskStatus(url: "https://gitlab.example.com/g/p/-/issues/1", status: .inReview)
+            XCTFail("expected throw")
+        } catch ProviderError.unimplemented {
+            // expected
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
     func testGitLabCodeBackendEnsureMergeLabelThrowsUnimplemented() async {
         let backend = GitLabCodeBackend(shellRunner: FakeShellRunner(), host: nil)
         do {
@@ -169,6 +395,52 @@ final class BackendsTests: XCTestCase {
         }
     }
 
+    func testGitLabCodeBackendEnableAutoMergeThrowsUnimplemented() async {
+        let backend = GitLabCodeBackend(shellRunner: FakeShellRunner(), host: nil)
+        do {
+            try await backend.enableAutoMerge(prURL: "https://gitlab.example.com/g/p/-/merge_requests/1")
+            XCTFail("expected throw")
+        } catch ProviderError.unimplemented {
+            // expected
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testGitLabCodeBackendUpdateBranchThrowsUnimplemented() async {
+        let backend = GitLabCodeBackend(shellRunner: FakeShellRunner(), host: nil)
+        do {
+            try await backend.updateBranch(prURL: "https://gitlab.example.com/g/p/-/merge_requests/1")
+            XCTFail("expected throw")
+        } catch ProviderError.unimplemented {
+            // expected
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testGitLabCodeBackendPRStatesPerMR() async throws {
+        let fake = FakeShellRunner()
+        let json = #"{"iid":3,"web_url":"https://gitlab.example.com/g/p/-/merge_requests/3","state":"merged","source_branch":"f","target_branch":"main","sha":"abc"}"#
+        fake.responses = [.success(json)]
+        let backend = GitLabCodeBackend(shellRunner: fake, host: "gitlab.example.com")
+        let states = try await backend.prStates(refs: [PRRef(owner: "g", repo: "p", number: 3)])
+        XCTAssertEqual(states.count, 1)
+        XCTAssertEqual(states["https://gitlab.example.com/g/p/-/merge_requests/3"]?.state, "MERGED")
+        XCTAssertEqual(fake.calls.count, 1)
+    }
+
+    func testGitLabCodeBackendFetchPRMetadataParses() async throws {
+        let fake = FakeShellRunner()
+        let json = #"{"iid":3,"title":"MR","source_branch":"f","sha":"abc","target_branch":"main"}"#
+        fake.responses = [.success(json)]
+        let backend = GitLabCodeBackend(shellRunner: fake, host: "gitlab.example.com")
+        let meta = try await backend.fetchPRMetadata(prURL: "https://gitlab.example.com/g/p/-/merge_requests/3")
+        XCTAssertEqual(meta.title, "MR")
+        XCTAssertEqual(meta.number, 3)
+        XCTAssertEqual(meta.headRefName, "f")
+    }
+
     // MARK: - Stub Corveil
 
     func testStubCorveilTaskBackendThrowsUnimplementedForEveryMethod() async {
@@ -176,8 +448,11 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(backend.provider, .corveil)
         XCTAssertTrue(backend.capabilities.isEmpty)
         await XCTAssertThrowsErrorAsync(try await backend.fetchTask(url: "https://corveil.io/t/1"))
+        await XCTAssertThrowsErrorAsync(try await backend.listAssigned())
         await XCTAssertThrowsErrorAsync(try await backend.setLabels(url: "x", add: ["a"], remove: []))
         await XCTAssertThrowsErrorAsync(try await backend.setTaskStatus(url: "x", status: .inReview))
+        await XCTAssertThrowsErrorAsync(try await backend.assign(url: "x", to: "me"))
+        await XCTAssertThrowsErrorAsync(try await backend.createTask(repo: "a/b", title: "t", body: "b", labels: []))
     }
 
     // MARK: - Factory

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -390,6 +390,20 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(fake.calls.count, 2)
     }
 
+    func testGitLabTaskBackendListAssignedSkipsClosedCallWhenNotRequested() async throws {
+        // Regression guard: passing includeClosed: false must skip the second
+        // REST round-trip. The IssueTracker GitLab path uses this to avoid a
+        // wasted call every 60s — the closed-diff logic is GitHub-only.
+        let fake = FakeShellRunner()
+        let openJSON = #"[{"iid":7,"title":"Open","web_url":"https://gl/g/p/-/issues/7","state":"opened","labels":[],"references":{"full":"g/p#7"}}]"#
+        fake.responses = [.success(openJSON)]
+        let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.example.com")
+        let listing = try await backend.listAssigned(includeClosed: false)
+        XCTAssertEqual(listing.open.count, 1)
+        XCTAssertEqual(listing.closed.count, 0)
+        XCTAssertEqual(fake.calls.count, 1)
+    }
+
     func testGitLabTaskBackendAssignInvokesGlabIssueUpdate() async throws {
         let fake = FakeShellRunner()
         let backend = GitLabTaskBackend(shellRunner: fake, host: "gitlab.example.com")

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -627,7 +627,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Start issue tracker
-        let tracker = IssueTracker(appState: appState)
+        let tracker = IssueTracker(appState: appState, providerManager: providerManager)
         tracker.onNewReviewRequests = { [weak self] newRequests in
             for request in newRequests {
                 self?.notificationManager?.notifyReviewRequest(request)

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -1044,22 +1044,11 @@ final class IssueTracker {
     private func fetchPRsForReconcile(candidates: [ReconcileCandidate]) async -> [ReconcileBranchMatch]? {
         guard !candidates.isEmpty else { return [] }
         let backend = providerManager.codeBackend(for: .github)!
-        let cands = candidates.map { BranchCandidate(repoSlug: $0.repoSlug, branch: $0.branch) }
-        let cmap: [BranchCandidate: UUID] = Dictionary(
-            uniqueKeysWithValues: zip(cands, candidates.map(\.sessionID))
-        )
         do {
-            let matches = try await backend.findRecentPRsForBranches(cands)
-            return matches.compactMap { m in
-                guard let sid = cmap[m.candidate] else { return nil }
-                return ReconcileBranchMatch(
-                    sessionID: sid,
-                    number: m.number,
-                    url: m.url,
-                    state: m.state,
-                    updatedAt: m.updatedAt
-                )
-            }
+            let matches = try await backend.findRecentPRsForBranches(
+                Self.dedupedBranchCandidates(candidates)
+            )
+            return Self.fanOutMatches(matches, across: candidates)
         } catch {
             handleGitHubBackendError(error, operation: "findRecentPRsForBranches(github)")
             return nil
@@ -1073,26 +1062,62 @@ final class IssueTracker {
     ) async -> [ReconcileBranchMatch] {
         guard !candidates.isEmpty else { return [] }
         let backend = providerManager.codeBackend(for: .gitlab, host: host)!
-        let cands = candidates.map { BranchCandidate(repoSlug: $0.repoSlug, branch: $0.branch) }
-        let cmap: [BranchCandidate: UUID] = Dictionary(
-            uniqueKeysWithValues: zip(cands, candidates.map(\.sessionID))
-        )
         do {
-            let matches = try await backend.findRecentPRsForBranches(cands)
-            return matches.compactMap { m in
-                guard let sid = cmap[m.candidate] else { return nil }
-                return ReconcileBranchMatch(
-                    sessionID: sid,
-                    number: m.number,
-                    url: m.url,
-                    state: m.state,
-                    updatedAt: m.updatedAt
-                )
-            }
+            let matches = try await backend.findRecentPRsForBranches(
+                Self.dedupedBranchCandidates(candidates)
+            )
+            return Self.fanOutMatches(matches, across: candidates)
         } catch {
             print("[IssueTracker] Reconcile via backend failed for host \(host): \(error.localizedDescription.prefix(200))")
             return []
         }
+    }
+
+    /// Project `ReconcileCandidate`s onto the de-duplicated `(repoSlug, branch)`
+    /// pairs the backend needs. Two sessions on the same branch (a duplicated
+    /// session, or reconcile firing before the first session's PR link lands)
+    /// produce a single backend query — we fan the matches back out per
+    /// session in `fanOutMatches`.
+    nonisolated static func dedupedBranchCandidates(_ candidates: [ReconcileCandidate]) -> [BranchCandidate] {
+        var seen: Set<BranchCandidate> = []
+        var out: [BranchCandidate] = []
+        for c in candidates {
+            let bc = BranchCandidate(repoSlug: c.repoSlug, branch: c.branch)
+            if seen.insert(bc).inserted { out.append(bc) }
+        }
+        return out
+    }
+
+    /// Each backend `BranchPRMatch` is duplicated for every `ReconcileCandidate`
+    /// that shares its `(repoSlug, branch)`. This preserves the prior
+    /// per-session sessionID-threading even when two sessions point at the
+    /// same branch — collapsing them via `Dictionary(uniqueKeysWithValues:)`
+    /// would either trap or silently drop one session's PR link.
+    nonisolated static func fanOutMatches(
+        _ matches: [BranchPRMatch],
+        across candidates: [ReconcileCandidate]
+    ) -> [ReconcileBranchMatch] {
+        // Group sessions by their (repoSlug, branch) so a single match maps
+        // to every session that owns that key.
+        var sessionsByBranch: [BranchCandidate: [UUID]] = [:]
+        for c in candidates {
+            let bc = BranchCandidate(repoSlug: c.repoSlug, branch: c.branch)
+            sessionsByBranch[bc, default: []].append(c.sessionID)
+        }
+        var out: [ReconcileBranchMatch] = []
+        for match in matches {
+            guard let sids = sessionsByBranch[match.candidate] else { continue }
+            for sid in sids {
+                out.append(ReconcileBranchMatch(
+                    sessionID: sid,
+                    number: match.number,
+                    url: match.url,
+                    state: match.state,
+                    updatedAt: match.updatedAt
+                ))
+            }
+        }
+        return out
     }
 
     /// Persist the reconciliation decisions. Re-checks `appState.links` at

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -169,10 +169,6 @@ final class IssueTracker {
     /// Below this many remaining GraphQL points we proactively skip a cycle.
     private let rateLimitThreshold = 50
 
-    /// gh invocations made during the current `refresh()`. Incremented by the
-    /// shell helpers, reset at the start of each refresh.
-    private var currentRefreshGhCalls = 0
-
     init(appState: AppState, providerManager: ProviderManager) {
         self.appState = appState
         self.providerManager = providerManager
@@ -307,7 +303,6 @@ final class IssueTracker {
         appState.isLoadingIssues = true
         defer { appState.isLoadingIssues = false }
 
-        currentRefreshGhCalls = 0
         let startedAt = Date()
 
         guard let devRoot = ConfigStore.loadDevRoot(),
@@ -523,9 +518,9 @@ final class IssueTracker {
         let elapsedStr = String(format: "%.2fs", elapsed)
         if let rl = appState.githubRateLimit {
             let mins = Int(max(0, rl.resetAt.timeIntervalSinceNow / 60))
-            print("[IssueTracker] refresh: \(currentRefreshGhCalls) gh calls in \(elapsedStr), GraphQL \(rl.remaining)/\(rl.limit) remaining, resets in \(mins)m")
+            print("[IssueTracker] refresh: \(elapsedStr), GraphQL \(rl.remaining)/\(rl.limit) remaining, resets in \(mins)m")
         } else {
-            print("[IssueTracker] refresh: \(currentRefreshGhCalls) gh calls in \(elapsedStr)")
+            print("[IssueTracker] refresh: \(elapsedStr)")
         }
     }
 
@@ -1971,9 +1966,10 @@ final class IssueTracker {
     private func fetchGitLabIssues(host: String) async -> [AssignedIssue] {
         let backend = providerManager.taskBackend(for: .gitlab, host: host)
         do {
-            let listing = try await backend.listAssigned()
-            // Only open issues, to match the prior single-call semantics
-            // (refresh() consumes closed-issues via the GitHub path today).
+            // Pass includeClosed: false so we don't fire a wasted closed-issues
+            // REST call every 60s — only the open list is consumed by refresh()
+            // for the GitLab path (the closed-diff logic is GitHub-only today).
+            let listing = try await backend.listAssigned(includeClosed: false)
             return listing.open
         } catch {
             print("[IssueTracker] fetchGitLabIssues(host: \(host)) failed: \(error)")
@@ -2028,93 +2024,5 @@ final class IssueTracker {
 
         // Update local session status to .inReview
         appState.onSetSessionInReview?(sessionID)
-    }
-
-    // MARK: - Shell
-
-    private func shell(env: [String: String] = [:], cwd: String? = nil, _ args: String...) async throws -> String {
-        return try await shell(env: env, cwd: cwd, args: args)
-    }
-
-    private func shell(env: [String: String] = [:], cwd: String? = nil, args: [String]) async throws -> String {
-        currentRefreshGhCalls += 1
-        let args = args
-        let env = env
-        let cwd = cwd
-        return try await Task.detached {
-            let process = Process()
-            let outPipe = Pipe()
-            let errPipe = Pipe()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = args
-            process.environment = env.isEmpty
-                ? ShellEnvironment.shared.env
-                : ShellEnvironment.shared.merging(env)
-            if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
-            process.standardOutput = outPipe
-            process.standardError = errPipe
-            try process.run()
-            // Read pipes BEFORE waitUntilExit to avoid deadlock when
-            // output exceeds the 64 KB pipe buffer (consolidated GraphQL
-            // responses routinely reach ~86 KB).
-            let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else {
-                let stderr = (String(data: errData, encoding: .utf8) ?? "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                let cmd = args.joined(separator: " ")
-                let desc = "`\(cmd)` exited \(process.terminationStatus)"
-                    + (stderr.isEmpty ? "" : ": \(stderr)")
-                throw NSError(
-                    domain: "IssueTracker",
-                    code: Int(process.terminationStatus),
-                    userInfo: [NSLocalizedDescriptionKey: desc]
-                )
-            }
-            return String(data: outData, encoding: .utf8) ?? ""
-        }.value
-    }
-
-    private struct ShellResult: Sendable {
-        let stdout: String
-        let stderr: String
-        let exitCode: Int32
-    }
-
-    private func shellWithStatus(_ args: String...) async -> ShellResult {
-        return await shellWithStatus(args: args)
-    }
-
-    private func shellWithStatus(args: [String]) async -> ShellResult {
-        return await shellWithStatus(env: [:], args: args)
-    }
-
-    private func shellWithStatus(env: [String: String], args: [String]) async -> ShellResult {
-        currentRefreshGhCalls += 1
-        let args = args
-        let env = env
-        return await Task.detached {
-            let process = Process()
-            let outPipe = Pipe()
-            let errPipe = Pipe()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = args
-            process.environment = env.isEmpty
-                ? ShellEnvironment.shared.env
-                : ShellEnvironment.shared.merging(env)
-            process.standardOutput = outPipe
-            process.standardError = errPipe
-            do { try process.run() } catch { return ShellResult(stdout: "", stderr: error.localizedDescription, exitCode: -1) }
-            // Read pipes BEFORE waitUntilExit to avoid pipe-buffer deadlock.
-            let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-            return ShellResult(
-                stdout: String(data: outData, encoding: .utf8) ?? "",
-                stderr: String(data: errData, encoding: .utf8) ?? "",
-                exitCode: process.terminationStatus
-            )
-        }.value
     }
 }

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -605,38 +605,36 @@ final class IssueTracker {
         let taskBackend = providerManager.taskBackend(for: .github)
         let codeBackend = providerManager.codeBackend(for: .github)!
 
-        async let assignedTask = Task { () -> Result<AssignedListing, Error> in
-            do { return .success(try await taskBackend.listAssigned()) }
-            catch { return .failure(error) }
-        }.value
-        async let monitoredTask = Task { () -> Result<MonitoredPRListing, Error> in
-            do { return .success(try await codeBackend.listMonitoredPRs()) }
-            catch { return .failure(error) }
-        }.value
+        async let assignedAsync = taskBackend.listAssigned()
+        async let monitoredAsync = codeBackend.listMonitoredPRs()
 
-        let assignedResult = await assignedTask
-        let monitoredResult = await monitoredTask
-
-        switch assignedResult {
-        case .failure(let err):
-            handleGitHubBackendError(err, operation: "listAssigned")
+        let assigned: AssignedListing
+        let monitored: MonitoredPRListing
+        do {
+            assigned = try await assignedAsync
+        } catch {
+            handleGitHubBackendError(error, operation: "listAssigned")
+            // Drain the second task so we don't leak an unawaited future.
+            _ = try? await monitoredAsync
             return nil
-        case .success:
-            break
         }
-        switch monitoredResult {
-        case .failure(let err):
-            handleGitHubBackendError(err, operation: "listMonitoredPRs")
-            return nil
-        case .success:
-            break
-        }
-        guard case .success(let assigned) = assignedResult,
-              case .success(let monitored) = monitoredResult else {
+        do {
+            monitored = try await monitoredAsync
+        } catch {
+            handleGitHubBackendError(error, operation: "listMonitoredPRs")
             return nil
         }
 
-        clearScopeWarning()
+        if let scope = assigned.missingScope {
+            // listAssigned silently degrades on INSUFFICIENT_SCOPES (drops
+            // projectItems) and reports the scope here so the warning UI
+            // stays lit instead of getting cleared on the next poll. This
+            // preserves the prior `reportScopeWarning("read:project")`
+            // behavior the consolidated query had inline.
+            reportScopeWarning(scope)
+        } else {
+            clearScopeWarning()
+        }
         return ConsolidatedGitHubResponse(
             openIssues: assigned.open,
             closedIssues: assigned.closed,
@@ -739,8 +737,15 @@ final class IssueTracker {
             let backend = providerManager.codeBackend(for: .github)!
             do {
                 let states = try await backend.prStates(refs: githubRefs)
+                // Keying by PRRef means we don't lose records when the API
+                // returns a canonical URL different from the stored one.
+                // Fall back to the stored URL when the API didn't provide
+                // one (defensive — usually populated).
                 for ref in githubRefs {
-                    guard let url = githubURLByRef[ref], let rec = states[url] else { continue }
+                    guard var rec = states[ref] else { continue }
+                    if rec.url.isEmpty, let stored = githubURLByRef[ref] {
+                        rec = Self.withURL(rec, url: stored)
+                    }
                     prs.append(rec)
                 }
             } catch {
@@ -754,7 +759,10 @@ final class IssueTracker {
             do {
                 let states = try await backend.prStates(refs: refs)
                 for ref in refs {
-                    guard let url = gitlabURLByRef[ref], let rec = states[url] else { continue }
+                    guard var rec = states[ref] else { continue }
+                    if rec.url.isEmpty, let stored = gitlabURLByRef[ref] {
+                        rec = Self.withURL(rec, url: stored)
+                    }
                     prs.append(rec)
                 }
             } catch {
@@ -764,6 +772,32 @@ final class IssueTracker {
         }
 
         return StalePRFetchResult(prs: prs, complete: complete)
+    }
+
+    /// Copy `pr` with a different `url`. Used by the stale-PR follow-up to
+    /// substitute the session-link URL when the backend returned an empty
+    /// `web_url` (defensive — GitLab's REST shape always populates it, but
+    /// we'd rather preserve the link than lose the record).
+    nonisolated static func withURL(_ pr: ViewerPR, url: String) -> ViewerPR {
+        PRRecord(
+            number: pr.number,
+            url: url,
+            state: pr.state,
+            mergeable: pr.mergeable,
+            mergeStateStatus: pr.mergeStateStatus,
+            reviewDecision: pr.reviewDecision,
+            isDraft: pr.isDraft,
+            headRefName: pr.headRefName,
+            headRefOid: pr.headRefOid,
+            baseRefName: pr.baseRefName,
+            repoNameWithOwner: pr.repoNameWithOwner,
+            labels: pr.labels,
+            linkedIssueReferences: pr.linkedIssueReferences,
+            checksState: pr.checksState,
+            failedCheckNames: pr.failedCheckNames,
+            latestReviewStates: pr.latestReviewStates,
+            updatedAt: pr.updatedAt
+        )
     }
 
     /// Parse a GitLab MR URL into (host, slug, number). Robust to nested
@@ -785,6 +819,26 @@ final class IssueTracker {
         let trailParts = trailing.split(separator: "/").map(String.init)
         guard let first = trailParts.first, let number = Int(first) else { return nil }
         return (host, slug, number)
+    }
+
+    /// Thin alias so test code keeps working through the migration. The real
+    /// normalization lives on `GitLabCodeBackend` (CrowProvider).
+    nonisolated static func normalizeGitLabPRState(_ raw: String) -> String {
+        GitLabCodeBackend.normalizeState(raw)
+    }
+
+    /// Thin alias so test code keeps working through the migration. The real
+    /// parsing lives on `GitLabCodeBackend` (CrowProvider).
+    nonisolated static func parseGitLabStaleMRResponse(
+        _ output: String,
+        fallbackURL: String,
+        fallbackSlug: String
+    ) -> ViewerPR? {
+        GitLabCodeBackend.parseStaleMRResponse(
+            output,
+            fallbackURL: fallbackURL,
+            fallbackSlug: fallbackSlug
+        )
     }
 
     // Consolidated GraphQL parsing now lives in CrowProvider's GitHubTaskBackend

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -6,17 +6,26 @@ import CrowProvider
 
 /// Polls GitHub/GitLab for issues assigned to the current user.
 ///
-/// GitHub polling is consolidated into a single aliased GraphQL query per refresh
-/// (see `Self.consolidatedQuery`). Per-session PR detection, PR status, and
-/// auto-complete all piggyback on that one response — no per-session `gh` calls.
-/// The `rateLimit` block on each response feeds `AppState.githubRateLimit`, and
-/// a soft threshold + 403 detection suspend polling when quotas are low.
+/// GitHub polling routes through `CrowProvider`'s `TaskBackend.listAssigned`
+/// and `CodeBackend.listMonitoredPRs` (see ADR 0005). The PR side picks up
+/// review requests, viewer PRs, and rate-limit observation in one batched
+/// GraphQL call; the task side fetches open + recently-closed issues in
+/// another. Per-session PR detection, PR status, and auto-complete all
+/// piggyback on those two responses — no per-session `gh` calls. The
+/// `rateLimit` block on each response feeds `AppState.githubRateLimit`,
+/// and a soft threshold + 403 detection suspend polling when quotas are low.
 @MainActor
 final class IssueTracker {
     private let appState: AppState
+    private let providerManager: ProviderManager
     private var timer: Timer?
     private let pollInterval: TimeInterval = 60 // 1 minute
     private var isRefreshing = false
+
+    /// Local alias for the canonical `PRRecord` shape now living in
+    /// `CrowProvider`. The migration kept the name in place to minimize the
+    /// IssueTracker diff — every `ViewerPR` in this file is a `PRRecord`.
+    typealias ViewerPR = PRRecord
 
     /// Callback for new review request notifications (set by AppDelegate).
     var onNewReviewRequests: (([ReviewRequest]) -> Void)?
@@ -164,8 +173,9 @@ final class IssueTracker {
     /// shell helpers, reset at the start of each refresh.
     private var currentRefreshGhCalls = 0
 
-    init(appState: AppState) {
+    init(appState: AppState, providerManager: ProviderManager) {
         self.appState = appState
+        self.providerManager = providerManager
     }
 
     func start() {
@@ -488,39 +498,24 @@ final class IssueTracker {
     /// otherwise ignored — the in-memory `autoCreateInFlight` + active-session
     /// dedup keeps duplicate spawns at bay until the label is gone.
     private func removeAutoCreateLabel(from issue: AssignedIssue) async {
-        let result: ShellResult
-        switch issue.provider {
-        case .github:
-            result = await shellWithStatus(
-                "gh", "issue", "edit", issue.url,
-                "--remove-label", Self.autoCreateLabel
-            )
-        case .gitlab:
-            // issue.id format: "gitlab:host:org/repo#number"
+        // issue.id format for GitLab: "gitlab:host:org/repo#number". Need the
+        // host segment to pick the right `GITLAB_HOST` for the backend.
+        let host: String?
+        if issue.provider == .gitlab {
             let parts = issue.id.split(separator: ":", maxSplits: 2).map(String.init)
             guard parts.count == 3 else {
                 print("[IssueTracker] cannot strip label, malformed gitlab id: \(issue.id)")
                 return
             }
-            let host = parts[1]
-            let repo = issue.repo
-            result = await shellWithStatus(
-                env: ["GITLAB_HOST": host],
-                args: [
-                    "glab", "issue", "update", String(issue.number),
-                    "--repo", repo,
-                    "--unlabel", Self.autoCreateLabel
-                ]
-            )
-        case .corveil:
-            // Stub: Corveil label management arrives with a real CorveilTaskBackend.
-            // See ADR 0005. listAssigned() returns no Corveil issues today, so this
-            // branch is defensive only.
-            return
+            host = parts[1]
+        } else {
+            host = nil
         }
-        if result.exitCode != 0 {
-            let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            print("[IssueTracker] failed to remove \(Self.autoCreateLabel) from \(issue.url): \(stderr)")
+        let backend = providerManager.taskBackend(for: issue.provider, host: host)
+        do {
+            try await backend.setLabels(url: issue.url, add: [], remove: [Self.autoCreateLabel])
+        } catch {
+            print("[IssueTracker] failed to remove \(Self.autoCreateLabel) from \(issue.url): \(error.localizedDescription)")
         }
     }
 
@@ -542,30 +537,6 @@ final class IssueTracker {
         let viewerPRs: [ViewerPR]
         let reviewRequests: [ReviewRequest]
         let rateLimit: GitHubRateLimit?
-    }
-
-    struct ViewerPR: Sendable {
-        let number: Int
-        let url: String
-        let state: String          // OPEN / MERGED / CLOSED
-        let mergeable: String      // MERGEABLE / CONFLICTING / UNKNOWN
-        let mergeStateStatus: String // BEHIND / BLOCKED / CLEAN / DIRTY / DRAFT / HAS_HOOKS / UNKNOWN / UNSTABLE
-        let reviewDecision: String // APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED / ""
-        let isDraft: Bool
-        let headRefName: String
-        let headRefOid: String     // Head commit SHA (empty if unavailable)
-        let baseRefName: String
-        let repoNameWithOwner: String
-        let labels: [LabelInfo]
-        let linkedIssueReferences: [LinkedIssue]
-        let checksState: String    // SUCCESS / FAILURE / PENDING / EXPECTED / ERROR / ""
-        let failedCheckNames: [String]
-        let latestReviewStates: [String]
-
-        struct LinkedIssue: Sendable {
-            let number: Int
-            let repo: String
-        }
     }
 
     // MARK: - PR Dedup
@@ -626,144 +597,68 @@ final class IssueTracker {
         return order.compactMap { byURL[$0] }
     }
 
-    private static let consolidatedQuery = """
-    query($openQuery: String!, $closedQuery: String!, $reviewQuery: String!) {
-      openIssues: search(type: ISSUE, query: $openQuery, first: 100) {
-        nodes {
-          ... on Issue {
-            number title url state updatedAt
-            repository { nameWithOwner }
-            labels(first: 20) { nodes { name color } }
-            projectItems(first: 10) {
-              nodes {
-                fieldValueByName(name: "Status") {
-                  ... on ProjectV2ItemFieldSingleSelectValue { name }
-                }
-              }
-            }
-          }
-        }
-      }
-      viewerPRs: viewer {
-        pullRequests(first: 50, states: [OPEN], orderBy: {field: UPDATED_AT, direction: DESC}) {
-          nodes {
-            number url state mergeable mergeStateStatus reviewDecision isDraft headRefName headRefOid baseRefName
-            repository { nameWithOwner }
-            labels(first: 20) { nodes { name color } }
-            closingIssuesReferences(first: 5) { nodes { number repository { nameWithOwner } } }
-            statusCheckRollup {
-              state
-              contexts(first: 25) {
-                nodes {
-                  __typename
-                  ... on CheckRun { name conclusion status }
-                  ... on StatusContext { context state }
-                }
-              }
-            }
-            latestReviews(first: 5) { nodes { state } }
-          }
-        }
-      }
-      closedIssues: search(type: ISSUE, query: $closedQuery, first: 50) {
-        nodes {
-          ... on Issue {
-            number title url state updatedAt
-            repository { nameWithOwner }
-            labels(first: 20) { nodes { name color } }
-          }
-        }
-      }
-      reviewPRs: search(type: ISSUE, query: $reviewQuery, first: 50) {
-        nodes {
-          ... on PullRequest {
-            number title url isDraft updatedAt headRefName headRefOid baseRefName state
-            author { login }
-            repository { nameWithOwner }
-            labels(first: 20) { nodes { name color } }
-            reviews(last: 20) { nodes { author { login } submittedAt state } }
-          }
-        }
-      }
-      viewer { login }
-      rateLimit { remaining limit resetAt cost }
-    }
-    """
-
-    /// GraphQL search only accepts date-only for `closed:>=` — full ISO8601 gets
-    /// rejected, so format YYYY-MM-DD based on 24h ago.
-    private func closedSinceString() -> String {
-        let fmt = DateFormatter()
-        fmt.dateFormat = "yyyy-MM-dd"
-        fmt.timeZone = TimeZone(identifier: "UTC")
-        return fmt.string(from: Date().addingTimeInterval(-86400))
-    }
-
+    /// Pull the viewer's assigned issues, monitored PRs, and review requests
+    /// via the GitHub backends. Issues + PRs go in parallel — the GitHub
+    /// backend issues two GraphQL calls in flight at once (one for assigned
+    /// issues, one for PRs + reviews).
     private func runConsolidatedGitHubQuery() async -> ConsolidatedGitHubResponse? {
-        let openQuery = "assignee:@me state:open type:issue"
-        let closedQuery = "assignee:@me state:closed closed:>=\(closedSinceString()) type:issue"
-        let reviewQuery = "review-requested:@me state:open type:pr"
+        let taskBackend = providerManager.taskBackend(for: .github)
+        let codeBackend = providerManager.codeBackend(for: .github)!
 
-        let args: [String] = [
-            "gh", "api", "graphql",
-            "-f", "query=\(Self.consolidatedQuery)",
-            "-F", "openQuery=\(openQuery)",
-            "-F", "closedQuery=\(closedQuery)",
-            "-F", "reviewQuery=\(reviewQuery)"
-        ]
-        let result = await shellWithStatus(args: args)
+        async let assignedTask = Task { () -> Result<AssignedListing, Error> in
+            do { return .success(try await taskBackend.listAssigned()) }
+            catch { return .failure(error) }
+        }.value
+        async let monitoredTask = Task { () -> Result<MonitoredPRListing, Error> in
+            do { return .success(try await codeBackend.listMonitoredPRs()) }
+            catch { return .failure(error) }
+        }.value
 
-        if result.exitCode != 0 {
-            if handleGraphQLRateLimit(stderr: result.stderr) { return nil }
-            if result.stderr.contains("INSUFFICIENT_SCOPES") || result.stderr.contains("read:project") {
-                reportScopeWarning("read:project")
-                // Retry without projectItems so the rest of the data still renders.
-                return await retryWithoutProjectItems(
-                    openQuery: openQuery,
-                    closedQuery: closedQuery,
-                    reviewQuery: reviewQuery
-                )
-            }
-            print("[IssueTracker] Consolidated GraphQL query failed (exit \(result.exitCode)): \(result.stderr.prefix(300))")
+        let assignedResult = await assignedTask
+        let monitoredResult = await monitoredTask
+
+        switch assignedResult {
+        case .failure(let err):
+            handleGitHubBackendError(err, operation: "listAssigned")
+            return nil
+        case .success:
+            break
+        }
+        switch monitoredResult {
+        case .failure(let err):
+            handleGitHubBackendError(err, operation: "listMonitoredPRs")
+            return nil
+        case .success:
+            break
+        }
+        guard case .success(let assigned) = assignedResult,
+              case .success(let monitored) = monitoredResult else {
             return nil
         }
 
         clearScopeWarning()
-        // Parse off the main actor — only the Sendable result hops back (#304).
-        let output = result.stdout
-        return await Task.detached { self.parseConsolidatedResponse(output) }.value
+        return ConsolidatedGitHubResponse(
+            openIssues: assigned.open,
+            closedIssues: assigned.closed,
+            viewerPRs: monitored.viewerPRs,
+            reviewRequests: monitored.reviewRequests,
+            rateLimit: assigned.rateLimit ?? monitored.rateLimit
+        )
     }
 
-    private func retryWithoutProjectItems(openQuery: String, closedQuery: String, reviewQuery: String) async -> ConsolidatedGitHubResponse? {
-        // Stripped query: same as consolidatedQuery but with the projectItems block removed.
-        let stripped = Self.consolidatedQuery.replacingOccurrences(
-            of: """
-                projectItems(first: 10) {
-                  nodes {
-                    fieldValueByName(name: "Status") {
-                      ... on ProjectV2ItemFieldSingleSelectValue { name }
-                    }
-                  }
-                }
-        """,
-            with: ""
-        )
-        let args: [String] = [
-            "gh", "api", "graphql",
-            "-f", "query=\(stripped)",
-            "-F", "openQuery=\(openQuery)",
-            "-F", "closedQuery=\(closedQuery)",
-            "-F", "reviewQuery=\(reviewQuery)"
-        ]
-        let result = await shellWithStatus(args: args)
-        guard result.exitCode == 0 else {
-            if handleGraphQLRateLimit(stderr: result.stderr) { return nil }
-            print("[IssueTracker] GraphQL retry (no projectItems) failed (exit \(result.exitCode)): \(result.stderr.prefix(300))")
-            return nil
+    /// Route typed `ProviderError`s from GitHub backends to the matching
+    /// IssueTracker UI side-effect (scope warning, rate-limit suspension).
+    /// Untyped errors get a console line and otherwise propagate as "this
+    /// cycle is degraded" via the caller's nil-return.
+    private func handleGitHubBackendError(_ error: Error, operation: String) {
+        switch error {
+        case ProviderError.insufficientScope(let scope):
+            reportScopeWarning(scope)
+        case ProviderError.rateLimited(let stderr):
+            _ = handleGraphQLRateLimit(stderr: stderr)
+        default:
+            print("[IssueTracker] \(operation) failed: \(error.localizedDescription)")
         }
-        // Parse off the main actor — only the Sendable result hops back (#304).
-        let output = result.stdout
-        return await Task.detached { self.parseConsolidatedResponse(output) }.value
     }
 
     // MARK: - Stale PR Follow-up
@@ -802,195 +697,79 @@ final class IssueTracker {
     /// Fetch state for a small set of PRs/MRs that are linked to a session
     /// but no longer in the open viewer set (typically merged or closed).
     /// Splits URLs by provider — GitHub PRs go through one batched aliased
-    /// `gh api graphql` call, GitLab MRs go through one `glab api` call per
+    /// `gh`/`glab` call, GitLab MRs go through one REST call per
     /// MR (with `GITLAB_HOST` set per host). A failure on either side marks
     /// the result incomplete but doesn't suppress the other side's PRs.
     /// Returns minimal `ViewerPR` records — only `state`, `url`, repo, and
     /// branch refs are populated; checks/reviews are left empty since
     /// they're moot for closed PRs.
     private func fetchStalePRStates(urls: [String]) async -> StalePRFetchResult {
-        // Parse each URL into (owner, repo, number); skip any we can't parse.
-        var githubParsed: [(url: String, owner: String, repo: String, number: Int)] = []
-        var gitlabParsedByHost: [String: [(url: String, slug: String, number: Int)]] = [:]
+        // Bucket URLs by (provider, host). GitLab self-hosted needs the host so the
+        // backend pins the right GITLAB_HOST env var.
+        var githubRefs: [PRRef] = []
+        var githubURLByRef: [PRRef: String] = [:]
+        var gitlabByHost: [String: [PRRef]] = [:]
+        var gitlabURLByRef: [PRRef: String] = [:]
+
         for url in urls {
             if let g = Self.parseGitLabMRURL(url) {
-                gitlabParsedByHost[g.host, default: []].append((url, g.slug, g.number))
+                let parts = g.slug.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true).map(String.init)
+                guard parts.count == 2 else { continue }
+                let ref = PRRef(owner: parts[0], repo: parts[1], number: g.number)
+                gitlabByHost[g.host, default: []].append(ref)
+                gitlabURLByRef[ref] = url
                 continue
             }
             guard let p = ProviderManager.parseTicketURLComponents(url) else { continue }
-            // Anything not parsed as GitLab is treated as GitHub. The
-            // ProviderManager parser covers github.com URLs; self-hosted
-            // GitLab URLs are caught above by `parseGitLabMRURL`.
             if let host = URL(string: url)?.host, host != "github.com" {
-                // Unrecognized host that didn't match the GitLab MR shape —
-                // skip rather than blindly route to gh.
                 continue
             }
-            githubParsed.append((url, p.org, p.repo, p.number))
+            let ref = PRRef(owner: p.org, repo: p.repo, number: p.number)
+            githubRefs.append(ref)
+            githubURLByRef[ref] = url
         }
-        guard !githubParsed.isEmpty || !gitlabParsedByHost.isEmpty else {
+        guard !githubRefs.isEmpty || !gitlabByHost.isEmpty else {
             return StalePRFetchResult(prs: [], complete: true)
         }
 
         var prs: [ViewerPR] = []
         var complete = true
 
-        if !githubParsed.isEmpty {
-            if let ghPRs = await fetchStalePRStatesGitHub(parsed: githubParsed) {
-                prs.append(contentsOf: ghPRs)
-            } else {
+        if !githubRefs.isEmpty {
+            let backend = providerManager.codeBackend(for: .github)!
+            do {
+                let states = try await backend.prStates(refs: githubRefs)
+                for ref in githubRefs {
+                    guard let url = githubURLByRef[ref], let rec = states[url] else { continue }
+                    prs.append(rec)
+                }
+            } catch {
+                handleGitHubBackendError(error, operation: "prStates(github)")
                 complete = false
             }
         }
 
-        for (host, parsed) in gitlabParsedByHost {
-            let (mrPRs, ok) = await fetchStaleMRStatesGitLab(parsed: parsed, host: host)
-            prs.append(contentsOf: mrPRs)
-            if !ok { complete = false }
+        for (host, refs) in gitlabByHost {
+            let backend = providerManager.codeBackend(for: .gitlab, host: host)!
+            do {
+                let states = try await backend.prStates(refs: refs)
+                for ref in refs {
+                    guard let url = gitlabURLByRef[ref], let rec = states[url] else { continue }
+                    prs.append(rec)
+                }
+            } catch {
+                print("[IssueTracker] Stale-PR follow-up via backend failed for host \(host): \(error.localizedDescription.prefix(200))")
+                complete = false
+            }
         }
 
         return StalePRFetchResult(prs: prs, complete: complete)
     }
 
-    /// GitHub stale-PR fetch: one aliased GraphQL query covering every
-    /// (owner, repo, number) tuple. Returns `nil` on shell error or rate
-    /// limit so the caller can mark the cycle incomplete.
-    private func fetchStalePRStatesGitHub(
-        parsed: [(url: String, owner: String, repo: String, number: Int)]
-    ) async -> [ViewerPR]? {
-        guard !parsed.isEmpty else { return [] }
-
-        // Build aliased query: pr0, pr1, ... each fetching one pullRequest.
-        var queryParts: [String] = []
-        var args: [String] = ["gh", "api", "graphql"]
-        for (i, p) in parsed.enumerated() {
-            queryParts.append("""
-              pr\(i): repository(owner: $owner\(i), name: $repo\(i)) {
-                pullRequest(number: $num\(i)) {
-                  number url state mergeable mergeStateStatus reviewDecision isDraft
-                  headRefName headRefOid baseRefName
-                  repository { nameWithOwner }
-                }
-              }
-            """)
-            args.append(contentsOf: ["-F", "owner\(i)=\(p.owner)"])
-            args.append(contentsOf: ["-F", "repo\(i)=\(p.repo)"])
-            args.append(contentsOf: ["-F", "num\(i)=\(p.number)"])
-        }
-        var varDecls: [String] = []
-        for i in 0..<parsed.count {
-            varDecls.append("$owner\(i): String!, $repo\(i): String!, $num\(i): Int!")
-        }
-        let query = """
-        query(\(varDecls.joined(separator: ", "))) {
-        \(queryParts.joined(separator: "\n"))
-          rateLimit { remaining limit resetAt cost }
-        }
-        """
-        args.insert(contentsOf: ["-f", "query=\(query)"], at: 3)
-
-        let result = await shellWithStatus(args: args)
-        if result.exitCode != 0 {
-            if handleGraphQLRateLimit(stderr: result.stderr) { return nil }
-            print("[IssueTracker] Stale-PR follow-up failed (exit \(result.exitCode)): \(result.stderr.prefix(200))")
-            return nil
-        }
-        return parseStalePRResponse(result.stdout, count: parsed.count)
-    }
-
-    /// GitLab stale-MR fetch: one `glab api projects/{slug}/merge_requests/{iid}`
-    /// per MR for a given host. GitLab's REST API doesn't support batching by
-    /// IDs the way GitHub's GraphQL does, but the per-cycle stale set is
-    /// usually tiny (sessions with merged/closed PRs that haven't been
-    /// auto-completed yet). Returns `(prs, ok)` where `ok` is false if any
-    /// call for this host failed.
-    private func fetchStaleMRStatesGitLab(
-        parsed: [(url: String, slug: String, number: Int)],
-        host: String
-    ) async -> ([ViewerPR], Bool) {
-        var prs: [ViewerPR] = []
-        var ok = true
-        for entry in parsed {
-            let encodedSlug = entry.slug.addingPercentEncoding(
-                withAllowedCharacters: .alphanumerics
-            ) ?? entry.slug
-            let endpoint = "projects/\(encodedSlug)/merge_requests/\(entry.number)"
-
-            let output: String
-            do {
-                output = try await shell(env: ["GITLAB_HOST": host], cwd: NSHomeDirectory(), "glab", "api", endpoint)
-            } catch {
-                print("[IssueTracker] Stale-PR follow-up failed for \(entry.slug)!\(entry.number) on \(host): \(error.localizedDescription.prefix(200))")
-                ok = false
-                continue
-            }
-            if let pr = Self.parseGitLabStaleMRResponse(output, fallbackURL: entry.url, fallbackSlug: entry.slug) {
-                prs.append(pr)
-            } else {
-                ok = false
-            }
-        }
-        return (prs, ok)
-    }
-
-    /// Parse a GitLab `projects/{slug}/merge_requests/{iid}` REST response
-    /// into a minimal `ViewerPR`. State is normalized to GitHub's
-    /// `OPEN|MERGED|CLOSED` so downstream code stays provider-agnostic.
-    /// Returns nil if the JSON shape doesn't match.
-    nonisolated static func parseGitLabStaleMRResponse(
-        _ output: String,
-        fallbackURL: String,
-        fallbackSlug: String
-    ) -> ViewerPR? {
-        guard let data = output.data(using: .utf8),
-              let item = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
-        }
-        guard let number = item["iid"] as? Int else { return nil }
-        let url = (item["web_url"] as? String) ?? fallbackURL
-        let rawState = (item["state"] as? String) ?? ""
-        let state = normalizeGitLabPRState(rawState)
-        let headRefName = (item["source_branch"] as? String) ?? ""
-        let baseRefName = (item["target_branch"] as? String) ?? ""
-        let headRefOid = (item["sha"] as? String) ?? ""
-        let isDraft = (item["draft"] as? Bool) ?? (item["work_in_progress"] as? Bool) ?? false
-
-        return ViewerPR(
-            number: number,
-            url: url,
-            state: state,
-            mergeable: "UNKNOWN",
-            mergeStateStatus: "UNKNOWN",
-            reviewDecision: "",
-            isDraft: isDraft,
-            headRefName: headRefName,
-            headRefOid: headRefOid,
-            baseRefName: baseRefName,
-            repoNameWithOwner: fallbackSlug,
-            labels: [],
-            linkedIssueReferences: [],
-            checksState: "",
-            failedCheckNames: [],
-            latestReviewStates: []
-        )
-    }
-
-    /// Normalize GitLab MR state strings to the GitHub `state` vocabulary
-    /// the rest of the codebase reads (`OPEN`/`MERGED`/`CLOSED`). Falls back
-    /// to upper-casing the raw value for unrecognized states (matches
-    /// `fetchGitLabMRsForReconcile`).
-    nonisolated static func normalizeGitLabPRState(_ raw: String) -> String {
-        switch raw {
-        case "opened": return "OPEN"
-        case "merged": return "MERGED"
-        case "closed": return "CLOSED"
-        default:       return raw.uppercased()
-        }
-    }
-
     /// Parse a GitLab MR URL into (host, slug, number). Robust to nested
     /// groups (slug is everything between the host and `/-/merge_requests/`).
-    /// Returns nil for non-GitLab-MR URLs.
+    /// Returns nil for non-GitLab-MR URLs. Kept here (not in CrowProvider)
+    /// because it's used by the URL-routing logic above.
     nonisolated static func parseGitLabMRURL(_ url: String) -> (host: String, slug: String, number: Int)? {
         guard let protoRange = url.range(of: "://") else { return nil }
         let afterProto = String(url[protoRange.upperBound...])
@@ -1003,326 +782,15 @@ final class IssueTracker {
         let host = leadParts[0]
         let slug = leadParts.dropFirst().joined(separator: "/")
 
-        // `trailing` is everything after `/-/merge_requests/` — usually just
-        // the MR number, occasionally `<n>/diffs` or similar from a deep
-        // link. Take the first segment as the number.
         let trailParts = trailing.split(separator: "/").map(String.init)
         guard let first = trailParts.first, let number = Int(first) else { return nil }
         return (host, slug, number)
     }
 
-    private func parseStalePRResponse(_ output: String, count: Int) -> [ViewerPR]? {
-        guard let data = output.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let dataObj = json["data"] as? [String: Any] else { return nil }
-
-        if let rl = parseRateLimit(dataObj["rateLimit"] as? [String: Any]) {
-            appState.githubRateLimit = rl
-        }
-
-        var prs: [ViewerPR] = []
-        for i in 0..<count {
-            guard let repoObj = dataObj["pr\(i)"] as? [String: Any],
-                  let prObj = repoObj["pullRequest"] as? [String: Any],
-                  let number = prObj["number"] as? Int,
-                  let url = prObj["url"] as? String,
-                  let state = prObj["state"] as? String else { continue }
-
-            let mergeable = prObj["mergeable"] as? String ?? "UNKNOWN"
-            let mergeStateStatus = prObj["mergeStateStatus"] as? String ?? "UNKNOWN"
-            let reviewDecision = prObj["reviewDecision"] as? String ?? ""
-            let isDraft = prObj["isDraft"] as? Bool ?? false
-            let headRefName = prObj["headRefName"] as? String ?? ""
-            let headRefOid = prObj["headRefOid"] as? String ?? ""
-            let baseRefName = prObj["baseRefName"] as? String ?? ""
-            let repoName = (prObj["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
-
-            prs.append(ViewerPR(
-                number: number,
-                url: url,
-                state: state,
-                mergeable: mergeable,
-                mergeStateStatus: mergeStateStatus,
-                reviewDecision: reviewDecision,
-                isDraft: isDraft,
-                headRefName: headRefName,
-                headRefOid: headRefOid,
-                baseRefName: baseRefName,
-                repoNameWithOwner: repoName,
-                labels: [],
-                linkedIssueReferences: [],
-                checksState: "",
-                failedCheckNames: [],
-                latestReviewStates: []
-            ))
-        }
-        return prs
-    }
-
-    // `nonisolated` so the JSON parsing — the heaviest CPU work in a refresh
-    // (up to ~50 PRs + ~50 review requests + ~150 issues with nested
-    // label/check/review traversal) — can run off the main actor via
-    // `Task.detached`. These helpers touch no instance/`appState` state, only
-    // their arguments and a local date formatter, so they are safe off-actor.
-    // Only the resulting (Sendable) value hops back to the main actor (#304).
-    nonisolated private func parseConsolidatedResponse(_ output: String) -> ConsolidatedGitHubResponse? {
-        guard let data = output.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let dataObj = json["data"] as? [String: Any] else {
-            print("[IssueTracker] Failed to parse consolidated GraphQL response")
-            return nil
-        }
-
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        let openIssues = parseIssueNodes(
-            dataObj["openIssues"] as? [String: Any],
-            defaultState: "open",
-            dateFormatter: dateFormatter
-        )
-        let closedIssues = parseIssueNodes(
-            dataObj["closedIssues"] as? [String: Any],
-            defaultState: "closed",
-            dateFormatter: dateFormatter,
-            projectStatusOverride: .done
-        )
-        let viewerPRs = parseViewerPRs(dataObj["viewerPRs"] as? [String: Any])
-        let viewerLogin = (dataObj["viewer"] as? [String: Any])?["login"] as? String
-        let reviewRequests = parseReviewRequests(
-            dataObj["reviewPRs"] as? [String: Any],
-            dateFormatter: dateFormatter,
-            viewerLogin: viewerLogin
-        )
-        let rateLimit = parseRateLimit(dataObj["rateLimit"] as? [String: Any])
-
-        return ConsolidatedGitHubResponse(
-            openIssues: openIssues,
-            closedIssues: closedIssues,
-            viewerPRs: viewerPRs,
-            reviewRequests: reviewRequests,
-            rateLimit: rateLimit
-        )
-    }
-
-    nonisolated private func parseIssueNodes(
-        _ searchObj: [String: Any]?,
-        defaultState: String,
-        dateFormatter: ISO8601DateFormatter,
-        projectStatusOverride: TicketStatus? = nil
-    ) -> [AssignedIssue] {
-        guard let nodes = searchObj?["nodes"] as? [[String: Any]] else { return [] }
-        return nodes.compactMap { node -> AssignedIssue? in
-            guard let number = node["number"] as? Int,
-                  let title = node["title"] as? String,
-                  let url = node["url"] as? String else { return nil }
-
-            let state = (node["state"] as? String ?? defaultState).lowercased()
-            let repoName = (node["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
-            let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
-                .compactMap { labelNode -> LabelInfo? in
-                    guard let name = labelNode["name"] as? String else { return nil }
-                    let color = labelNode["color"] as? String
-                    return LabelInfo(name: name, color: color)
-                } ?? []
-
-            var updatedAt: Date?
-            if let dateStr = node["updatedAt"] as? String {
-                updatedAt = dateFormatter.date(from: dateStr)
-            }
-
-            var projectStatus: TicketStatus = projectStatusOverride ?? .unknown
-            if projectStatusOverride == nil,
-               let projectItems = node["projectItems"] as? [String: Any],
-               let itemNodes = projectItems["nodes"] as? [[String: Any]] {
-                for item in itemNodes {
-                    if let fv = item["fieldValueByName"] as? [String: Any],
-                       let statusName = fv["name"] as? String {
-                        projectStatus = TicketStatus(projectBoardName: statusName)
-                        break
-                    }
-                }
-            }
-
-            return AssignedIssue(
-                id: "github:\(repoName)#\(number)",
-                number: number,
-                title: title,
-                state: state,
-                url: url,
-                repo: repoName,
-                labels: labels,
-                provider: .github,
-                updatedAt: updatedAt,
-                projectStatus: projectStatus
-            )
-        }
-    }
-
-    nonisolated private func parseViewerPRs(_ viewerObj: [String: Any]?) -> [ViewerPR] {
-        guard let pullRequests = viewerObj?["pullRequests"] as? [String: Any],
-              let nodes = pullRequests["nodes"] as? [[String: Any]] else { return [] }
-
-        return nodes.compactMap { node -> ViewerPR? in
-            guard let number = node["number"] as? Int,
-                  let url = node["url"] as? String,
-                  let state = node["state"] as? String else { return nil }
-
-            let mergeable = node["mergeable"] as? String ?? "UNKNOWN"
-            let mergeStateStatus = node["mergeStateStatus"] as? String ?? "UNKNOWN"
-            let reviewDecision = node["reviewDecision"] as? String ?? ""
-            let isDraft = node["isDraft"] as? Bool ?? false
-            let headRefName = node["headRefName"] as? String ?? ""
-            let headRefOid = node["headRefOid"] as? String ?? ""
-            let baseRefName = node["baseRefName"] as? String ?? ""
-            let repoName = (node["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
-
-            let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
-                .compactMap { labelNode -> LabelInfo? in
-                    guard let name = labelNode["name"] as? String else { return nil }
-                    let color = labelNode["color"] as? String
-                    return LabelInfo(name: name, color: color)
-                } ?? []
-
-            let linkedNodes = (node["closingIssuesReferences"] as? [String: Any])?["nodes"] as? [[String: Any]] ?? []
-            let linkedRefs: [ViewerPR.LinkedIssue] = linkedNodes.compactMap { ref in
-                guard let n = ref["number"] as? Int else { return nil }
-                let r = (ref["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
-                return ViewerPR.LinkedIssue(number: n, repo: r)
-            }
-
-            let rollup = node["statusCheckRollup"] as? [String: Any]
-            let checksState = rollup?["state"] as? String ?? ""
-            let contextNodes = ((rollup?["contexts"] as? [String: Any])?["nodes"] as? [[String: Any]]) ?? []
-            let failedCheckNames: [String] = contextNodes.compactMap { ctx in
-                // CheckRun: conclusion == "FAILURE"; StatusContext: state == "FAILURE"/"ERROR"
-                if let conclusion = ctx["conclusion"] as? String, conclusion == "FAILURE" {
-                    return ctx["name"] as? String
-                }
-                if let st = ctx["state"] as? String, st == "FAILURE" || st == "ERROR" {
-                    return ctx["context"] as? String
-                }
-                return nil
-            }
-
-            let latestReviewNodes = (node["latestReviews"] as? [String: Any])?["nodes"] as? [[String: Any]] ?? []
-            let reviewStates = latestReviewNodes.compactMap { $0["state"] as? String }
-
-            return ViewerPR(
-                number: number,
-                url: url,
-                state: state,
-                mergeable: mergeable,
-                mergeStateStatus: mergeStateStatus,
-                reviewDecision: reviewDecision,
-                isDraft: isDraft,
-                headRefName: headRefName,
-                headRefOid: headRefOid,
-                baseRefName: baseRefName,
-                repoNameWithOwner: repoName,
-                labels: labels,
-                linkedIssueReferences: linkedRefs,
-                checksState: checksState,
-                failedCheckNames: failedCheckNames,
-                latestReviewStates: reviewStates
-            )
-        }
-    }
-
-    nonisolated private func parseReviewRequests(
-        _ searchObj: [String: Any]?,
-        dateFormatter: ISO8601DateFormatter,
-        viewerLogin: String?
-    ) -> [ReviewRequest] {
-        guard let nodes = searchObj?["nodes"] as? [[String: Any]] else { return [] }
-
-        // Only formal verdicts satisfy a review request. COMMENTED/PENDING
-        // do not — gating on those would mis-complete a session before the
-        // viewer has actually approved or requested changes.
-        let satisfyingStates: Set<String> = ["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]
-
-        var requests: [ReviewRequest] = []
-        for node in nodes {
-            guard let number = node["number"] as? Int,
-                  let title = node["title"] as? String,
-                  let url = node["url"] as? String else { continue }
-
-            let repoName = (node["repository"] as? [String: Any])?["nameWithOwner"] as? String ?? ""
-            let authorLogin = (node["author"] as? [String: Any])?["login"] as? String ?? ""
-            let isDraft = node["isDraft"] as? Bool ?? false
-            let headBranch = node["headRefName"] as? String ?? ""
-            let headRefOid = node["headRefOid"] as? String
-            let baseBranch = node["baseRefName"] as? String ?? ""
-            let updatedAt = (node["updatedAt"] as? String).flatMap { dateFormatter.date(from: $0) }
-            let labels = ((node["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
-                .compactMap { labelNode -> LabelInfo? in
-                    guard let name = labelNode["name"] as? String else { return nil }
-                    let color = labelNode["color"] as? String
-                    return LabelInfo(name: name, color: color)
-                } ?? []
-
-            // Latest viewer-authored review timestamp (APPROVED / CHANGES_REQUESTED
-            // / DISMISSED only). Used by `decideReviewCompletions` to detect when
-            // the reviewer has actually submitted a verdict so the session can be
-            // auto-completed before the PR is merged.
-            var viewerLastReviewedAt: Date?
-            if let viewerLogin,
-               let reviewNodes = ((node["reviews"] as? [String: Any])?["nodes"]) as? [[String: Any]] {
-                for review in reviewNodes {
-                    guard let author = (review["author"] as? [String: Any])?["login"] as? String,
-                          author == viewerLogin,
-                          let state = review["state"] as? String,
-                          satisfyingStates.contains(state),
-                          let submittedAtStr = review["submittedAt"] as? String,
-                          let submittedAt = dateFormatter.date(from: submittedAtStr) else { continue }
-                    if viewerLastReviewedAt == nil || submittedAt > viewerLastReviewedAt! {
-                        viewerLastReviewedAt = submittedAt
-                    }
-                }
-            }
-
-            requests.append(ReviewRequest(
-                id: "github:\(repoName)#\(number)",
-                prNumber: number,
-                title: title,
-                url: url,
-                repo: repoName,
-                author: authorLogin,
-                headBranch: headBranch,
-                baseBranch: baseBranch,
-                isDraft: isDraft,
-                requestedAt: updatedAt,
-                labels: labels,
-                provider: .github,
-                headRefOid: headRefOid,
-                viewerLastReviewedAt: viewerLastReviewedAt
-            ))
-        }
-        // Newest first so stale review requests sink to the bottom
-        return requests.sorted { ($0.requestedAt ?? .distantPast) > ($1.requestedAt ?? .distantPast) }
-    }
-
-    nonisolated private func parseRateLimit(_ obj: [String: Any]?) -> GitHubRateLimit? {
-        guard let obj,
-              let remaining = obj["remaining"] as? Int,
-              let limit = obj["limit"] as? Int,
-              let cost = obj["cost"] as? Int,
-              let resetAtStr = obj["resetAt"] as? String else { return nil }
-
-        let fmt = ISO8601DateFormatter()
-        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let resetAt = fmt.date(from: resetAtStr)
-            ?? ISO8601DateFormatter().date(from: resetAtStr)
-            ?? Date().addingTimeInterval(60 * 60)
-
-        return GitHubRateLimit(
-            remaining: remaining,
-            limit: limit,
-            resetAt: resetAt,
-            cost: cost,
-            observedAt: Date()
-        )
-    }
+    // Consolidated GraphQL parsing now lives in CrowProvider's GitHubTaskBackend
+    // and GitHubCodeBackend (see ADR 0005). The IssueTracker pulls assembled
+    // `AssignedListing` / `MonitoredPRListing` from the backends in
+    // `runConsolidatedGitHubQuery` above and consumes them directly.
 
     // MARK: - Session PR Link Detection (piggyback)
 
@@ -1514,140 +982,63 @@ final class IssueTracker {
         return out
     }
 
-    /// One aliased `gh api graphql` call: for each candidate, fetch up to 5 PRs
-    /// on that `headRefName`, most-recently-updated first. Returns `nil` on
-    /// shell / rate-limit / parse failure so the reconcile pass can skip the
-    /// cycle without treating a degraded response as "no PRs found".
+    /// One batched call per backend: GitHub issues a single aliased GraphQL
+    /// query covering every candidate; GitLab issues one REST call per
+    /// (host, candidate) tuple. Returns `nil` on backend error so the
+    /// reconcile pass can skip the cycle without treating a degraded
+    /// response as "no PRs found".
     private func fetchPRsForReconcile(candidates: [ReconcileCandidate]) async -> [ReconcileBranchMatch]? {
-        // Split each slug into (owner, repo). Skip any we can't parse.
-        var parsed: [(idx: Int, cand: ReconcileCandidate, owner: String, repo: String)] = []
-        for (i, c) in candidates.enumerated() {
-            let parts = c.repoSlug.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true)
-            guard parts.count == 2 else { continue }
-            parsed.append((i, c, String(parts[0]), String(parts[1])))
-        }
-        guard !parsed.isEmpty else { return [] }
-
-        var queryParts: [String] = []
-        var args: [String] = ["gh", "api", "graphql"]
-        for p in parsed {
-            queryParts.append("""
-              pr\(p.idx): repository(owner: $owner\(p.idx), name: $repo\(p.idx)) {
-                pullRequests(headRefName: $branch\(p.idx), first: 5, orderBy: {field: UPDATED_AT, direction: DESC}) {
-                  nodes { number url state updatedAt headRefName }
-                }
-              }
-            """)
-            args.append(contentsOf: ["-F", "owner\(p.idx)=\(p.owner)"])
-            args.append(contentsOf: ["-F", "repo\(p.idx)=\(p.repo)"])
-            args.append(contentsOf: ["-F", "branch\(p.idx)=\(p.cand.branch)"])
-        }
-        var varDecls: [String] = []
-        for p in parsed {
-            varDecls.append("$owner\(p.idx): String!, $repo\(p.idx): String!, $branch\(p.idx): String!")
-        }
-        let query = """
-        query(\(varDecls.joined(separator: ", "))) {
-        \(queryParts.joined(separator: "\n"))
-          rateLimit { remaining limit resetAt cost }
-        }
-        """
-        args.insert(contentsOf: ["-f", "query=\(query)"], at: 3)
-
-        let result = await shellWithStatus(args: args)
-        if result.exitCode != 0 {
-            if handleGraphQLRateLimit(stderr: result.stderr) { return nil }
-            print("[IssueTracker] Reconcile PR fetch failed (exit \(result.exitCode)): \(result.stderr.prefix(200))")
+        guard !candidates.isEmpty else { return [] }
+        let backend = providerManager.codeBackend(for: .github)!
+        let cands = candidates.map { BranchCandidate(repoSlug: $0.repoSlug, branch: $0.branch) }
+        let cmap: [BranchCandidate: UUID] = Dictionary(
+            uniqueKeysWithValues: zip(cands, candidates.map(\.sessionID))
+        )
+        do {
+            let matches = try await backend.findRecentPRsForBranches(cands)
+            return matches.compactMap { m in
+                guard let sid = cmap[m.candidate] else { return nil }
+                return ReconcileBranchMatch(
+                    sessionID: sid,
+                    number: m.number,
+                    url: m.url,
+                    state: m.state,
+                    updatedAt: m.updatedAt
+                )
+            }
+        } catch {
+            handleGitHubBackendError(error, operation: "findRecentPRsForBranches(github)")
             return nil
         }
-        return parseReconcilePRResponse(result.stdout, parsed: parsed)
     }
 
-    private func parseReconcilePRResponse(
-        _ output: String,
-        parsed: [(idx: Int, cand: ReconcileCandidate, owner: String, repo: String)]
-    ) -> [ReconcileBranchMatch]? {
-        guard let data = output.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let dataObj = json["data"] as? [String: Any] else { return nil }
-
-        if let rl = parseRateLimit(dataObj["rateLimit"] as? [String: Any]) {
-            appState.githubRateLimit = rl
-        }
-
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        var matches: [ReconcileBranchMatch] = []
-        for p in parsed {
-            guard let repoObj = dataObj["pr\(p.idx)"] as? [String: Any],
-                  let prs = repoObj["pullRequests"] as? [String: Any],
-                  let nodes = prs["nodes"] as? [[String: Any]] else { continue }
-            for node in nodes {
-                guard let number = node["number"] as? Int,
-                      let url = node["url"] as? String,
-                      let state = node["state"] as? String else { continue }
-                let updatedAt = (node["updatedAt"] as? String).flatMap { dateFormatter.date(from: $0) }
-                matches.append(ReconcileBranchMatch(
-                    sessionID: p.cand.sessionID,
-                    number: number,
-                    url: url,
-                    state: state,
-                    updatedAt: updatedAt
-                ))
-            }
-        }
-        return matches
-    }
-
-    /// One `glab api` call per (host, candidate). Uses the REST endpoint
-    /// because `glab mr list` at v1.82 lacks `--state` and `--output-format`
-    /// (see repo CLAUDE.md). `glab api` with `GITLAB_HOST` set returns raw
-    /// JSON reliably and supports `source_branch` + `state=all`.
+    /// GitLab equivalent: route through the GitLab `CodeBackend` for the given host.
     private func fetchGitLabMRsForReconcile(
         candidates: [ReconcileCandidate],
         host: String
     ) async -> [ReconcileBranchMatch] {
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        var matches: [ReconcileBranchMatch] = []
-        for candidate in candidates {
-            let encodedSlug = candidate.repoSlug.addingPercentEncoding(
-                withAllowedCharacters: .alphanumerics
-            ) ?? candidate.repoSlug
-            let encodedBranch = candidate.branch.addingPercentEncoding(
-                withAllowedCharacters: .alphanumerics
-            ) ?? candidate.branch
-            let endpoint = "projects/\(encodedSlug)/merge_requests?source_branch=\(encodedBranch)&state=all&per_page=5&order_by=updated_at"
-
-            let output: String
-            do {
-                output = try await shell(env: ["GITLAB_HOST": host], cwd: NSHomeDirectory(), "glab", "api", endpoint)
-            } catch {
-                print("[IssueTracker] Reconcile glab api failed for \(candidate.repoSlug)#\(candidate.branch) on \(host): \(error.localizedDescription.prefix(200))")
-                continue
+        guard !candidates.isEmpty else { return [] }
+        let backend = providerManager.codeBackend(for: .gitlab, host: host)!
+        let cands = candidates.map { BranchCandidate(repoSlug: $0.repoSlug, branch: $0.branch) }
+        let cmap: [BranchCandidate: UUID] = Dictionary(
+            uniqueKeysWithValues: zip(cands, candidates.map(\.sessionID))
+        )
+        do {
+            let matches = try await backend.findRecentPRsForBranches(cands)
+            return matches.compactMap { m in
+                guard let sid = cmap[m.candidate] else { return nil }
+                return ReconcileBranchMatch(
+                    sessionID: sid,
+                    number: m.number,
+                    url: m.url,
+                    state: m.state,
+                    updatedAt: m.updatedAt
+                )
             }
-            guard let data = output.data(using: .utf8),
-                  let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-                continue
-            }
-            for item in items {
-                guard let number = item["iid"] as? Int,
-                      let url = item["web_url"] as? String else { continue }
-                let rawState = (item["state"] as? String) ?? ""
-                let normalized = Self.normalizeGitLabPRState(rawState)
-                let updatedAt = (item["updated_at"] as? String).flatMap { dateFormatter.date(from: $0) }
-                matches.append(ReconcileBranchMatch(
-                    sessionID: candidate.sessionID,
-                    number: number,
-                    url: url,
-                    state: normalized,
-                    updatedAt: updatedAt
-                ))
-            }
+        } catch {
+            print("[IssueTracker] Reconcile via backend failed for host \(host): \(error.localizedDescription.prefix(200))")
+            return []
         }
-        return matches
     }
 
     /// Persist the reconciliation decisions. Re-checks `appState.links` at
@@ -1945,18 +1336,19 @@ final class IssueTracker {
         guard await prHasCrowAuthoredCommit(pr: pr) else {
             NSLog("[Crow] crow:merge ignored on %@ — no Crow-Session trailer matching a known session",
                   pr.url as NSString)
-            // Leave the URL in autoMergeInFlight so we don't re-fetch
-            // commits every minute for a permanently-ineligible PR. The
-            // set is in-memory only — restart will re-check, which is
-            // fine for what's a fairly rare label-misuse case.
             return
         }
 
         await ensureMergeLabel(repo: pr.repoNameWithOwner)
 
-        let cmd = #"cd "$TMPDIR" && gh pr merge \#(pr.url) --auto --squash --delete-branch"#
-        let result = await shellWithStatus(args: ["sh", "-c", cmd])
-        if result.exitCode == 0 {
+        let backend = providerManager.codeBackend(for: .github)!
+        guard backend.capabilities.contains(.autoMerge) else {
+            // Capability gate: don't even try if the backend can't enable auto-merge.
+            autoMergeInFlight.remove(pr.url)
+            return
+        }
+        do {
+            try await backend.enableAutoMerge(prURL: pr.url)
             let now = Date()
             if let idx = appState.sessions.firstIndex(where: { $0.id == session.id }) {
                 appState.sessions[idx].autoMergeEnabledAt = now
@@ -1971,10 +1363,10 @@ final class IssueTracker {
             NSLog("[Crow] Auto-merge enabled on %@ (session %@, squash)",
                   pr.url as NSString, session.id.uuidString as NSString)
             onAutoMergeEnabled?(session.id, pr.url, pr.number)
-        } else {
+        } catch {
             autoMergeInFlight.remove(pr.url)
-            NSLog("[Crow] gh pr merge --auto failed for %@ (exit %d): %@",
-                  pr.url as NSString, result.exitCode, String(result.stderr.prefix(300)) as NSString)
+            NSLog("[Crow] enableAutoMerge failed for %@: %@",
+                  pr.url as NSString, error.localizedDescription as NSString)
         }
     }
 
@@ -1991,60 +1383,55 @@ final class IssueTracker {
         guard await prHasCrowAuthoredCommit(pr: pr) else {
             NSLog("[Crow] crow:merge update-branch skipped on %@ — no Crow-Session trailer matching a known session",
                   pr.url as NSString)
-            // Mirror attemptEnableAutoMerge: leave the URL in autoMergeInFlight
-            // so we don't re-fetch commits every minute for an ineligible PR.
             return
         }
 
-        let cmd = #"cd "$TMPDIR" && gh pr update-branch \#(pr.url)"#
-        let result = await shellWithStatus(args: ["sh", "-c", cmd])
-        // Always clear the in-flight marker so the next poll can merge (or
-        // re-update once a new head appears). The per-head attempted key still
-        // prevents re-updating the same head state.
-        autoMergeInFlight.remove(pr.url)
-        if result.exitCode == 0 {
+        let backend = providerManager.codeBackend(for: .github)!
+        defer { autoMergeInFlight.remove(pr.url) }
+        guard backend.capabilities.contains(.updateBranch) else { return }
+        do {
+            try await backend.updateBranch(prURL: pr.url)
             NSLog("[Crow] Updated branch for %@ (session %@, was BEHIND base)",
                   pr.url as NSString, session.id.uuidString as NSString)
-        } else {
-            NSLog("[Crow] gh pr update-branch failed for %@ (exit %d): %@",
-                  pr.url as NSString, result.exitCode, String(result.stderr.prefix(300)) as NSString)
+        } catch {
+            NSLog("[Crow] updateBranch failed for %@: %@",
+                  pr.url as NSString, error.localizedDescription as NSString)
         }
     }
 
     /// Fetch the PR's commits and return true iff at least one carries a
-    /// `Crow-Session: <uuid>` trailer matching a known session. Uses the
-    /// REST `/repos/.../pulls/{N}/commits` endpoint (page-limited; the
-    /// default 30-commit window is plenty for any Crow PR).
+    /// `Crow-Session: <uuid>` trailer matching a known session.
     private func prHasCrowAuthoredCommit(pr: ViewerPR) async -> Bool {
-        let endpoint = "/repos/\(pr.repoNameWithOwner)/pulls/\(pr.number)/commits"
-        let result = await shellWithStatus(args: ["gh", "api", endpoint])
-        guard result.exitCode == 0 else {
-            NSLog("[Crow] gh api %@ failed (exit %d): %@",
-                  endpoint as NSString, result.exitCode,
-                  String(result.stderr.prefix(300)) as NSString)
+        let backend = providerManager.codeBackend(for: .github)!
+        let commits: [CommitInfo]
+        do {
+            commits = try await backend.fetchCrowAuthoredCommits(
+                prURL: pr.url,
+                repoSlug: pr.repoNameWithOwner,
+                prNumber: pr.number
+            )
+        } catch {
+            NSLog("[Crow] fetchCrowAuthoredCommits failed for %@: %@",
+                  pr.url as NSString, error.localizedDescription as NSString)
             return false
         }
-        guard let data = result.stdout.data(using: .utf8),
-              let nodes = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-            return false
-        }
-        let messages: [String] = nodes.compactMap { ($0["commit"] as? [String: Any])?["message"] as? String }
+        let messages = commits.map(\.message)
         let knownIDs = Set(appState.sessions.map(\.id))
         return Self.crowAuthored(commitMessages: messages, knownSessionIDs: knownIDs)
     }
 
     /// Best-effort: ensure the `crow:merge` label exists in the repo so
-    /// repo owners don't need to pre-create it. `gh label create` fails
-    /// loudly when the label already exists; the failure is harmless and
-    /// not surfaced.
+    /// repo owners don't need to pre-create it. The backend swallows the
+    /// "already exists" failure.
     private func ensureMergeLabel(repo: String) async {
         guard !repo.isEmpty else { return }
-        _ = await shellWithStatus(args: [
-            "gh", "label", "create", Self.autoMergeLabel,
-            "--repo", repo,
-            "--color", "0E8A16",
-            "--description", "Crow: enable auto-merge once mergeable"
-        ])
+        let backend = providerManager.codeBackend(for: .github)!
+        guard backend.capabilities.contains(.autoMergeLabel) else { return }
+        do {
+            try await backend.ensureMergeLabel(repo: repo)
+        } catch {
+            // Best-effort — swallow.
+        }
     }
 
     // MARK: - Auto-Rebase Watcher (CROW-318)
@@ -2112,7 +1499,7 @@ final class IssueTracker {
 
         // Cheap local checks first — a completed/archived session may still
         // carry an open `.pr` link with no worktree to rebase into, and unlike
-        // auto-merge there's no label gate, so avoid spending a `gh api` call
+        // auto-merge there's no label gate, so avoid spending a backend call
         // (Crow-authorship) before discovering there's nothing to do.
         let worktrees = appState.worktrees(for: session.id)
         guard let primary = worktrees.first(where: { $0.isPrimary }) ?? worktrees.first,
@@ -2503,39 +1890,15 @@ final class IssueTracker {
     // MARK: - GitLab
 
     private func fetchGitLabIssues(host: String) async -> [AssignedIssue] {
-        let output: String
+        let backend = providerManager.taskBackend(for: .gitlab, host: host)
         do {
-            // Use `glab api` rather than `glab issue list`: the latter shells
-            // out to `git` even when no repo is involved and aborts with
-            // "fatal: not a git repository" when cwd isn't a git working tree.
-            output = try await shell(
-                env: ["GITLAB_HOST": host],
-                cwd: NSHomeDirectory(),
-                "glab", "api", "issues?scope=assigned_to_me&state=opened&per_page=100"
-            )
+            let listing = try await backend.listAssigned()
+            // Only open issues, to match the prior single-call semantics
+            // (refresh() consumes closed-issues via the GitHub path today).
+            return listing.open
         } catch {
             print("[IssueTracker] fetchGitLabIssues(host: \(host)) failed: \(error)")
             return []
-        }
-
-        guard let data = output.data(using: .utf8),
-              let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
-
-        return items.compactMap { item -> AssignedIssue? in
-            guard let number = item["iid"] as? Int,
-                  let title = item["title"] as? String,
-                  let url = item["web_url"] as? String else { return nil }
-
-            let state = item["state"] as? String ?? "opened"
-            let labels = (item["labels"] as? [String] ?? []).map { LabelInfo(name: $0) }
-            let refs = item["references"] as? [String: Any]
-            let fullRef = refs?["full"] as? String ?? ""
-
-            return AssignedIssue(
-                id: "gitlab:\(host):\(fullRef)",
-                number: number, title: title, state: state == "opened" ? "open" : state,
-                url: url, repo: fullRef, labels: labels, provider: .gitlab
-            )
         }
     }
 
@@ -2554,128 +1917,24 @@ final class IssueTracker {
         let repoName = parsed.repo
         let number = parsed.number
 
+        let backend = providerManager.taskBackend(for: .github)
+        // Capability-gated UI affordance; the backend method now performs the
+        // GraphQL mutation directly (no more legacy IssueTracker escape-hatch).
+        guard backend.capabilities.contains(.projectBoardStatus) else { return }
+
         appState.isMarkingInReview[sessionID] = true
         defer { appState.isMarkingInReview[sessionID] = false }
 
-        // Step 1: Query the project item ID, project ID, Status field ID, and available options
-        // so we can find the "In Review" option to set.
-        let query = """
-        query($owner: String!, $repo: String!, $number: Int!) {
-          repository(owner: $owner, name: $repo) {
-            issue(number: $number) {
-              projectItems(first: 10) {
-                nodes {
-                  id
-                  project { id }
-                  fieldValueByName(name: "Status") {
-                    ... on ProjectV2ItemFieldSingleSelectValue {
-                      name
-                      field {
-                        ... on ProjectV2SingleSelectField {
-                          id
-                          options { id name }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        """
-
-        let queryResult = await shellWithStatus(
-            "gh", "api", "graphql",
-            "-f", "query=\(query)",
-            "-F", "owner=\(owner)",
-            "-F", "repo=\(repoName)",
-            "-F", "number=\(number)"
-        )
-
-        if queryResult.exitCode != 0 {
-            if queryResult.stderr.contains("INSUFFICIENT_SCOPES") || queryResult.stderr.contains("read:project") || queryResult.stderr.contains("project") {
-                reportScopeWarning("project")
-            } else {
-                print("[IssueTracker] GraphQL query failed: \(queryResult.stderr.prefix(200))")
-            }
+        do {
+            try await backend.setTaskStatus(url: ticketURL, status: .inReview)
+        } catch ProviderError.insufficientScope {
+            reportScopeWarning("project")
             return
-        }
-
-        // Parse the query response
-        guard let data = queryResult.stdout.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let dataObj = json["data"] as? [String: Any],
-              let repository = dataObj["repository"] as? [String: Any],
-              let issueObj = repository["issue"] as? [String: Any],
-              let projectItems = issueObj["projectItems"] as? [String: Any],
-              let nodes = projectItems["nodes"] as? [[String: Any]],
-              !nodes.isEmpty else {
-            print("[IssueTracker] Issue \(owner)/\(repoName)#\(number) is not in any GitHub Project")
+        } catch ProviderError.unimplemented(let msg) {
+            print("[IssueTracker] markInReview: \(msg)")
             return
-        }
-
-        // Find a project item that has a Status field with an "In Review" option
-        var itemID: String?
-        var projectID: String?
-        var fieldID: String?
-        var optionID: String?
-
-        for node in nodes {
-            guard let nodeID = node["id"] as? String,
-                  let project = node["project"] as? [String: Any],
-                  let projID = project["id"] as? String,
-                  let fieldValue = node["fieldValueByName"] as? [String: Any],
-                  let field = fieldValue["field"] as? [String: Any],
-                  let fID = field["id"] as? String,
-                  let options = field["options"] as? [[String: Any]] else { continue }
-
-            // Find the "In Review" option (case-insensitive)
-            for option in options {
-                guard let optName = option["name"] as? String,
-                      let optID = option["id"] as? String else { continue }
-                let normalized = optName.lowercased().trimmingCharacters(in: .whitespaces)
-                if normalized == "in review" || normalized == "review" {
-                    itemID = nodeID
-                    projectID = projID
-                    fieldID = fID
-                    optionID = optID
-                    break
-                }
-            }
-            if optionID != nil { break }
-        }
-
-        guard let itemID, let projectID, let fieldID, let optionID else {
-            print("[IssueTracker] No 'In Review' status option found in project for \(owner)/\(repoName)#\(number)")
-            return
-        }
-
-        // Step 2: Mutation to update the Status field to the "In Review" option
-        let mutation = """
-        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-          updateProjectV2ItemFieldValue(input: {
-            projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
-            value: { singleSelectOptionId: $optionId }
-          }) { projectV2Item { id } }
-        }
-        """
-
-        let mutationResult = await shellWithStatus(
-            "gh", "api", "graphql",
-            "-f", "query=\(mutation)",
-            "-F", "projectId=\(projectID)",
-            "-F", "itemId=\(itemID)",
-            "-F", "fieldId=\(fieldID)",
-            "-F", "optionId=\(optionID)"
-        )
-
-        if mutationResult.exitCode != 0 {
-            if mutationResult.stderr.contains("INSUFFICIENT_SCOPES") {
-                reportScopeWarning("project")
-            } else {
-                print("[IssueTracker] Failed to update project status: \(mutationResult.stderr.prefix(200))")
-            }
+        } catch {
+            print("[IssueTracker] markInReview failed for \(owner)/\(repoName)#\(number): \(error.localizedDescription.prefix(200))")
             return
         }
 

--- a/Sources/Crow/App/SessionService.swift
+++ b/Sources/Crow/App/SessionService.swift
@@ -1232,19 +1232,13 @@ final class SessionService {
             }
         }
 
-        // Try to fetch issue title — prefer the TaskBackend abstraction (ADR 0005)
-        // when a manager is wired; fall back to inline `gh` for older call paths.
-        if let issueURL = info.url {
-            if let manager = providerManager {
-                let backend = manager.taskBackend(forURL: issueURL)
-                if let ticket = try? await backend.fetchTask(url: issueURL) {
-                    info.title = ticket.title
-                }
-            } else if let output = try? await shell("gh", "issue", "view", issueURL, "--json", "title"),
-               let data = output.data(using: .utf8),
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let title = json["title"] as? String {
-                info.title = title
+        // Try to fetch issue title via the TaskBackend abstraction (ADR 0005).
+        // Falls through silently if no `providerManager` is wired or the fetch
+        // fails — title stays whatever the dir-name parser produced.
+        if let issueURL = info.url, let manager = providerManager {
+            let backend = manager.taskBackend(forURL: issueURL)
+            if let ticket = try? await backend.fetchTask(url: issueURL) {
+                info.title = ticket.title
             }
         }
 
@@ -1254,29 +1248,16 @@ final class SessionService {
     /// Check for a pull request on a branch and return a link if found.
     private func findPRLink(branch: String, repoPath: String, sessionID: UUID, provider: Provider) async -> SessionLink? {
         guard let repoSlug = resolveRepoSlug(repoPath: repoPath) else { return nil }
-        // Prefer CodeBackend.linkedPR (ADR 0005) when a manager is wired; fall
-        // back to the inline `gh pr list` shell-out only when no manager is
-        // available — otherwise we'd issue the identical command twice on the
-        // common "no PR exists" path.
-        if let manager = providerManager {
-            guard let backend = manager.codeBackend(for: provider),
-                  let pr = try? await backend.linkedPR(repo: repoSlug, branch: branch) else {
-                return nil
-            }
-            NSLog("[SessionService] Found PR #\(pr.number) for branch '\(branch)'")
-            return SessionLink(sessionID: sessionID, label: "PR #\(pr.number)", url: pr.url, linkType: .pr)
+        // Route through CodeBackend.linkedPR (ADR 0005). Without a wired
+        // providerManager we can't look up a PR; that's the caller's signal
+        // to skip the link.
+        guard let manager = providerManager,
+              let backend = manager.codeBackend(for: provider),
+              let pr = try? await backend.linkedPR(repo: repoSlug, branch: branch) else {
+            return nil
         }
-        guard let prOutput = try? await shell(
-            "gh", "pr", "list", "--repo", repoSlug, "--head", branch,
-            "--state", "all", "--json", "number,url,state", "--limit", "1"
-        ), let prData = prOutput.data(using: .utf8),
-           let prItems = try? JSONSerialization.jsonObject(with: prData) as? [[String: Any]],
-           let pr = prItems.first,
-           let prNum = pr["number"] as? Int,
-           let prURL = pr["url"] as? String else { return nil }
-
-        NSLog("[SessionService] Found PR #\(prNum) for branch '\(branch)'")
-        return SessionLink(sessionID: sessionID, label: "PR #\(prNum)", url: prURL, linkType: .pr)
+        NSLog("[SessionService] Found PR #\(pr.number) for branch '\(branch)'")
+        return SessionLink(sessionID: sessionID, label: "PR #\(pr.number)", url: pr.url, linkType: .pr)
     }
 
     private func recoverOrphan(worktreePath: String, branch: String, repoName: String, repoPath: String) async {
@@ -1499,6 +1480,24 @@ final class SessionService {
         // expanded SKILL.md body (#431).
         let reviewAgentKind = appState.agentKind(for: .review)
         let env = ShellEnvironment.shared.env
+
+        // Fetch PR metadata via the GitHub CodeBackend (ADR 0005) before
+        // dispatching the heavyweight clone work to a detached task. Done
+        // here on the main actor so the providerManager dependency doesn't
+        // need to cross the actor boundary into the detached task.
+        let prMetadata: PRMetadata
+        do {
+            guard let manager = providerManager else {
+                NSLog("[SessionService] No providerManager wired; cannot prepare review for \(prURL)")
+                return nil
+            }
+            let backend = manager.codeBackend(for: .github)!
+            prMetadata = try await backend.fetchPRMetadata(prURL: prURL)
+        } catch {
+            NSLog("[SessionService] Failed to fetch PR metadata for \(prURL): \(error.localizedDescription)")
+            return nil
+        }
+
         let prep: ReviewClonePrep
         do {
             prep = try await Task.detached(priority: .userInitiated) {
@@ -1509,7 +1508,8 @@ final class SessionService {
                     prNumber: prNumber,
                     devRoot: devRoot,
                     env: env,
-                    reviewAgentKind: reviewAgentKind
+                    reviewAgentKind: reviewAgentKind,
+                    prMetadata: prMetadata
                 )
             }.value
         } catch {
@@ -1603,28 +1603,22 @@ final class SessionService {
         prNumber: Int,
         devRoot: String,
         env: [String: String],
-        reviewAgentKind: AgentKind
+        reviewAgentKind: AgentKind,
+        prMetadata: PRMetadata
     ) async throws -> ReviewClonePrep {
-        // Fetch PR metadata
-        let prOutput = try await runShellAsync(env: env, args: [
-            "gh", "pr", "view", prURL,
-            "--json", "title,headRefName,headRefOid,baseRefName,number"
-        ])
-
-        guard let prData = prOutput.data(using: .utf8),
-              let prJSON = try? JSONSerialization.jsonObject(with: prData) as? [String: Any],
-              let prTitle = prJSON["title"] as? String,
-              let headBranch = prJSON["headRefName"] as? String else {
+        let prTitle = prMetadata.title
+        let headBranch = prMetadata.headRefName
+        guard !headBranch.isEmpty else {
             throw NSError(
                 domain: "SessionService",
                 code: -1,
-                userInfo: [NSLocalizedDescriptionKey: "Failed to parse PR metadata for \(prURL)"]
+                userInfo: [NSLocalizedDescriptionKey: "PR metadata missing headRefName for \(prURL)"]
             )
         }
         // `headRefOid` is the SHA the review session is anchored to. Used by
         // the kickoff guard (AppDelegate) as a fallback re-kick signal when
         // the PR head advances without an explicit re-request (CROW-290).
-        let headRefOid = prJSON["headRefOid"] as? String
+        let headRefOid: String? = prMetadata.headRefOid.isEmpty ? nil : prMetadata.headRefOid
 
         let reviewsDir = (devRoot as NSString).appendingPathComponent("crow-reviews")
         let cloneDirName = "\(repoName)-pr-\(prNumber)"

--- a/Tests/CrowTests/IssueTrackerDedupTests.swift
+++ b/Tests/CrowTests/IssueTrackerDedupTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import CrowCore
+import CrowProvider
 @testable import Crow
 
 @Suite("IssueTracker PR dedup")
@@ -19,7 +20,7 @@ struct IssueTrackerDedupTests {
         baseRefName: String = "",
         repoNameWithOwner: String = "",
         labels: [LabelInfo] = [],
-        linkedIssueReferences: [IssueTracker.ViewerPR.LinkedIssue] = [],
+        linkedIssueReferences: [LinkedIssueRef] = [],
         checksState: String = "",
         failedCheckNames: [String] = [],
         latestReviewStates: [String] = []

--- a/Tests/CrowTests/IssueTrackerReconcileTests.swift
+++ b/Tests/CrowTests/IssueTrackerReconcileTests.swift
@@ -1,5 +1,7 @@
 import Foundation
 import Testing
+import CrowCore
+import CrowProvider
 @testable import Crow
 
 @Suite("IssueTracker reconcile decision")
@@ -154,5 +156,77 @@ struct IssueTrackerRemoteSlugTests {
     @Test func returnsEmptyForUnrecognized() {
         #expect(IssueTracker.extractSlug(fromRemote: "/tmp/local/repo") == "")
         #expect(IssueTracker.extractSlug(fromRemote: "") == "")
+    }
+}
+
+@Suite("IssueTracker reconcile fan-out")
+struct IssueTrackerReconcileFanOutTests {
+
+    private func candidate(_ sid: UUID, _ slug: String, _ branch: String, provider: Provider = .github) -> IssueTracker.ReconcileCandidate {
+        IssueTracker.ReconcileCandidate(
+            sessionID: sid,
+            provider: provider,
+            repoSlug: slug,
+            branch: branch,
+            gitlabHost: nil
+        )
+    }
+
+    @Test func dedupedBranchCandidatesCollapsesDuplicates() {
+        // Regression guard for the @MainActor crash that
+        // `Dictionary(uniqueKeysWithValues:)` triggered: two sessions sharing
+        // a (repoSlug, branch) must produce a single backend query candidate,
+        // not trap on duplicate keys.
+        let s1 = UUID()
+        let s2 = UUID()
+        let cands = [
+            candidate(s1, "acme/api", "feature/x"),
+            candidate(s2, "acme/api", "feature/x"),
+            candidate(s1, "acme/api", "feature/y"),
+        ]
+        let out = IssueTracker.dedupedBranchCandidates(cands)
+        #expect(out.count == 2)
+        #expect(out.contains(BranchCandidate(repoSlug: "acme/api", branch: "feature/x")))
+        #expect(out.contains(BranchCandidate(repoSlug: "acme/api", branch: "feature/y")))
+    }
+
+    @Test func fanOutMatchesEmitsOneRecordPerSessionSharingABranch() {
+        // When two sessions share (repoSlug, branch), a single backend match
+        // must produce one ReconcileBranchMatch per session — collapsing them
+        // to one sessionID would silently drop the PR link for the other.
+        let s1 = UUID()
+        let s2 = UUID()
+        let cands = [
+            candidate(s1, "acme/api", "feature/x"),
+            candidate(s2, "acme/api", "feature/x"),
+        ]
+        let bc = BranchCandidate(repoSlug: "acme/api", branch: "feature/x")
+        let backendMatches = [
+            BranchPRMatch(candidate: bc, number: 42, url: "https://github.com/acme/api/pull/42",
+                          state: "OPEN", updatedAt: nil)
+        ]
+        let fanned = IssueTracker.fanOutMatches(backendMatches, across: cands)
+        #expect(fanned.count == 2)
+        let sids: Set<UUID> = Set(fanned.map(\.sessionID))
+        #expect(sids == [s1, s2])
+        #expect(fanned.allSatisfy { $0.number == 42 })
+        #expect(fanned.allSatisfy { $0.state == "OPEN" })
+    }
+
+    @Test func fanOutMatchesDropsUnknownCandidates() {
+        // A match for a candidate the caller didn't request must not bleed
+        // into the output (defensive: a stale or malformed backend response
+        // shouldn't create phantom sessionIDs).
+        let s1 = UUID()
+        let bc1 = BranchCandidate(repoSlug: "acme/api", branch: "feature/x")
+        let bc2 = BranchCandidate(repoSlug: "acme/api", branch: "feature/y")
+        let backendMatches = [
+            BranchPRMatch(candidate: bc1, number: 1, url: "u1", state: "OPEN", updatedAt: nil),
+            BranchPRMatch(candidate: bc2, number: 2, url: "u2", state: "OPEN", updatedAt: nil),
+        ]
+        let cands = [candidate(s1, "acme/api", "feature/x")]
+        let fanned = IssueTracker.fanOutMatches(backendMatches, across: cands)
+        #expect(fanned.count == 1)
+        #expect(fanned[0].number == 1)
     }
 }

--- a/Tests/CrowTests/QuickActionPromptsTests.swift
+++ b/Tests/CrowTests/QuickActionPromptsTests.swift
@@ -13,6 +13,17 @@ private struct FakeCodeBackend: CodeBackend {
     let capabilities: Set<CodeCapability> = []
     func linkedPR(repo: String, branch: String) async throws -> LinkedPR? { nil }
     func ensureMergeLabel(repo: String) async throws {}
+    func listMonitoredPRs() async throws -> MonitoredPRListing {
+        MonitoredPRListing(viewerPRs: [], reviewRequests: [], viewerLogin: "")
+    }
+    func prStates(refs: [PRRef]) async throws -> [PRRef: PRRecord] { [:] }
+    func fetchCrowAuthoredCommits(prURL: String, repoSlug: String, prNumber: Int) async throws -> [CommitInfo] { [] }
+    func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch] { [] }
+    func enableAutoMerge(prURL: String) async throws {}
+    func updateBranch(prURL: String) async throws {}
+    func fetchPRMetadata(prURL: String) async throws -> PRMetadata {
+        PRMetadata(title: "", number: 0, headRefName: "", headRefOid: "", baseRefName: "")
+    }
 }
 
 @Suite("QuickActionPrompts.mergePR")

--- a/docs/adr/0005-task-and-code-backend-protocols.md
+++ b/docs/adr/0005-task-and-code-backend-protocols.md
@@ -1,7 +1,7 @@
 # 0005 — TaskBackend and CodeBackend protocols
 
-- **Status:** Proposed
-- **Date:** 2026-06-03
+- **Status:** Accepted (foundation #411, migration #454)
+- **Date:** 2026-06-03 (proposed), 2026-06-07 (accepted)
 - **Deciders:** Crow maintainers
 
 ## Context
@@ -24,9 +24,11 @@ A non-coding task in Corveil paired with a `.github` PR (or `.gitlab` MR) is a l
 Crow exposes two independent protocols under `CrowProvider`:
 
 - **`TaskBackend`** — tracker side. Owns issue/task lifecycle: `fetchTask`, `listAssigned`, `setLabels`, `setTaskStatus`, `assign`, `createTask`.
-- **`CodeBackend`** — VCS side. Owns PR lifecycle: `linkedPR`, `prStates`, `ensureMergeLabel`, `fetchCrowAuthoredCommits`.
+- **`CodeBackend`** — VCS side. Owns PR lifecycle: `linkedPR`, `listMonitoredPRs`, `prStates`, `ensureMergeLabel`, `fetchCrowAuthoredCommits`, `findRecentPRsForBranches`, `enableAutoMerge`, `updateBranch`, `fetchPRMetadata`.
 
-Each backend declares its **capabilities** as a `Set` (`TaskCapability` and `CodeCapability`). Callers branch on capabilities, not on provider identity. Capabilities gate UI affordances and call-site decisions; they do not by themselves guarantee a method's implementation is wired (a backend may declare a UI-facing capability while routing execution through a legacy path — see `.projectBoardStatus` on `GitHubTaskBackend`, where `IssueTracker.markInReview` performs the mutation until the `setTaskStatus` GraphQL migration lands). Examples:
+The `CodeBackend` surface grew beyond the original spec (`linkedPR`, `prStates`, `ensureMergeLabel`, `fetchCrowAuthoredCommits`) during the #454 migration so that every direct `gh`/`glab` shell-out in `IssueTracker.swift` could route through the abstraction. `enableAutoMerge`, `updateBranch`, `findRecentPRsForBranches`, `listMonitoredPRs`, and `fetchPRMetadata` are operational primitives — not new abstractions — that the grep-empty acceptance test required. They're capability-gated where the operation isn't universal (GitLab declares no `.autoMerge` / `.updateBranch`); the methods throw `ProviderError.unimplemented` for backends without the capability.
+
+Each backend declares its **capabilities** as a `Set` (`TaskCapability` and `CodeCapability`). Callers branch on capabilities, not on provider identity. Capabilities gate UI affordances **and** guarantee the relevant method is wired — after #454 there is no longer an "I declare it but don't implement it" caveat. Examples:
 
 ```swift
 // UI gating — the direct replacement for `if session.provider == .github { ... }`.
@@ -34,10 +36,10 @@ if taskBackend.capabilities.contains(.projectBoardStatus) {
     showInReviewButton()
 }
 
-// Calling a capability-gated method. Backends that declare the capability may
-// still throw `.unimplemented` if their implementation is pending; callers
-// that exercise the method directly must be prepared for that and either fall
-// back to a legacy path or surface the error.
+// Calling a capability-gated method. With the #454 migration in place, the
+// capability flag is both the UI guard AND the implementation guarantee:
+// GitHubTaskBackend.setTaskStatus now performs the GraphQL mutation
+// directly (no more IssueTracker.markInReview escape-hatch).
 if taskBackend.capabilities.contains(.projectBoardStatus) {
     try await taskBackend.setTaskStatus(url: url, status: .inReview)
 }
@@ -47,30 +49,62 @@ New backends declare what they support and the call site asks; no `switch` over 
 
 Backends take a `ShellRunner` (a thin `protocol` over `Process()` + `ShellEnvironment.shared`) at init, so unit tests inject a `FakeShellRunner` that records command vectors and returns canned JSON. The three near-duplicate `private func shell` implementations in `ProviderManager`, `IssueTracker`, and `SessionService` collapse into one `ProcessShellRunner`.
 
-`ProviderManager` becomes a non-actor factory (`final class … : Sendable`) that hands out the right backend(s) for a session or URL. URL parsing utilities (`parseTicketURLComponents`, `detectProvider`, `classifySpec`) stay where they are. Isolation lives in the `ShellRunner` it injects, not on the factory itself.
+`ProviderManager` is a non-actor factory (`final class … : Sendable`) that hands out the right backend(s) for a session or URL. URL parsing utilities (`parseTicketURLComponents`, `detectProvider`, `classifySpec`) stay where they are. Isolation lives in the `ShellRunner` it injects, not on the factory itself.
 
 Concrete implementations:
 
 | Backend | Provider | Capabilities |
 |---|---|---|
 | `GitHubTaskBackend` | `.github` | `[projectBoardStatus, batchedQuery]` |
-| `GitHubCodeBackend` | `.github` | `[autoMergeLabel, batchedPRStates]` |
-| `GitLabTaskBackend` | `.gitlab` | `[]` (v1) |
-| `GitLabCodeBackend` | `.gitlab` | `[]` (v1) |
+| `GitHubCodeBackend` | `.github` | `[autoMergeLabel, batchedPRStates, autoMerge, updateBranch]` |
+| `GitLabTaskBackend` | `.gitlab` | `[]` |
+| `GitLabCodeBackend` | `.gitlab` | `[]` |
 | `StubCorveilTaskBackend` | `.corveil` | `[]` — every method throws `.unimplemented` |
 
 There is no `StubCorveilCodeBackend` — Corveil has no git. A Corveil-tasked session uses a `.github` or `.gitlab` `CodeBackend`, which is the whole point of the split.
 
-`Session.provider` remains a single optional field for v1 — code looks up both backends from the same value. A follow-up adds `Session.codeProvider: Provider?` once a real Corveil backend is implemented and cross-backend sessions are a working flow, not a theoretical one.
+`Session.provider` remains a single optional field — code looks up both backends from the same value. A follow-up adds `Session.codeProvider: Provider?` once a real Corveil backend is implemented and cross-backend sessions are a working flow, not a theoretical one.
+
+## Migration status
+
+Method-by-method state as of the #454 PR. "Site" is where the implementation lives (no parenthetical means it's in the backend file itself).
+
+### TaskBackend
+
+| Method | GitHub | GitLab | Corveil | Notes |
+|---|---|---|---|---|
+| `fetchTask` | ✅ | ✅ | throws | shipped #411 |
+| `setLabels` | ✅ | ✅ | throws | shipped #411 |
+| `setTaskStatus` | ✅ (#454) | throws (no cap) | throws | #454 closed the escape-hatch — `IssueTracker.markInReview` no longer runs a parallel GraphQL mutation |
+| `listAssigned` | ✅ (#454) | ✅ (#454) | throws | GitHub batches open+closed in one GraphQL call; GitLab issues two REST calls |
+| `assign` | ✅ (#454) | ✅ (#454) | throws | for `setup.sh` and skill flows |
+| `createTask` | ✅ (#454) | ✅ (#454) | throws | for `/crow-create-ticket` |
+
+### CodeBackend
+
+| Method | GitHub | GitLab | Notes |
+|---|---|---|---|
+| `linkedPR` | ✅ | ✅ | shipped #411 |
+| `ensureMergeLabel` | ✅ (cap-gated) | throws (no cap) | shipped #411; `.autoMergeLabel` gates |
+| `listMonitoredPRs` | ✅ (#454) | partial | GitHub returns viewer PRs + review-requested in one GraphQL call; GitLab returns review-requested only (no `viewerPRs` analogue today) |
+| `prStates` | ✅ (#454, batched) | ✅ (#454, per-MR) | `.batchedPRStates` declared only by GitHub |
+| `fetchCrowAuthoredCommits` | ✅ (#454) | ✅ (#454) | callers filter by `Crow-Session:` trailer |
+| `findRecentPRsForBranches` | ✅ (#454, batched) | ✅ (#454, per-candidate) | reconcile path |
+| `enableAutoMerge` | ✅ (#454, cap-gated) | throws (no cap) | `.autoMerge` gates |
+| `updateBranch` | ✅ (#454, cap-gated) | throws (no cap) | `.updateBranch` gates |
+| `fetchPRMetadata` | ✅ (#454) | ✅ (#454) | used by `SessionService.prepareReviewClone` |
+
+After #454, `rg '"gh"|"glab"|gh api|glab api' Sources/Crow/App/IssueTracker.swift` returns zero matches — the acceptance signal for "the abstraction is the actual runtime path, not just the API."
 
 ## Consequences
 
 **Easier:**
 
 - "Add a third provider" stops being a sprawling diff across `IssueTracker` and becomes a new file in `Backends/` plus a factory case.
-- Behavior matrices become testable. Each backend is exercised against a `FakeShellRunner` — the regression net the codebase currently lacks.
-- The parallel GitHub/GitLab halves of `listAssigned` and `prStates` stop sitting in the same file. They move to their respective backend files where their idioms (batched GraphQL vs per-MR REST) are local concerns, not global ones.
+- Behavior matrices become testable. Each backend is exercised against a `FakeShellRunner` — the regression net the codebase previously lacked.
+- The parallel GitHub/GitLab halves of `listAssigned`, `prStates`, `findRecentPRsForBranches`, etc. stop sitting in the same file. They moved to their respective backend files where their idioms (batched GraphQL vs per-MR REST) are local concerns, not global ones.
 - Non-coding tasks are no longer an architectural awkwardness. A task without a `CodeBackend` is a normal session; PR-related code paths simply aren't invoked.
+- Capability flags now mean what they say. A backend that declares `.projectBoardStatus` actually implements `setTaskStatus` — no more "the UI guard is the capability but the implementation lives elsewhere."
 
 **Harder / accepted:**
 
@@ -78,6 +112,7 @@ There is no `StubCorveilCodeBackend` — Corveil has no git. A Corveil-tasked se
 - Capability flags are an enum the maintainer keeps in sync. A new capability is a two-edit change (add the case, declare it on the relevant backend) — easy to forget, hard to catch by build.
 - The `Session.provider == provider` simplification limits cross-backend pairings until the `Session.codeProvider` follow-up lands. Real Corveil work blocks on that ticket.
 - `setup.sh` and skill scripts continue to shell `gh`/`glab` directly — they don't run through Swift and stay out of this abstraction. A separate effort once a real Corveil backend exists.
+- The GitHub viewer's consolidated query is now split across two calls (`listAssigned` for issues, `listMonitoredPRs` for PRs + reviews). One extra GraphQL round-trip per polling cycle (negligible against the ~5000/hour rate limit budget). The trade buys clean task/code separation in the protocol surface.
 
 ## Alternatives considered
 
@@ -85,14 +120,17 @@ There is no `StubCorveilCodeBackend` — Corveil has no git. A Corveil-tasked se
 - **Throw `.unsupportedOperation`** instead of capability flags. Rejected — forces callers into try/catch when they really want to branch before calling. Capability flags also document the support matrix in one place; throwing scatters it across catch blocks.
 - **Keep `ProviderManager` as an actor.** Rejected — backends are `Sendable` protocol existentials, the factory hands them out synchronously, and the only real isolation is around the shell runner (where it belongs). Making the factory itself an actor adds `await` to every call site for no concurrency benefit.
 - **Closure-based shell runner.** Considered — lighter weight (just `let shell: @Sendable ([String], [String:String], String?) -> String`). Rejected in favor of a named protocol so future callers (and skills) can discover and conform to it the same way they conform to `Sendable`.
+- **Keep the consolidated GraphQL query as a single `listAssigned` returning a mixed envelope** (issues + viewerPRs + reviewRequests). Rejected during #454 in favor of splitting `listAssigned` (TaskBackend) and `listMonitoredPRs` (CodeBackend). The protocol-purity win was worth one extra round-trip per minute.
 
 ## References
 
-- Ticket: [#410](https://github.com/radiusmethod/crow/issues/410)
+- Tickets: [#410](https://github.com/radiusmethod/crow/issues/410) (foundation, closed via #411), [#454](https://github.com/radiusmethod/crow/issues/454) (migration)
+- PRs: #411 (foundation), the PR closing #454 (migration)
 - Code:
   - `Packages/CrowProvider/Sources/CrowProvider/TaskBackend.swift`
   - `Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift`
+  - `Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift`
   - `Packages/CrowProvider/Sources/CrowProvider/Backends/`
   - `Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift`
   - `Packages/CrowCore/Sources/CrowCore/ShellRunner.swift`
-- Follow-up tickets: AutoRespond CLI migration, UI capability checks, `Session.codeProvider` field.
+- Follow-up tickets: real Corveil `TaskBackend`, `Session.codeProvider` field for cross-backend pairings, `setup.sh` / skill migration off direct `gh`/`glab`.


### PR DESCRIPTION
Closes #454.

## Summary

- Expands `TaskBackend` and `CodeBackend` to the full ADR 0005 surface plus the operational primitives (`enableAutoMerge`, `updateBranch`, `findRecentPRsForBranches`, `listMonitoredPRs`, `fetchPRMetadata`) that the grep-empty acceptance test required.
- Closes the `setTaskStatus` escape-hatch: `GitHubTaskBackend.setTaskStatus` now runs the GraphQL project-board mutation directly; `IssueTracker.markInReview` is a thin capability gate that delegates to the backend.
- Ports every `gh`/`glab` shell-out in `IssueTracker.swift` through the backends — `rg '"gh"|"glab"|gh api|glab api' Sources/Crow/App/IssueTracker.swift` returns zero matches.
- Ports the ticket/PR fetch fallbacks in `SessionService.swift` (`parseTicketInfo`, `findPRLink`, `prepareReviewClone`) through the backends. Repo clones stay direct — outside the TaskBackend/CodeBackend surface.
- Adds 33 new `BackendsTests` cases against `FakeShellRunner` covering every new method.
- Updates ADR 0005 to `Accepted` with a Migration Status subsection documenting method-by-method coverage and the surface that grew beyond the original spec.

## Test plan

- [x] `swift build --arch arm64` — succeeds with no new warnings.
- [x] `swift test --package-path Packages/CrowProvider` — all 65 tests pass (BackendsTests + ProviderManagerTests).
- [x] `swift test --package-path Packages/{CrowCore,CrowGit,CrowPersistence,CrowIPC}` — all pass.
- [x] Grep test: `rg '"gh"|"glab"|gh api|glab api' Sources/Crow/App/IssueTracker.swift` returns zero matches.
- [ ] Manual smoke: open a GitHub-backed session and a GitLab-backed session in Crow; verify assigned-issue panel renders both, label add/remove works on issues, stale-PR badges flip correctly, mark-in-review flips the GitHub project board, and auto-merge fires when conditions are met. (Reviewer's call.)

## Out of scope (per ticket)

- Real Corveil `TaskBackend` (stub stays).
- `Session.codeProvider` field.
- `setup.sh` / skill scripts shelling `gh`/`glab` directly.
- `SessionService` repo clone operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)