### PR TITLE
Re-arm auto-respond on new review activity + post-commit push (CROW-456)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/PRStatus.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/PRStatus.swift
@@ -9,19 +9,28 @@ public struct PRStatus: Codable, Sendable, Equatable {
     /// Head commit SHA. Used to dedupe per-commit transition events
     /// (e.g. don't re-fire "checks failing" when the same commit is re-run).
     public var headSha: String?
+    /// Node ID of the most recent CHANGES_REQUESTED review on this PR, when
+    /// the provider surfaces stable review identifiers. Round-2 dedup uses
+    /// this so a fresh "Request changes" submission re-arms auto-respond
+    /// even when the bucket stays in `.changesRequested`. `nil` when no
+    /// CHANGES_REQUESTED review is currently visible, or on providers that
+    /// don't expose review IDs in the monitored-PR query (e.g. GitLab).
+    public var latestReviewID: String?
 
     public init(
         checksPass: CheckStatus = .unknown,
         reviewStatus: ReviewStatus = .unknown,
         mergeable: MergeStatus = .unknown,
         failedCheckNames: [String] = [],
-        headSha: String? = nil
+        headSha: String? = nil,
+        latestReviewID: String? = nil
     ) {
         self.checksPass = checksPass
         self.reviewStatus = reviewStatus
         self.mergeable = mergeable
         self.failedCheckNames = failedCheckNames
         self.headSha = headSha
+        self.latestReviewID = latestReviewID
     }
 
     public init(from decoder: Decoder) throws {
@@ -31,10 +40,11 @@ public struct PRStatus: Codable, Sendable, Equatable {
         mergeable = try c.decodeIfPresent(MergeStatus.self, forKey: .mergeable) ?? .unknown
         failedCheckNames = try c.decodeIfPresent([String].self, forKey: .failedCheckNames) ?? []
         headSha = try c.decodeIfPresent(String.self, forKey: .headSha)
+        latestReviewID = try c.decodeIfPresent(String.self, forKey: .latestReviewID)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case checksPass, reviewStatus, mergeable, failedCheckNames, headSha
+        case checksPass, reviewStatus, mergeable, failedCheckNames, headSha, latestReviewID
     }
 
     public enum CheckStatus: String, Codable, Sendable {

--- a/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
@@ -7,11 +7,10 @@ import Foundation
 /// so the comparison logic stays unit-testable.
 public struct PRStatusTransition: Sendable, Equatable {
     public enum Kind: String, Sendable, Equatable {
-        /// A reviewer transitioned the PR into "changes requested", or a new
-        /// round of changes-requested activity occurred while the PR was still
-        /// in `.changesRequested` (new formal review, or new commit pushed
-        /// after the prior review). See `transitions(from:to:…)` for the
-        /// round-2 detection rules.
+        /// A reviewer transitioned the PR into "changes requested", or a fresh
+        /// formal "Request changes" review was submitted while the PR was
+        /// already in `.changesRequested` (round-2; identified by review-id
+        /// rotation). See `transitions(from:to:…)` for the detection rules.
         case changesRequested
         /// At least one CI/CD check newly transitioned to failing on the
         /// current head commit.
@@ -23,14 +22,16 @@ public struct PRStatusTransition: Sendable, Equatable {
     public let prURL: String
     public let prNumber: Int?
     /// Head commit SHA at the moment of the transition. Part of the dedupe key
-    /// for both `.checksFailing` (re-runs on the same commit must not re-fire)
-    /// and `.changesRequested` (a post-commit push while still in
-    /// changes-requested must re-arm — CROW-456).
+    /// for `.checksFailing` so re-runs on the same commit don't re-fire.
+    /// Carried on `.changesRequested` for downstream telemetry/UI but is not
+    /// part of that dedupe key (see `dedupeKey`).
     public let headSha: String?
     /// Node ID of the most recent CHANGES_REQUESTED review when the transition
-    /// fired. Part of the `.changesRequested` dedupe key so a second formal
-    /// "Request changes" submission re-arms auto-respond even when the bucket
-    /// hasn't moved. `nil` for providers that don't expose review IDs.
+    /// fired. Sole round-2 discriminator in the `.changesRequested` dedupe
+    /// key — a fresh formal review rotates this and re-arms auto-respond,
+    /// while the author's own response push (which doesn't dismiss the
+    /// reviewer's CHANGES_REQUESTED decision) leaves it alone and stays
+    /// deduped. `nil` for providers that don't expose review IDs.
     public let latestReviewID: String?
     /// Names of failing checks (empty for `.changesRequested`).
     public let failedCheckNames: [String]
@@ -55,18 +56,18 @@ public struct PRStatusTransition: Sendable, Equatable {
 
     /// Stable key used to suppress duplicate fires across polling cycles.
     ///
-    /// `.changesRequested` includes both the latest CHANGES_REQUESTED review
-    /// ID and the head SHA, so:
-    /// - the same review observed twice → same key → deduped
-    /// - a new formal "Request changes" → new review ID → fires
-    /// - a new commit after the prior review → new SHA → fires
+    /// `.changesRequested` keys on `(session, kind, latestReviewID)`. The
+    /// review ID rotates only when a reviewer submits a new formal review —
+    /// not when the author pushes a fix — so the auto-respond prompt that
+    /// instructs the agent to "commit the fix, push, re-request review"
+    /// can't trigger itself on the next poll (CROW-456 review feedback).
     ///
     /// `.checksFailing` keys on `(session, kind, headSha)` so a new commit
     /// that also fails CI can re-fire.
     public var dedupeKey: String {
         switch kind {
         case .changesRequested:
-            return "\(sessionID.uuidString)|changesRequested|\(latestReviewID ?? "")|\(headSha ?? "")"
+            return "\(sessionID.uuidString)|changesRequested|\(latestReviewID ?? "")"
         case .checksFailing:
             return "\(sessionID.uuidString)|checksFailing|\(headSha ?? "")"
         }
@@ -80,11 +81,14 @@ extension PRStatus {
     /// existing PR state never triggers a fire-on-startup. Otherwise emits
     /// at most one `.changesRequested` and one `.checksFailing`, in that order.
     ///
-    /// For `.changesRequested`, fires on any of:
-    /// - Entering the bucket (old wasn't in `.changesRequested`).
-    /// - Same bucket, new review ID (a second formal "Request changes").
-    /// - Same bucket, new head SHA (agent pushed a fix after the prior
-    ///   review; reviewer's next pass should re-prompt the agent).
+    /// `.changesRequested` fires when the bucket is entered (`old` wasn't
+    /// `.changesRequested`) or when the latest CHANGES_REQUESTED review ID
+    /// rotates while still in the bucket (a fresh formal "Request changes"
+    /// submission). A head-SHA change alone does **not** fire — `reviewDecision`
+    /// stays `CHANGES_REQUESTED` after the author pushes, so any such trigger
+    /// would re-fire on the agent's own response push and create an auto-respond
+    /// loop. Real "round 2 after a fix" always involves the reviewer submitting
+    /// a new formal review, which rotates the review ID.
     ///
     /// - Note: This is the pure piece of the transition pipeline; the
     ///   stateful dedupe (across polls) lives in `IssueTracker`.
@@ -104,10 +108,7 @@ extension PRStatus {
             let newReview = old.latestReviewID != nil
                 && new.latestReviewID != nil
                 && old.latestReviewID != new.latestReviewID
-            let postCommitPush = old.reviewStatus == .changesRequested
-                && old.headSha != new.headSha
-                && new.headSha != nil
-            if entering || newReview || postCommitPush {
+            if entering || newReview {
                 out.append(PRStatusTransition(
                     kind: .changesRequested,
                     sessionID: sessionID,

--- a/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
@@ -7,7 +7,11 @@ import Foundation
 /// so the comparison logic stays unit-testable.
 public struct PRStatusTransition: Sendable, Equatable {
     public enum Kind: String, Sendable, Equatable {
-        /// A reviewer transitioned the PR into "changes requested".
+        /// A reviewer transitioned the PR into "changes requested", or a new
+        /// round of changes-requested activity occurred while the PR was still
+        /// in `.changesRequested` (new formal review, or new commit pushed
+        /// after the prior review). See `transitions(from:to:…)` for the
+        /// round-2 detection rules.
         case changesRequested
         /// At least one CI/CD check newly transitioned to failing on the
         /// current head commit.
@@ -18,10 +22,16 @@ public struct PRStatusTransition: Sendable, Equatable {
     public let sessionID: UUID
     public let prURL: String
     public let prNumber: Int?
-    /// Head commit SHA at the moment of the transition. Used as part of the
-    /// dedupe key for `.checksFailing` so re-runs on the same commit don't
-    /// re-fire.
+    /// Head commit SHA at the moment of the transition. Part of the dedupe key
+    /// for both `.checksFailing` (re-runs on the same commit must not re-fire)
+    /// and `.changesRequested` (a post-commit push while still in
+    /// changes-requested must re-arm — CROW-456).
     public let headSha: String?
+    /// Node ID of the most recent CHANGES_REQUESTED review when the transition
+    /// fired. Part of the `.changesRequested` dedupe key so a second formal
+    /// "Request changes" submission re-arms auto-respond even when the bucket
+    /// hasn't moved. `nil` for providers that don't expose review IDs.
+    public let latestReviewID: String?
     /// Names of failing checks (empty for `.changesRequested`).
     public let failedCheckNames: [String]
 
@@ -31,6 +41,7 @@ public struct PRStatusTransition: Sendable, Equatable {
         prURL: String,
         prNumber: Int? = nil,
         headSha: String? = nil,
+        latestReviewID: String? = nil,
         failedCheckNames: [String] = []
     ) {
         self.kind = kind
@@ -38,17 +49,24 @@ public struct PRStatusTransition: Sendable, Equatable {
         self.prURL = prURL
         self.prNumber = prNumber
         self.headSha = headSha
+        self.latestReviewID = latestReviewID
         self.failedCheckNames = failedCheckNames
     }
 
     /// Stable key used to suppress duplicate fires across polling cycles.
-    /// `.changesRequested` keys on `(session, kind)` — the rule re-arms when
-    /// the status moves away from `.changesRequested`. `.checksFailing` keys
-    /// on `(session, kind, headSha)` so a new commit can re-fire.
+    ///
+    /// `.changesRequested` includes both the latest CHANGES_REQUESTED review
+    /// ID and the head SHA, so:
+    /// - the same review observed twice → same key → deduped
+    /// - a new formal "Request changes" → new review ID → fires
+    /// - a new commit after the prior review → new SHA → fires
+    ///
+    /// `.checksFailing` keys on `(session, kind, headSha)` so a new commit
+    /// that also fails CI can re-fire.
     public var dedupeKey: String {
         switch kind {
         case .changesRequested:
-            return "\(sessionID.uuidString)|changesRequested"
+            return "\(sessionID.uuidString)|changesRequested|\(latestReviewID ?? "")|\(headSha ?? "")"
         case .checksFailing:
             return "\(sessionID.uuidString)|checksFailing|\(headSha ?? "")"
         }
@@ -61,6 +79,12 @@ extension PRStatus {
     /// Returns an empty array on the first observation (`old == nil`) so
     /// existing PR state never triggers a fire-on-startup. Otherwise emits
     /// at most one `.changesRequested` and one `.checksFailing`, in that order.
+    ///
+    /// For `.changesRequested`, fires on any of:
+    /// - Entering the bucket (old wasn't in `.changesRequested`).
+    /// - Same bucket, new review ID (a second formal "Request changes").
+    /// - Same bucket, new head SHA (agent pushed a fix after the prior
+    ///   review; reviewer's next pass should re-prompt the agent).
     ///
     /// - Note: This is the pure piece of the transition pipeline; the
     ///   stateful dedupe (across polls) lives in `IssueTracker`.
@@ -75,15 +99,25 @@ extension PRStatus {
 
         var out: [PRStatusTransition] = []
 
-        if old.reviewStatus != .changesRequested && new.reviewStatus == .changesRequested {
-            out.append(PRStatusTransition(
-                kind: .changesRequested,
-                sessionID: sessionID,
-                prURL: prURL,
-                prNumber: prNumber,
-                headSha: new.headSha,
-                failedCheckNames: []
-            ))
+        if new.reviewStatus == .changesRequested {
+            let entering = old.reviewStatus != .changesRequested
+            let newReview = old.latestReviewID != nil
+                && new.latestReviewID != nil
+                && old.latestReviewID != new.latestReviewID
+            let postCommitPush = old.reviewStatus == .changesRequested
+                && old.headSha != new.headSha
+                && new.headSha != nil
+            if entering || newReview || postCommitPush {
+                out.append(PRStatusTransition(
+                    kind: .changesRequested,
+                    sessionID: sessionID,
+                    prURL: prURL,
+                    prNumber: prNumber,
+                    headSha: new.headSha,
+                    latestReviewID: new.latestReviewID,
+                    failedCheckNames: []
+                ))
+            }
         }
 
         if old.checksPass != .failing && new.checksPass == .failing {

--- a/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
@@ -105,6 +105,14 @@ extension PRStatus {
 
         if new.reviewStatus == .changesRequested {
             let entering = old.reviewStatus != .changesRequested
+            // Require both ids to be non-nil. If a CHANGES_REQUESTED review is
+            // briefly absent from `latestReviews(first: 5)` (buried behind 5+
+            // other reviewers' latest reviews) and then resurfaces with a new
+            // id, the nil → id step intentionally won't fire. We prefer a
+            // missed re-prompt to a spurious one — `reviewDecision` and the
+            // `latestReviews`-derived id can legitimately disagree during a
+            // single CHANGES_REQUESTED tenure, and a spurious fire would
+            // re-prompt the agent for no reviewer action.
             let newReview = old.latestReviewID != nil
                 && new.latestReviewID != nil
                 && old.latestReviewID != new.latestReviewID

--- a/Packages/CrowCore/Tests/CrowCoreTests/PRStatusTransitionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/PRStatusTransitionTests.swift
@@ -84,15 +84,30 @@ struct PRStatusTransitionTests {
     }
 
     @Test
-    func changesRequestedSameStateNewShaFires() {
-        // CROW-456: agent pushed a fix after the prior review. Reviewer's next
-        // look should re-trigger auto-respond regardless of whether they've
-        // submitted a fresh formal review yet.
+    func changesRequestedSameStateNewShaWithoutNewReviewDoesNotFire() {
+        // CROW-456 review feedback: a head-SHA change alone must NOT fire.
+        // GitHub doesn't dismiss CHANGES_REQUESTED on author push, so the
+        // agent's own response push (after the auto-respond prompt told it
+        // to commit + push + re-request reviewers) would otherwise trigger
+        // auto-respond again — a self-sustaining loop. Real "round 2" always
+        // brings a new formal review and a new review ID.
         let old = status(review: .changesRequested, sha: shaA, reviewID: "R_1")
         let new = status(review: .changesRequested, sha: shaB, reviewID: "R_1")
+        #expect(compute(from: old, to: new).isEmpty)
+    }
+
+    @Test
+    func changesRequestedNewReviewAfterAgentPushFires() {
+        // The "agent pushed a fix, reviewer responded with more changes" path.
+        // The fresh formal review rotates `latestReviewID` regardless of how
+        // many SHAs the agent pushed in between, so `newReview` covers this
+        // case without needing a separate post-commit-push trigger.
+        let old = status(review: .changesRequested, sha: shaA, reviewID: "R_1")
+        let new = status(review: .changesRequested, sha: shaB, reviewID: "R_2")
         let ts = compute(from: old, to: new)
         #expect(ts.count == 1)
         #expect(ts.first?.kind == .changesRequested)
+        #expect(ts.first?.latestReviewID == "R_2")
         #expect(ts.first?.headSha == shaB)
     }
 
@@ -152,17 +167,19 @@ struct PRStatusTransitionTests {
     // MARK: - Dedupe key
 
     @Test
-    func dedupeKeyForChangesRequestedIncludesReviewIDAndSha() {
-        // CROW-456: same review + same SHA must collapse; different review or
-        // different SHA must produce a different key so re-fire isn't suppressed.
+    func dedupeKeyForChangesRequestedIncludesReviewIDOnly() {
+        // CROW-456: review ID is the sole round-2 discriminator. Same review
+        // collapses; new review breaks the key. Head SHA is intentionally NOT
+        // in the key — see `changesRequestedSameStateNewShaWithoutNewReviewDoesNotFire`
+        // for the rationale (avoids the agent-push self-loop).
         let base = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaA, latestReviewID: "R_1")
         let sameAgain = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaA, latestReviewID: "R_1")
         let newReview = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaA, latestReviewID: "R_2")
-        let newSha = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaB, latestReviewID: "R_1")
+        let onlyNewSha = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaB, latestReviewID: "R_1")
 
         #expect(base.dedupeKey == sameAgain.dedupeKey)
         #expect(base.dedupeKey != newReview.dedupeKey)
-        #expect(base.dedupeKey != newSha.dedupeKey)
+        #expect(base.dedupeKey == onlyNewSha.dedupeKey)
     }
 
     @Test

--- a/Packages/CrowCore/Tests/CrowCoreTests/PRStatusTransitionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/PRStatusTransitionTests.swift
@@ -13,6 +13,7 @@ struct PRStatusTransitionTests {
         review: PRStatus.ReviewStatus = .reviewRequired,
         checks: PRStatus.CheckStatus = .pending,
         sha: String? = nil,
+        reviewID: String? = nil,
         failed: [String] = []
     ) -> PRStatus {
         PRStatus(
@@ -20,7 +21,8 @@ struct PRStatusTransitionTests {
             reviewStatus: review,
             mergeable: .unknown,
             failedCheckNames: failed,
-            headSha: sha
+            headSha: sha,
+            latestReviewID: reviewID
         )
     }
 
@@ -62,9 +64,36 @@ struct PRStatusTransitionTests {
 
     @Test
     func changesRequestedToChangesRequestedDoesNotFire() {
-        // Status hasn't transitioned — every poll observes the same state.
-        let ts = compute(from: status(review: .changesRequested), to: status(review: .changesRequested))
-        #expect(ts.isEmpty)
+        // Status hasn't transitioned — every poll observes the same state with
+        // the same review ID and SHA, so no re-fire.
+        let old = status(review: .changesRequested, sha: shaA, reviewID: "R_1")
+        let new = status(review: .changesRequested, sha: shaA, reviewID: "R_1")
+        #expect(compute(from: old, to: new).isEmpty)
+    }
+
+    @Test
+    func changesRequestedSameStateNewReviewIDFires() {
+        // CROW-456: reviewer submitted a second "Request changes" without an
+        // intervening approval. The review ID rotates, so we must re-arm.
+        let old = status(review: .changesRequested, sha: shaA, reviewID: "R_1")
+        let new = status(review: .changesRequested, sha: shaA, reviewID: "R_2")
+        let ts = compute(from: old, to: new)
+        #expect(ts.count == 1)
+        #expect(ts.first?.kind == .changesRequested)
+        #expect(ts.first?.latestReviewID == "R_2")
+    }
+
+    @Test
+    func changesRequestedSameStateNewShaFires() {
+        // CROW-456: agent pushed a fix after the prior review. Reviewer's next
+        // look should re-trigger auto-respond regardless of whether they've
+        // submitted a fresh formal review yet.
+        let old = status(review: .changesRequested, sha: shaA, reviewID: "R_1")
+        let new = status(review: .changesRequested, sha: shaB, reviewID: "R_1")
+        let ts = compute(from: old, to: new)
+        #expect(ts.count == 1)
+        #expect(ts.first?.kind == .changesRequested)
+        #expect(ts.first?.headSha == shaB)
     }
 
     @Test
@@ -123,13 +152,17 @@ struct PRStatusTransitionTests {
     // MARK: - Dedupe key
 
     @Test
-    func dedupeKeyForChangesRequestedDoesNotIncludeSha() {
-        // Once we've seen a changesRequested for a session, subsequent
-        // re-observations of the same state must dedupe regardless of which
-        // commit happens to be HEAD at the moment.
-        let t1 = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaA)
-        let t2 = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaB)
-        #expect(t1.dedupeKey == t2.dedupeKey)
+    func dedupeKeyForChangesRequestedIncludesReviewIDAndSha() {
+        // CROW-456: same review + same SHA must collapse; different review or
+        // different SHA must produce a different key so re-fire isn't suppressed.
+        let base = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaA, latestReviewID: "R_1")
+        let sameAgain = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaA, latestReviewID: "R_1")
+        let newReview = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaA, latestReviewID: "R_2")
+        let newSha = PRStatusTransition(kind: .changesRequested, sessionID: sessionID, prURL: prURL, prNumber: 1, headSha: shaB, latestReviewID: "R_1")
+
+        #expect(base.dedupeKey == sameAgain.dedupeKey)
+        #expect(base.dedupeKey != newReview.dedupeKey)
+        #expect(base.dedupeKey != newSha.dedupeKey)
     }
 
     @Test

--- a/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
+++ b/Packages/CrowPersistence/Sources/CrowPersistence/JSONStore.swift
@@ -1,6 +1,25 @@
 import Foundation
 import CrowCore
 
+/// Persisted slice of `IssueTracker` state needed to survive Crow restarts
+/// without re-firing already-handled PR transitions (CROW-456).
+///
+/// `previousPRStatus` is keyed by session UUID string so the on-disk shape
+/// stays plain JSON. `emittedTransitionKeys` is serialized as an array because
+/// `Set` is not a stable JSON type — the in-memory load converts back.
+public struct PersistedIssueTrackerState: Codable, Sendable, Equatable {
+    public var previousPRStatus: [String: PRStatus]
+    public var emittedTransitionKeys: [String]
+
+    public init(
+        previousPRStatus: [String: PRStatus] = [:],
+        emittedTransitionKeys: [String] = []
+    ) {
+        self.previousPRStatus = previousPRStatus
+        self.emittedTransitionKeys = emittedTransitionKeys
+    }
+}
+
 /// Persisted data structure.
 public struct StoreData: Codable, Sendable {
     public var sessions: [Session]
@@ -12,19 +31,26 @@ public struct StoreData: Codable, Sendable {
     /// synthesized `Codable` tolerates a missing optional, keeping us backward
     /// compatible and avoiding the corrupt-store backup path.
     public var hookStates: [String: PersistedHookState]?
+    /// Cross-restart cache of last-observed PR statuses + emitted transition
+    /// dedup keys (CROW-456). Optional for backward compatibility with older
+    /// `store.json` files; on first read after upgrade it's nil and the
+    /// tracker behaves as it always did until the next poll persists state.
+    public var issueTrackerState: PersistedIssueTrackerState?
 
     public init(
         sessions: [Session] = [],
         worktrees: [SessionWorktree] = [],
         links: [SessionLink] = [],
         terminals: [SessionTerminal] = [],
-        hookStates: [String: PersistedHookState]? = nil
+        hookStates: [String: PersistedHookState]? = nil,
+        issueTrackerState: PersistedIssueTrackerState? = nil
     ) {
         self.sessions = sessions
         self.worktrees = worktrees
         self.links = links
         self.terminals = terminals
         self.hookStates = hookStates
+        self.issueTrackerState = issueTrackerState
     }
 }
 

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
@@ -213,7 +213,7 @@ import Testing
         headSha: "abc123",
         latestReviewID: "R_kgD0_1"
     )
-    let dedupKey = "\(sessionID.uuidString)|changesRequested|R_kgD0_1|abc123"
+    let dedupKey = "\(sessionID.uuidString)|changesRequested|R_kgD0_1"
     let state = PersistedIssueTrackerState(
         previousPRStatus: [sessionID.uuidString: pr],
         emittedTransitionKeys: [dedupKey]

--- a/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
+++ b/Packages/CrowPersistence/Tests/CrowPersistenceTests/JSONStoreTests.swift
@@ -197,3 +197,55 @@ import Testing
     #expect(rl.linkType == .ticket)
     #expect(rl.label == "Issue")
 }
+
+// MARK: - CROW-456 IssueTracker state persistence
+
+@Test func issueTrackerStateRoundTripsThroughDisk() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let sessionID = UUID()
+    let pr = PRStatus(
+        checksPass: .failing,
+        reviewStatus: .changesRequested,
+        mergeable: .mergeable,
+        failedCheckNames: ["lint"],
+        headSha: "abc123",
+        latestReviewID: "R_kgD0_1"
+    )
+    let dedupKey = "\(sessionID.uuidString)|changesRequested|R_kgD0_1|abc123"
+    let state = PersistedIssueTrackerState(
+        previousPRStatus: [sessionID.uuidString: pr],
+        emittedTransitionKeys: [dedupKey]
+    )
+
+    let store = JSONStore(directory: dir)
+    store.mutate { $0.issueTrackerState = state }
+
+    let reloaded = JSONStore(directory: dir).data.issueTrackerState
+    #expect(reloaded == state)
+    #expect(reloaded?.previousPRStatus[sessionID.uuidString]?.latestReviewID == "R_kgD0_1")
+    #expect(reloaded?.emittedTransitionKeys == [dedupKey])
+}
+
+@Test func storeDataDecodesWithoutIssueTrackerStateField() throws {
+    // Backward compatibility: older store.json files predate CROW-456 and
+    // won't have the issueTrackerState key. Decoding must still succeed.
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+    let legacyJSON = """
+    {
+      "sessions": [],
+      "worktrees": [],
+      "links": [],
+      "terminals": []
+    }
+    """
+    try legacyJSON.data(using: .utf8)!.write(to: dir.appendingPathComponent("store.json"))
+
+    let store = JSONStore(directory: dir)
+    #expect(store.data.issueTrackerState == nil)
+    #expect(store.data.sessions.isEmpty)
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -47,6 +47,13 @@ public struct PRRecord: Sendable {
     public let checksState: String        // SUCCESS / FAILURE / PENDING / EXPECTED / ERROR / ""
     public let failedCheckNames: [String]
     public let latestReviewStates: [String]
+    /// Node ID of the most recent CHANGES_REQUESTED review on this PR, when
+    /// available. Drives the round-2 dedup logic in `IssueTracker` so a second
+    /// formal "Request changes" submission re-arms auto-respond. `nil` when no
+    /// CHANGES_REQUESTED review is among the latest projected reviews, or on
+    /// providers (e.g. GitLab) that don't surface stable review IDs in the
+    /// monitored-MR query.
+    public let latestReviewID: String?
     /// Used by reconcile tie-breaking when multiple non-OPEN PRs exist on the same branch.
     public let updatedAt: Date?
 
@@ -67,6 +74,7 @@ public struct PRRecord: Sendable {
         checksState: String = "",
         failedCheckNames: [String] = [],
         latestReviewStates: [String] = [],
+        latestReviewID: String? = nil,
         updatedAt: Date? = nil
     ) {
         self.number = number
@@ -85,6 +93,7 @@ public struct PRRecord: Sendable {
         self.checksState = checksState
         self.failedCheckNames = failedCheckNames
         self.latestReviewStates = latestReviewStates
+        self.latestReviewID = latestReviewID
         self.updatedAt = updatedAt
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -251,7 +251,7 @@ public struct GitHubCodeBackend: CodeBackend {
                 }
               }
             }
-            latestReviews(first: 5) { nodes { state } }
+            latestReviews(first: 5) { nodes { id state submittedAt } }
           }
         }
       }
@@ -338,6 +338,11 @@ public struct GitHubCodeBackend: CodeBackend {
         }
         let latestReviewNodes = (node["latestReviews"] as? [String: Any])?["nodes"] as? [[String: Any]] ?? []
         let reviewStates = latestReviewNodes.compactMap { $0["state"] as? String }
+        // GitHub returns latestReviews newest-first; the first CHANGES_REQUESTED
+        // entry is the most recent one. Used as the round-2 dedup discriminator
+        // so a fresh "Request changes" submission re-arms auto-respond even when
+        // the bucket stays in changesRequested.
+        let latestReviewID = latestReviewNodes.first(where: { ($0["state"] as? String) == "CHANGES_REQUESTED" })?["id"] as? String
         return PRRecord(
             number: number,
             url: url,
@@ -354,7 +359,8 @@ public struct GitHubCodeBackend: CodeBackend {
             linkedIssueReferences: linkedRefs,
             checksState: checksState,
             failedCheckNames: failedCheckNames,
-            latestReviewStates: reviewStates
+            latestReviewStates: reviewStates,
+            latestReviewID: latestReviewID
         )
     }
 

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -338,11 +338,17 @@ public struct GitHubCodeBackend: CodeBackend {
         }
         let latestReviewNodes = (node["latestReviews"] as? [String: Any])?["nodes"] as? [[String: Any]] ?? []
         let reviewStates = latestReviewNodes.compactMap { $0["state"] as? String }
-        // GitHub returns latestReviews newest-first; the first CHANGES_REQUESTED
-        // entry is the most recent one. Used as the round-2 dedup discriminator
-        // so a fresh "Request changes" submission re-arms auto-respond even when
-        // the bucket stays in changesRequested.
-        let latestReviewID = latestReviewNodes.first(where: { ($0["state"] as? String) == "CHANGES_REQUESTED" })?["id"] as? String
+        // Pick the round-2 dedup discriminator deterministically: the
+        // CHANGES_REQUESTED review with the latest `submittedAt`. GitHub's
+        // `latestReviews` connection doesn't document a node order, so we
+        // don't rely on it; ISO-8601 with `Z` is lexicographically sortable
+        // when the timezone is consistent (which GitHub guarantees), so a
+        // string `max(by:)` is correct here without parsing dates.
+        // `max(by:)` over an empty filtered array returns `nil`, which threads
+        // through to PRStatus.latestReviewID = nil exactly as required.
+        let latestReviewID = latestReviewNodes
+            .filter { ($0["state"] as? String) == "CHANGES_REQUESTED" }
+            .max(by: { ($0["submittedAt"] as? String ?? "") < ($1["submittedAt"] as? String ?? "") })?["id"] as? String
         return PRRecord(
             number: number,
             url: url,

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -515,6 +515,120 @@ final class BackendsTests: XCTestCase {
         let backend = mgr.taskBackend(forURL: "https://corveil.io/tasks/42")
         XCTAssertEqual(backend.provider, .corveil)
     }
+
+    // MARK: - parseMonitoredPRsResponse latestReviewID (CROW-456)
+
+    /// `latestReviews` connection has no documented order. The parser must
+    /// pick the CHANGES_REQUESTED review with the latest `submittedAt`, not
+    /// the first one in the array — otherwise round-2 dedup could miss a
+    /// genuine new review (or worse, flip ids across polls and re-fire
+    /// auto-respond for no reviewer action).
+    func testParseMonitoredPRsPicksLatestSubmittedChangesRequestedReview() throws {
+        let json = """
+        {
+          "data": {
+            "viewerPRs": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "url": "https://github.com/a/b/pull/7",
+                    "state": "OPEN",
+                    "reviewDecision": "CHANGES_REQUESTED",
+                    "headRefOid": "deadbeef",
+                    "latestReviews": {
+                      "nodes": [
+                        {"id": "R_old",   "state": "CHANGES_REQUESTED", "submittedAt": "2026-06-01T10:00:00Z"},
+                        {"id": "R_newer", "state": "APPROVED",          "submittedAt": "2026-06-05T10:00:00Z"},
+                        {"id": "R_newest","state": "CHANGES_REQUESTED", "submittedAt": "2026-06-07T10:00:00Z"},
+                        {"id": "R_mid",   "state": "CHANGES_REQUESTED", "submittedAt": "2026-06-03T10:00:00Z"}
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "reviewPRs": {"nodes": []},
+            "viewer": {"login": "me"},
+            "rateLimit": {"remaining": 5000, "limit": 5000, "resetAt": "2026-06-08T17:00:00Z", "cost": 1}
+          }
+        }
+        """
+        let listing = try GitHubCodeBackend.parseMonitoredPRsResponse(json)
+        XCTAssertEqual(listing.viewerPRs.count, 1)
+        XCTAssertEqual(listing.viewerPRs[0].latestReviewID, "R_newest")
+    }
+
+    /// When no review has a `submittedAt` (degraded payload), `max(by:)` over
+    /// equal keys still returns an element rather than throwing — verify we
+    /// at least don't crash and we do return one of the CHANGES_REQUESTED ids.
+    func testParseMonitoredPRsLatestReviewIDDegradesGracefullyWithoutSubmittedAt() throws {
+        let json = """
+        {
+          "data": {
+            "viewerPRs": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 8,
+                    "url": "https://github.com/a/b/pull/8",
+                    "state": "OPEN",
+                    "reviewDecision": "CHANGES_REQUESTED",
+                    "headRefOid": "abc",
+                    "latestReviews": {
+                      "nodes": [
+                        {"id": "R_a", "state": "CHANGES_REQUESTED"},
+                        {"id": "R_b", "state": "CHANGES_REQUESTED"}
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "reviewPRs": {"nodes": []},
+            "viewer": {"login": "me"},
+            "rateLimit": {"remaining": 5000, "limit": 5000, "resetAt": "2026-06-08T17:00:00Z", "cost": 1}
+          }
+        }
+        """
+        let listing = try GitHubCodeBackend.parseMonitoredPRsResponse(json)
+        XCTAssertEqual(listing.viewerPRs.count, 1)
+        XCTAssertNotNil(listing.viewerPRs[0].latestReviewID)
+        XCTAssertTrue(["R_a", "R_b"].contains(listing.viewerPRs[0].latestReviewID))
+    }
+
+    func testParseMonitoredPRsLatestReviewIDIsNilWhenNoChangesRequested() throws {
+        let json = """
+        {
+          "data": {
+            "viewerPRs": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 9,
+                    "url": "https://github.com/a/b/pull/9",
+                    "state": "OPEN",
+                    "reviewDecision": "APPROVED",
+                    "headRefOid": "abc",
+                    "latestReviews": {
+                      "nodes": [
+                        {"id": "R_ok", "state": "APPROVED", "submittedAt": "2026-06-07T10:00:00Z"}
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "reviewPRs": {"nodes": []},
+            "viewer": {"login": "me"},
+            "rateLimit": {"remaining": 5000, "limit": 5000, "resetAt": "2026-06-08T17:00:00Z", "cost": 1}
+          }
+        }
+        """
+        let listing = try GitHubCodeBackend.parseMonitoredPRsResponse(json)
+        XCTAssertEqual(listing.viewerPRs.count, 1)
+        XCTAssertNil(listing.viewerPRs[0].latestReviewID)
+    }
 }
 
 private func XCTAssertThrowsErrorAsync<T>(_ expression: @autoclosure () async throws -> T,

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -1259,6 +1259,13 @@ final class IssueTracker {
         guard !viewerPRs.isEmpty else { return }
         let byURL = Dictionary(viewerPRs.map { ($0.url, $0) }, uniquingKeysWith: Self.mergePRRecords)
 
+        // Snapshot tracker state up front so we can skip the JSONStore write
+        // when this poll produced no observable change. Polls are quiet most
+        // of the time; without this guard `persistTrackerState` re-reads,
+        // re-encodes, and atomically rewrites `store.json` every 60s.
+        let priorPRStatus = previousPRStatus
+        let priorEmittedKeys = emittedTransitionKeys
+
         var transitions: [PRStatusTransition] = []
         let sessionsWithPRs = appState.sessions.filter { !$0.isManager }
         for session in sessionsWithPRs {
@@ -1273,11 +1280,11 @@ final class IssueTracker {
             // re-entry (approved → changesRequested again, passing → failing on
             // a new commit) can fire even if we previously emitted.
             //
-            // With CROW-456 the `.changesRequested` dedup key is composite
-            // (`session|changesRequested|reviewID|headSha`), so a new review
-            // or new commit naturally produces a different key. This cleanup
-            // bounds the in-memory set: when we leave the bucket entirely we
-            // drop every `changesRequested` entry for this session.
+            // With CROW-456 the `.changesRequested` dedup key is keyed on the
+            // latest CHANGES_REQUESTED review id, so a new formal review
+            // naturally produces a different key. This cleanup bounds the
+            // in-memory set: when we leave the bucket entirely we drop every
+            // `changesRequested` entry for this session.
             if let old = oldStatus {
                 if old.reviewStatus == .changesRequested && newStatus.reviewStatus != .changesRequested {
                     let prefix = "\(session.id.uuidString)|changesRequested|"
@@ -1310,7 +1317,9 @@ final class IssueTracker {
             onPRStatusTransitions?(transitions)
         }
 
-        persistTrackerState()
+        if previousPRStatus != priorPRStatus || emittedTransitionKeys != priorEmittedKeys {
+            persistTrackerState()
+        }
 
         applyAutoMerge(viewerPRs: viewerPRs)
         applyAutoRebase(viewerPRs: viewerPRs)

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -175,6 +175,12 @@ final class IssueTracker {
     }
 
     func start() {
+        // Restore cross-restart state from disk before the first poll so the
+        // initial fetch doesn't re-fire transitions we already handled
+        // (CROW-456). Stale entries for sessions that no longer exist are
+        // dropped during hydration.
+        hydratePersistedState()
+
         // Initial fetch
         Task { await refresh() }
 
@@ -572,7 +578,8 @@ final class IssueTracker {
             linkedIssueReferences: winner.linkedIssueReferences.isEmpty ? loser.linkedIssueReferences : winner.linkedIssueReferences,
             checksState: winner.checksState.isEmpty ? loser.checksState : winner.checksState,
             failedCheckNames: winner.failedCheckNames.isEmpty ? loser.failedCheckNames : winner.failedCheckNames,
-            latestReviewStates: winner.latestReviewStates.isEmpty ? loser.latestReviewStates : winner.latestReviewStates
+            latestReviewStates: winner.latestReviewStates.isEmpty ? loser.latestReviewStates : winner.latestReviewStates,
+            latestReviewID: winner.latestReviewID ?? loser.latestReviewID
         )
     }
 
@@ -1265,9 +1272,16 @@ final class IssueTracker {
             // Re-arm rules whose triggering condition has cleared, so a future
             // re-entry (approved → changesRequested again, passing → failing on
             // a new commit) can fire even if we previously emitted.
+            //
+            // With CROW-456 the `.changesRequested` dedup key is composite
+            // (`session|changesRequested|reviewID|headSha`), so a new review
+            // or new commit naturally produces a different key. This cleanup
+            // bounds the in-memory set: when we leave the bucket entirely we
+            // drop every `changesRequested` entry for this session.
             if let old = oldStatus {
                 if old.reviewStatus == .changesRequested && newStatus.reviewStatus != .changesRequested {
-                    emittedTransitionKeys.remove("\(session.id.uuidString)|changesRequested")
+                    let prefix = "\(session.id.uuidString)|changesRequested|"
+                    emittedTransitionKeys = emittedTransitionKeys.filter { !$0.hasPrefix(prefix) }
                 }
                 if old.checksPass == .failing && newStatus.checksPass != .failing {
                     if let sha = old.headSha {
@@ -1296,8 +1310,46 @@ final class IssueTracker {
             onPRStatusTransitions?(transitions)
         }
 
+        persistTrackerState()
+
         applyAutoMerge(viewerPRs: viewerPRs)
         applyAutoRebase(viewerPRs: viewerPRs)
+    }
+
+    // MARK: - Cross-restart persistence (CROW-456)
+
+    /// Load `previousPRStatus` + `emittedTransitionKeys` from disk on startup.
+    /// Drops entries whose session UUID is no longer present so the in-memory
+    /// state can't grow without bound across long-lived installs.
+    private func hydratePersistedState() {
+        guard let persisted = JSONStore().data.issueTrackerState else { return }
+        let validSessionIDs = Set(appState.sessions.map(\.id))
+        var restored: [UUID: PRStatus] = [:]
+        for (uuidString, status) in persisted.previousPRStatus {
+            guard let uuid = UUID(uuidString: uuidString), validSessionIDs.contains(uuid) else { continue }
+            restored[uuid] = status
+        }
+        previousPRStatus = restored
+
+        // Keep only dedup keys whose session UUID prefix matches a live session.
+        // Each key has shape "<uuid>|kind|…"; reject anything else.
+        let validUUIDPrefixes = Set(validSessionIDs.map { "\($0.uuidString)|" })
+        emittedTransitionKeys = Set(persisted.emittedTransitionKeys.filter { key in
+            validUUIDPrefixes.contains(where: { key.hasPrefix($0) })
+        })
+    }
+
+    /// Persist `previousPRStatus` + `emittedTransitionKeys` after every poll
+    /// that mutated them. `JSONStore.mutate` coalesces writes so this is cheap
+    /// even when transitions are quiet.
+    private func persistTrackerState() {
+        let snapshot = PersistedIssueTrackerState(
+            previousPRStatus: Dictionary(uniqueKeysWithValues: previousPRStatus.map { ($0.key.uuidString, $0.value) }),
+            emittedTransitionKeys: Array(emittedTransitionKeys)
+        )
+        JSONStore().mutate { data in
+            data.issueTrackerState = snapshot
+        }
     }
 
     // MARK: - Auto-Merge Watcher (CROW-299)
@@ -1690,7 +1742,8 @@ final class IssueTracker {
             reviewStatus: reviewStatus,
             mergeable: mergeStatus,
             failedCheckNames: failedChecks,
-            headSha: pr.headRefOid.isEmpty ? nil : pr.headRefOid
+            headSha: pr.headRefOid.isEmpty ? nil : pr.headRefOid,
+            latestReviewID: pr.latestReviewID
         )
     }
 

--- a/Tests/CrowTests/IssueTrackerDedupTests.swift
+++ b/Tests/CrowTests/IssueTrackerDedupTests.swift
@@ -23,7 +23,8 @@ struct IssueTrackerDedupTests {
         linkedIssueReferences: [LinkedIssueRef] = [],
         checksState: String = "",
         failedCheckNames: [String] = [],
-        latestReviewStates: [String] = []
+        latestReviewStates: [String] = [],
+        latestReviewID: String? = nil
     ) -> IssueTracker.ViewerPR {
         IssueTracker.ViewerPR(
             number: number,
@@ -41,7 +42,8 @@ struct IssueTrackerDedupTests {
             linkedIssueReferences: linkedIssueReferences,
             checksState: checksState,
             failedCheckNames: failedCheckNames,
-            latestReviewStates: latestReviewStates
+            latestReviewStates: latestReviewStates,
+            latestReviewID: latestReviewID
         )
     }
 
@@ -135,5 +137,25 @@ struct IssueTrackerDedupTests {
         )
         #expect(byURL.count == 1)
         #expect(byURL[url]?.state == "MERGED")
+    }
+
+    // MARK: - CROW-456 latestReviewID propagation
+
+    @Test func mergePRRecordsPrefersWinnerLatestReviewID() {
+        // Winner is whichever has the higher-rank state (MERGED beats OPEN).
+        // Forward its latestReviewID; fall back to loser's only when winner's
+        // is nil so we never lose round-2 dedup data during the merge.
+        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let openWithID = makeViewerPR(url: url, state: "OPEN", latestReviewID: "R_open")
+        let mergedWithID = makeViewerPR(url: url, state: "MERGED", latestReviewID: "R_merged")
+        #expect(IssueTracker.mergePRRecords(openWithID, mergedWithID).latestReviewID == "R_merged")
+        #expect(IssueTracker.mergePRRecords(mergedWithID, openWithID).latestReviewID == "R_merged")
+    }
+
+    @Test func mergePRRecordsBackfillsLatestReviewIDWhenWinnerLacks() {
+        let url = "https://github.com/radiusmethod/corveil/pull/201"
+        let openWithID = makeViewerPR(url: url, state: "OPEN", latestReviewID: "R_open")
+        let mergedNoID = makeViewerPR(url: url, state: "MERGED")
+        #expect(IssueTracker.mergePRRecords(openWithID, mergedNoID).latestReviewID == "R_open")
     }
 }


### PR DESCRIPTION
## Summary

Closes #456.

- Round 2+ of `CHANGES_REQUESTED` reviews now re-fire auto-respond. The dedup key shifts from bucket-only `"sessionID|changesRequested"` to `"sessionID|changesRequested|reviewID|headSha"`, and `PRStatus.transitions()` emits a candidate whenever the bucket is reentered, the latest CHANGES_REQUESTED review id rotates, or the head SHA changes while still in the bucket.
- GitHub viewer-PR GraphQL projection now includes `latestReviews(first: 5) { nodes { id state submittedAt } }`; the parser threads the most recent CHANGES_REQUESTED node id through `PRRecord` → `PRStatus` → `PRStatusTransition`.
- `IssueTracker` state (`previousPRStatus` + `emittedTransitionKeys`) persists to `JSONStore` so restarts no longer re-fire already-handled transitions or lose the re-arm trail. New optional `StoreData.issueTrackerState` field is backward-compatible with older `store.json`.
- GitLab path leaves `latestReviewID = nil` (provider doesn't surface review ids in the monitored-MR query) — no regression, no GitLab-side improvement in this PR.

## Heads-up for #454 / ADR 0005

The TaskBackend migration is moving the GraphQL projection. The new `latestReviews { id state submittedAt }` field needs to land in the destination so review-id dedup keeps working post-migration.

## Test plan

- [x] `cd Packages/CrowCore && arch -arm64 swift test` (233 tests, includes 3 new CROW-456 cases + replaced bug-locking dedup-key test)
- [x] `cd Packages/CrowPersistence && arch -arm64 swift test` (28 tests, includes new `issueTrackerStateRoundTripsThroughDisk` and `storeDataDecodesWithoutIssueTrackerStateField`)
- [x] `cd Packages/CrowProvider && arch -arm64 swift test` (35 tests)
- [x] `arch -arm64 swift test --arch arm64` from root (191 tests, includes 2 new `mergePRRecords` latestReviewID forwarding tests)
- [ ] Manual end-to-end: open a Crow session against a real PR, request changes via reviewer, wait for auto-respond, request changes a second time without approving → second prompt fires.
- [ ] Manual restart smoke: after a fire, quit Crow, relaunch; the next poll must not re-fire the same transition.

🐦‍⬛ [Created with Claude Code, orchestrated by Crow](https://github.com/radiusmethod/crow)

Co-Authored-By: Claude <noreply@anthropic.com>
Crow-Session: 790C6352-0086-4B1C-85E0-34F26866E0A3