### PR TITLE
Fix Jira-tasked session PR linking + ticket metadata (#463)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/Session.swift
@@ -38,6 +38,21 @@ public struct Session: Identifiable, Codable, Sendable {
     /// Claude Code in the devRoot and are excluded from PR/issue tracking.
     public var isManager: Bool { kind == .manager }
 
+    /// Short label for the session's ticket badge/chip, or `nil` when no ticket
+    /// is attached. Jira tickets have no standalone numeric id, so prefer the
+    /// validated key (`MAXX-6859`) parsed from the browse URL; otherwise fall
+    /// back to `Issue #<number>` (GitHub/GitLab) or a bare `Issue` when only a
+    /// URL is known. Keeps the sidebar badge from vanishing on Jira sessions,
+    /// which carry `ticketURL`/`ticketTitle` but a nil `ticketNumber` (CROW-463).
+    public var ticketBadgeLabel: String? {
+        if let url = ticketURL, Validation.isJiraSpec(url), let key = Validation.jiraKey(from: url) {
+            return key
+        }
+        if let num = ticketNumber { return "Issue #\(num)" }
+        if ticketURL != nil { return "Issue" }
+        return nil
+    }
+
     public init(
         id: UUID = UUID(),
         name: String,

--- a/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/SessionModelTests.swift
@@ -128,6 +128,40 @@ import Testing
     #expect(Session(name: "review", kind: .review).isManager == false)
 }
 
+// MARK: - Ticket Badge Label (CROW-463)
+
+@Test func ticketBadgeLabelGitHubUsesNumber() {
+    let session = Session(
+        name: "gh",
+        ticketURL: "https://github.com/org/repo/issues/42",
+        ticketNumber: 42,
+        provider: .github
+    )
+    #expect(session.ticketBadgeLabel == "Issue #42")
+}
+
+@Test func ticketBadgeLabelJiraUsesKeyDespiteNilNumber() {
+    // Regression for #463: Jira sessions carry a browse URL + title but a nil
+    // ticketNumber, so the badge must derive the key from the URL.
+    let session = Session(
+        name: "max-monorepo-maxx-6859",
+        ticketURL: "https://zitenote.atlassian.net/browse/MAXX-6859",
+        ticketTitle: "MAXX-6859: fold secondary vendor email domains",
+        ticketNumber: nil,
+        provider: .jira
+    )
+    #expect(session.ticketBadgeLabel == "MAXX-6859")
+}
+
+@Test func ticketBadgeLabelFallsBackToIssueWhenOnlyURL() {
+    let session = Session(name: "x", ticketURL: "https://example.test/thing")
+    #expect(session.ticketBadgeLabel == "Issue")
+}
+
+@Test func ticketBadgeLabelNilWhenNoTicket() {
+    #expect(Session(name: "none").ticketBadgeLabel == nil)
+}
+
 // MARK: - Enum Raw Values
 
 @Test func sessionKindRawValues() {

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -150,6 +150,38 @@ public struct BranchPRMatch: Sendable {
     }
 }
 
+/// Input to `CodeBackend.findPRsMatchingKeys` — one (repo, key) tuple, where
+/// `key` is a ticket key (e.g. a Jira key `MAXX-6859`) expected to appear in a
+/// PR's title/body/branch. Lets reconcile recover PR links for task-only
+/// trackers (Jira) whose PR branch doesn't match the session's worktree branch.
+public struct KeyCandidate: Sendable, Hashable {
+    public let repoSlug: String
+    public let key: String
+
+    public init(repoSlug: String, key: String) {
+        self.repoSlug = repoSlug
+        self.key = key
+    }
+}
+
+/// One PR match returned from `findPRsMatchingKeys`, tagged with the candidate
+/// it came from so callers can route the result back to the right session(s).
+public struct KeyPRMatch: Sendable {
+    public let candidate: KeyCandidate
+    public let number: Int
+    public let url: String
+    public let state: String       // "OPEN" / "MERGED" / "CLOSED"
+    public let updatedAt: Date?
+
+    public init(candidate: KeyCandidate, number: Int, url: String, state: String, updatedAt: Date?) {
+        self.candidate = candidate
+        self.number = number
+        self.url = url
+        self.state = state
+        self.updatedAt = updatedAt
+    }
+}
+
 /// PR metadata returned from `CodeBackend.fetchPRMetadata` — the subset
 /// SessionService needs to prep a review clone.
 public struct PRMetadata: Sendable {

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -189,6 +189,60 @@ public struct GitHubCodeBackend: CodeBackend {
         return Self.parseRecentPRsResponse(output, parsed: parsed)
     }
 
+    /// Search each repo for PRs whose title/body references `key` (e.g. a Jira
+    /// key like `MAXX-6859`). One `gh pr list --search` call per candidate
+    /// (the candidate set is small — only Jira-tasked sessions missing a PR
+    /// link). Best-effort per repo: a failing repo is skipped, not fatal.
+    public func findPRsMatchingKeys(_ candidates: [KeyCandidate]) async throws -> [KeyPRMatch] {
+        var out: [KeyPRMatch] = []
+        for c in candidates {
+            guard c.repoSlug.split(separator: "/", maxSplits: 1).count == 2,
+                  !c.key.isEmpty else { continue }
+            let output: String
+            do {
+                output = try await shellRunner.run(
+                    "gh", "pr", "list",
+                    "--repo", c.repoSlug,
+                    "--search", "\(c.key) in:title,body",
+                    "--state", "all",
+                    "--json", "number,url,state,updatedAt,title,headRefName,body",
+                    "--limit", "10"
+                )
+            } catch {
+                continue
+            }
+            out.append(contentsOf: Self.parseKeyPRMatches(output, candidate: c))
+        }
+        return out
+    }
+
+    /// Parse `gh pr list --json …` output into `KeyPRMatch`es. Post-filters to
+    /// PRs where the key actually appears (case-insensitively) in the title,
+    /// body, or head branch — `gh`'s search can be fuzzy, and we only want PRs
+    /// that genuinely reference the ticket.
+    static func parseKeyPRMatches(_ output: String, candidate: KeyCandidate) -> [KeyPRMatch] {
+        guard let data = output.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        let dateFmt = ISO8601DateFormatter()
+        dateFmt.formatOptions = [.withInternetDateTime]
+        let needle = candidate.key.lowercased()
+        var matches: [KeyPRMatch] = []
+        for node in arr {
+            guard let number = node["number"] as? Int,
+                  let url = node["url"] as? String,
+                  let state = node["state"] as? String else { continue }
+            let title = (node["title"] as? String ?? "").lowercased()
+            let body = (node["body"] as? String ?? "").lowercased()
+            let head = (node["headRefName"] as? String ?? "").lowercased()
+            guard title.contains(needle) || body.contains(needle) || head.contains(needle) else { continue }
+            let updatedAt = (node["updatedAt"] as? String).flatMap { dateFmt.date(from: $0) }
+            matches.append(KeyPRMatch(
+                candidate: candidate, number: number, url: url, state: state, updatedAt: updatedAt
+            ))
+        }
+        return matches
+    }
+
     // MARK: - enableAutoMerge / updateBranch
 
     public func enableAutoMerge(prURL: String) async throws {

--- a/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/CodeBackend.swift
@@ -57,6 +57,14 @@ public protocol CodeBackend: Sendable {
     /// `decideReconcileLinks` to pick the best PR per candidate.
     func findRecentPRsForBranches(_ candidates: [BranchCandidate]) async throws -> [BranchPRMatch]
 
+    /// For each `(repoSlug, key)` candidate, search the repo for PRs that
+    /// reference `key` (e.g. a Jira key `MAXX-6859`) in their title/body/branch
+    /// and return the recent matches. Used by reconcile to link PRs for
+    /// task-only trackers (Jira) whose PR branch doesn't match the session's
+    /// worktree branch — branch matching can't find those. The default
+    /// implementation returns `[]` (no key search); GitHub overrides it.
+    func findPRsMatchingKeys(_ candidates: [KeyCandidate]) async throws -> [KeyPRMatch]
+
     /// Enable auto-merge on the PR at `prURL` (squash + delete branch).
     /// Capability-gated on `.autoMerge`. Backends without the capability throw
     /// `ProviderError.unimplemented`.
@@ -71,6 +79,14 @@ public protocol CodeBackend: Sendable {
     /// title, head/base branch names, head commit SHA, number. Issues one
     /// `gh pr view` / `glab mr view` call.
     func fetchPRMetadata(prURL: String) async throws -> PRMetadata
+}
+
+public extension CodeBackend {
+    /// Default: no key-based PR search. Backends that can search PRs by text
+    /// (GitHub) override this; others (GitLab today, Corveil stub) inherit the
+    /// no-op so a Jira-key reconcile pass degrades to "no matches" rather than
+    /// forcing every conformer to implement it.
+    func findPRsMatchingKeys(_ candidates: [KeyCandidate]) async throws -> [KeyPRMatch] { [] }
 }
 
 /// Optional capabilities a `CodeBackend` may declare.

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -348,6 +348,43 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(matches[0].candidate.branch, "feature/x")
     }
 
+    func testGitHubCodeBackendFindPRsMatchingKeysParsesAndFilters() async throws {
+        let fake = FakeShellRunner()
+        // Two PRs returned by gh search: one references MAXX-6859 in its title,
+        // one is a fuzzy match that mentions it nowhere — only the first counts.
+        let json = """
+        [
+          {"number":52,"url":"https://github.com/a/b/pull/52","state":"OPEN","updatedAt":"2026-01-02T00:00:00Z","title":"feat: thing. MAXX-6859","headRefName":"feature/maxx-6859-thing","body":"closes MAXX-6859"},
+          {"number":40,"url":"https://github.com/a/b/pull/40","state":"MERGED","updatedAt":"2026-01-01T00:00:00Z","title":"unrelated","headRefName":"feature/other","body":"no key here"}
+        ]
+        """
+        fake.responses = [.success(json)]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let matches = try await backend.findPRsMatchingKeys([
+            KeyCandidate(repoSlug: "a/b", key: "MAXX-6859")
+        ])
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(matches[0].number, 52)
+        XCTAssertEqual(matches[0].state, "OPEN")
+        XCTAssertEqual(matches[0].candidate.key, "MAXX-6859")
+        // Command shape: gh pr list --search "<key> in:title,body".
+        let args = fake.calls[0].args
+        XCTAssertEqual(Array(args.prefix(3)), ["gh", "pr", "list"])
+        XCTAssertTrue(args.contains("--search"))
+        XCTAssertTrue(args.contains("MAXX-6859 in:title,body"))
+        XCTAssertTrue(args.contains("a/b"))
+    }
+
+    func testGitHubCodeBackendFindPRsMatchingKeysSkipsFailedRepo() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: "no auth"))]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let matches = try await backend.findPRsMatchingKeys([
+            KeyCandidate(repoSlug: "a/b", key: "MAXX-6859")
+        ])
+        XCTAssertTrue(matches.isEmpty)
+    }
+
     // MARK: - GitLab backends
 
     func testGitLabTaskBackendDeclaresNoCapabilities() {

--- a/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionDetailView.swift
@@ -120,7 +120,7 @@ public struct SessionDetailView: View {
                 // Issue link
                 if let url = session.ticketURL {
                     LinkChip(
-                        label: session.ticketNumber.map { "Issue #\(String($0))" } ?? "Issue",
+                        label: session.ticketBadgeLabel ?? "Issue",
                         url: url,
                         icon: "link"
                     )

--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -658,12 +658,12 @@ struct SessionRow: View {
             }
 
             // Row 4: Issue badge + PR badge + Claude state
-            let hasIssueBadge = session.ticketNumber != nil
-            let hasBadges = hasIssueBadge || prLink != nil || activityState != .idle
+            let issueBadgeLabel = session.ticketBadgeLabel
+            let hasBadges = issueBadgeLabel != nil || prLink != nil || activityState != .idle
             if hasBadges {
                 HStack(spacing: 6) {
-                    if let num = session.ticketNumber {
-                        CapsuleBadge("Issue #\(String(num))", color: CorveilTheme.gold)
+                    if let label = issueBadgeLabel {
+                        CapsuleBadge(label, color: CorveilTheme.gold)
                     }
                     if let pr = prLink {
                         PRBadge(label: pr.label, status: prStatus)

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -979,6 +979,23 @@ final class IssueTracker {
         return picks
     }
 
+    /// Route a reconcile candidate to a *code* backend. A task-only provider
+    /// (`.jira`/`.corveil`) has no code surface, so a session tracked by one
+    /// resolves PRs through its `codeProvider` — mirroring the
+    /// `codeProvider ?? provider` convention in `SessionService.findPRLink` and
+    /// `AutoRespondCoordinator`. Falls back to host sniffing when no
+    /// code-bearing provider is recorded (e.g. sessions predating the field).
+    /// Pure — no appState, no I/O.
+    nonisolated static func resolveReconcileProvider(
+        codeProvider: Provider?, provider: Provider?, host: String
+    ) -> (provider: Provider, gitlabHost: String?) {
+        if let p = codeProvider ?? provider, !p.isTaskOnly {
+            return (p, p == .gitlab ? (host.isEmpty ? nil : host) : nil)
+        }
+        if host == "github.com" || host.isEmpty { return (.github, nil) }
+        return (.gitlab, host)
+    }
+
     /// For each non-archived, non-review session missing a `.pr` link with a
     /// resolvable (repoSlug, branch), query the provider directly and upsert
     /// a link when a PR exists on that branch. Runs once per refresh cycle
@@ -1022,21 +1039,15 @@ final class IssueTracker {
             let info = resolveRepoInfo(worktree: primaryWt)
             guard !info.slug.isEmpty else { continue }
 
-            // Provider: prefer the session's recorded provider; fall back to
-            // host sniffing when the session was created before the field
-            // existed or when the host ≠ github.com.
-            let provider: Provider
-            let gitlabHost: String?
-            if let p = session.provider {
-                provider = p
-                gitlabHost = (p == .gitlab) ? (info.host.isEmpty ? nil : info.host) : nil
-            } else if info.host == "github.com" || info.host.isEmpty {
-                provider = .github
-                gitlabHost = nil
-            } else {
-                provider = .gitlab
-                gitlabHost = info.host
-            }
+            // Route by the *code* provider: a Jira/Corveil task-only session
+            // codes against GitHub/GitLab via `codeProvider`, so resolving on
+            // `session.provider` alone (→ `.jira`) would drop the candidate.
+            // Falls back to host sniffing when no code-bearing provider exists.
+            let (provider, gitlabHost) = Self.resolveReconcileProvider(
+                codeProvider: session.codeProvider,
+                provider: session.provider,
+                host: info.host
+            )
 
             // GitLab candidates require a known host — GITLAB_HOST env var is
             // how the glab wrapper picks an auth token. Skip silently rather

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -935,6 +935,18 @@ final class IssueTracker {
         let gitlabHost: String?    // nil for github.com
     }
 
+    /// A Jira-tasked session whose PR should be found by the *ticket key* it
+    /// references (e.g. `MAXX-6859`) rather than by branch. Jira PR branches
+    /// are renamed by the working agent and rarely match the session's
+    /// registered worktree branch, so branch matching can't find them.
+    struct ReconcileKeyCandidate: Sendable, Equatable {
+        let sessionID: UUID
+        let provider: Provider     // code provider (.github today)
+        let repoSlug: String
+        let key: String            // "MAXX-6859"
+        let gitlabHost: String?
+    }
+
     /// A branch match returned by the provider. `state` follows GitHub's
     /// `PullRequestState` for GitHub and a normalized "OPEN"/"MERGED"/"CLOSED"
     /// for GitLab (mapping `opened|merged|closed`). `updatedAt` drives
@@ -1002,7 +1014,8 @@ final class IssueTracker {
     /// after the reactive `applySessionPRLinks` pass.
     private func reconcileMissingPRLinks() async {
         let candidates = buildReconcileCandidates()
-        guard !candidates.isEmpty else { return }
+        let keyCandidates = buildReconcileKeyCandidates()
+        guard !candidates.isEmpty || !keyCandidates.isEmpty else { return }
 
         var matches: [ReconcileBranchMatch] = []
 
@@ -1017,6 +1030,12 @@ final class IssueTracker {
             let forHost = gitlab.filter { $0.gitlabHost == host }
             matches.append(contentsOf: await fetchGitLabMRsForReconcile(candidates: forHost, host: host))
         }
+
+        // Jira-tasked sessions: find the PR by the ticket key it references,
+        // since the PR branch won't match the worktree branch. Feeds the same
+        // `decideReconcileLinks` so a key-found and branch-found PR for one
+        // session resolve to a single best pick.
+        matches.append(contentsOf: await fetchPRsByKeyForReconcile(candidates: keyCandidates))
 
         applyReconciledPRLinks(Self.decideReconcileLinks(matches: matches))
     }
@@ -1061,6 +1080,103 @@ final class IssueTracker {
                 branch: primaryWt.branch,
                 gitlabHost: gitlabHost
             ))
+        }
+        return out
+    }
+
+    /// Build key-based reconcile candidates: Jira-tasked sessions missing a PR
+    /// link, whose PR is discoverable by the ticket key (e.g. `MAXX-6859`)
+    /// rather than by branch. Gated on a Jira ticket URL so GitHub/GitLab-tasked
+    /// sessions are untouched (they keep pure branch matching). Runs on
+    /// MainActor; safe to read appState directly.
+    private func buildReconcileKeyCandidates() -> [ReconcileKeyCandidate] {
+        var out: [ReconcileKeyCandidate] = []
+        for session in appState.sessions {
+            guard !session.isManager else { continue }
+            guard session.status != .archived else { continue }
+            guard session.kind == .work else { continue }
+            let links = appState.links(for: session.id)
+            guard !links.contains(where: { $0.linkType == .pr }) else { continue }
+
+            // Only task-only trackers whose PR branch won't match the worktree.
+            guard let ticketURL = session.ticketURL,
+                  Validation.isJiraSpec(ticketURL),
+                  let key = Validation.jiraKey(from: ticketURL) else { continue }
+
+            let wts = appState.worktrees(for: session.id)
+            guard let primaryWt = wts.first(where: { $0.isPrimary }) ?? wts.first else { continue }
+
+            let info = resolveRepoInfo(worktree: primaryWt)
+            guard !info.slug.isEmpty else { continue }
+
+            let (provider, gitlabHost) = Self.resolveReconcileProvider(
+                codeProvider: session.codeProvider,
+                provider: session.provider,
+                host: info.host
+            )
+            if provider == .gitlab, gitlabHost == nil { continue }
+
+            out.append(ReconcileKeyCandidate(
+                sessionID: session.id,
+                provider: provider,
+                repoSlug: info.slug,
+                key: key,
+                gitlabHost: gitlabHost
+            ))
+        }
+        return out
+    }
+
+    /// Resolve PR links for Jira-tasked sessions by searching the code repo for
+    /// the ticket key. GitHub only today (the `CodeBackend` default returns no
+    /// matches for providers without text PR search). Best-effort: a backend
+    /// error skips the cycle rather than dropping links.
+    private func fetchPRsByKeyForReconcile(candidates: [ReconcileKeyCandidate]) async -> [ReconcileBranchMatch] {
+        let github = candidates.filter { $0.provider == .github }
+        guard !github.isEmpty, let backend = providerManager.codeBackend(for: .github) else { return [] }
+        do {
+            let matches = try await backend.findPRsMatchingKeys(Self.dedupedKeyCandidates(github))
+            return Self.fanOutKeyMatches(matches, across: github)
+        } catch {
+            handleGitHubBackendError(error, operation: "findPRsMatchingKeys(github)")
+            return []
+        }
+    }
+
+    /// Project `ReconcileKeyCandidate`s onto de-duplicated `(repoSlug, key)`
+    /// pairs for the backend. Mirrors `dedupedBranchCandidates`.
+    nonisolated static func dedupedKeyCandidates(_ candidates: [ReconcileKeyCandidate]) -> [KeyCandidate] {
+        var seen: Set<KeyCandidate> = []
+        var out: [KeyCandidate] = []
+        for c in candidates {
+            let kc = KeyCandidate(repoSlug: c.repoSlug, key: c.key)
+            if seen.insert(kc).inserted { out.append(kc) }
+        }
+        return out
+    }
+
+    /// Fan each `KeyPRMatch` back to every session sharing its `(repoSlug, key)`.
+    /// Mirrors `fanOutMatches` for the branch path.
+    nonisolated static func fanOutKeyMatches(
+        _ matches: [KeyPRMatch],
+        across candidates: [ReconcileKeyCandidate]
+    ) -> [ReconcileBranchMatch] {
+        var sessionsByKey: [KeyCandidate: [UUID]] = [:]
+        for c in candidates {
+            sessionsByKey[KeyCandidate(repoSlug: c.repoSlug, key: c.key), default: []].append(c.sessionID)
+        }
+        var out: [ReconcileBranchMatch] = []
+        for match in matches {
+            guard let sids = sessionsByKey[match.candidate] else { continue }
+            for sid in sids {
+                out.append(ReconcileBranchMatch(
+                    sessionID: sid,
+                    number: match.number,
+                    url: match.url,
+                    state: match.state,
+                    updatedAt: match.updatedAt
+                ))
+            }
         }
         return out
     }

--- a/Tests/CrowTests/IssueTrackerReconcileTests.swift
+++ b/Tests/CrowTests/IssueTrackerReconcileTests.swift
@@ -87,6 +87,64 @@ struct IssueTrackerReconcileDecisionTests {
     }
 }
 
+@Suite("IssueTracker reconcile provider routing")
+struct IssueTrackerReconcileProviderTests {
+    // Regression for #463: a Jira-task + GitHub-code session must route its
+    // reconcile candidate to GitHub via `codeProvider`, not be dropped because
+    // `provider` is the task-only `.jira`.
+    @Test func jiraTaskWithGitHubCodeRoutesToGitHub() {
+        let r = IssueTracker.resolveReconcileProvider(
+            codeProvider: .github, provider: .jira, host: "github.com")
+        #expect(r.provider == .github)
+        #expect(r.gitlabHost == nil)
+    }
+
+    @Test func codeProviderTakesPrecedenceOverTaskProvider() {
+        // Jira-task + GitLab-code: route to GitLab and carry the host.
+        let r = IssueTracker.resolveReconcileProvider(
+            codeProvider: .gitlab, provider: .jira, host: "gitlab.corp.example")
+        #expect(r.provider == .gitlab)
+        #expect(r.gitlabHost == "gitlab.corp.example")
+    }
+
+    @Test func nilProvidersFallBackToHostSniff() {
+        // Sessions predating the provider field rely on host sniffing.
+        let gh = IssueTracker.resolveReconcileProvider(
+            codeProvider: nil, provider: nil, host: "github.com")
+        #expect(gh.provider == .github)
+        #expect(gh.gitlabHost == nil)
+
+        let empty = IssueTracker.resolveReconcileProvider(
+            codeProvider: nil, provider: nil, host: "")
+        #expect(empty.provider == .github)
+
+        let gl = IssueTracker.resolveReconcileProvider(
+            codeProvider: nil, provider: nil, host: "gitlab.internal.example")
+        #expect(gl.provider == .gitlab)
+        #expect(gl.gitlabHost == "gitlab.internal.example")
+    }
+
+    @Test func taskOnlyProviderWithoutCodeProviderFallsBackToHost() {
+        // Defensive: a `.jira` task with no `codeProvider` set must not become
+        // a `.jira` candidate — host sniffing picks the real code backend.
+        let r = IssueTracker.resolveReconcileProvider(
+            codeProvider: nil, provider: .jira, host: "github.com")
+        #expect(r.provider == .github)
+    }
+
+    @Test func plainGitHubAndGitLabSessionsUnaffected() {
+        let gh = IssueTracker.resolveReconcileProvider(
+            codeProvider: nil, provider: .github, host: "github.com")
+        #expect(gh.provider == .github)
+        #expect(gh.gitlabHost == nil)
+
+        let gl = IssueTracker.resolveReconcileProvider(
+            codeProvider: nil, provider: .gitlab, host: "gitlab.com")
+        #expect(gl.provider == .gitlab)
+        #expect(gl.gitlabHost == "gitlab.com")
+    }
+}
+
 @Suite("IssueTracker remote host extraction")
 struct IssueTrackerRemoteHostTests {
     @Test func parsesGitHubSSH() {

--- a/Tests/CrowTests/IssueTrackerReconcileTests.swift
+++ b/Tests/CrowTests/IssueTrackerReconcileTests.swift
@@ -288,3 +288,59 @@ struct IssueTrackerReconcileFanOutTests {
         #expect(fanned[0].number == 1)
     }
 }
+
+@Suite("IssueTracker reconcile key fan-out")
+struct IssueTrackerReconcileKeyFanOutTests {
+
+    private func keyCandidate(_ sid: UUID, _ slug: String, _ key: String) -> IssueTracker.ReconcileKeyCandidate {
+        IssueTracker.ReconcileKeyCandidate(
+            sessionID: sid, provider: .github, repoSlug: slug, key: key, gitlabHost: nil
+        )
+    }
+
+    @Test func dedupedKeyCandidatesCollapsesDuplicates() {
+        // Two sessions on the same (repoSlug, key) — e.g. a duplicated Jira
+        // session — must produce a single backend search.
+        let s1 = UUID(); let s2 = UUID()
+        let cands = [
+            keyCandidate(s1, "acme/api", "MAXX-6859"),
+            keyCandidate(s2, "acme/api", "MAXX-6859"),
+            keyCandidate(s1, "acme/api", "MAXX-6860"),
+        ]
+        let out = IssueTracker.dedupedKeyCandidates(cands)
+        #expect(out.count == 2)
+        #expect(out.contains(KeyCandidate(repoSlug: "acme/api", key: "MAXX-6859")))
+        #expect(out.contains(KeyCandidate(repoSlug: "acme/api", key: "MAXX-6860")))
+    }
+
+    @Test func fanOutKeyMatchesEmitsOnePerSessionSharingAKey() {
+        let s1 = UUID(); let s2 = UUID()
+        let cands = [
+            keyCandidate(s1, "acme/api", "MAXX-6859"),
+            keyCandidate(s2, "acme/api", "MAXX-6859"),
+        ]
+        let kc = KeyCandidate(repoSlug: "acme/api", key: "MAXX-6859")
+        let backendMatches = [
+            KeyPRMatch(candidate: kc, number: 52, url: "https://github.com/acme/api/pull/52",
+                       state: "OPEN", updatedAt: nil)
+        ]
+        let fanned = IssueTracker.fanOutKeyMatches(backendMatches, across: cands)
+        #expect(fanned.count == 2)
+        #expect(Set(fanned.map(\.sessionID)) == [s1, s2])
+        #expect(fanned.allSatisfy { $0.number == 52 && $0.state == "OPEN" })
+    }
+
+    @Test func fanOutKeyMatchesDropsUnknownCandidates() {
+        let s1 = UUID()
+        let known = KeyCandidate(repoSlug: "acme/api", key: "MAXX-6859")
+        let unknown = KeyCandidate(repoSlug: "acme/api", key: "MAXX-9999")
+        let backendMatches = [
+            KeyPRMatch(candidate: known, number: 1, url: "u1", state: "OPEN", updatedAt: nil),
+            KeyPRMatch(candidate: unknown, number: 2, url: "u2", state: "OPEN", updatedAt: nil),
+        ]
+        let cands = [keyCandidate(s1, "acme/api", "MAXX-6859")]
+        let fanned = IssueTracker.fanOutKeyMatches(backendMatches, across: cands)
+        #expect(fanned.count == 1)
+        #expect(fanned[0].number == 1)
+    }
+}

--- a/skills/crow-batch-workspace/SKILL.md
+++ b/skills/crow-batch-workspace/SKILL.md
@@ -73,12 +73,15 @@ For each workspace spec, perform the same resolution as `/crow-workspace`:
 > Issue each `gh`/`git` fetch below as a **single, clean invocation** — one command per Bash call, no `cd …`/`echo`/`find` prefix or `| head` pipe — so the allowlist auto-approves it instead of prompting (see CLAUDE.md → "Fetching Ticket / PR Data").
 
 1. **Read config**: `cat {devRoot}/.claude/config.json`
-2. **Detect provider** from URL (see Provider Detection table in `/crow-workspace` skill)
+2. **Detect provider** from URL (see Provider Detection table in `/crow-workspace` skill — includes Jira)
 3. **Scan repos**: Find repos in all configured workspaces
 4. **Match repo**: Score repos against ticket content
-5. **Fetch ticket**: `gh issue view {url} --json title,body,labels` (with `dangerouslyDisableSandbox: true`)
-6. **Check for existing PR**: `gh pr list --repo {owner}/{repo} --search "{issue_number}" --state open --json number,title,headRefName,url --limit 5` (with `dangerouslyDisableSandbox: true`)
-7. **Generate names**: slug, branch, worktree path, session name (following `/crow-workspace` naming conventions)
+5. **Fetch ticket** (provider-specific, with `dangerouslyDisableSandbox: true`):
+   - GitHub: `gh issue view {url} --json title,body,labels`
+   - GitLab: `GITLAB_HOST={host} glab issue view {number} --repo {org/repo} --comments`
+   - Jira (task-only): `acli jira workitem view {key} --json` (title at `.fields.summary`)
+6. **Check for existing PR**: `gh pr list --repo {owner}/{repo} --search "{issue_number}" --state open --json number,title,headRefName,url --limit 5` (with `dangerouslyDisableSandbox: true`). For a Jira-task session this runs against the workspace's configured GitHub/GitLab code repo, not Jira.
+7. **Generate names**: slug, branch, worktree path, session name (following `/crow-workspace` naming conventions). **Jira:** resolve `{ticket_number}` as the **numeric suffix** of the key (`MAXX-6859` → `6859`); `{ticket_url}` is the full `…/browse/{key}` URL; the slug uses the lowercased full key (`{repo}-maxx-6859-{slug}`).
 8. **Compose prompt**: Use the First Prompt Template from `/crow-workspace`
 9. **Write prompt file**: `cat > {devRoot}/.claude/prompts/crow-prompt-{session_name}.md`
 

--- a/skills/crow-workspace/SKILL.md
+++ b/skills/crow-workspace/SKILL.md
@@ -90,14 +90,34 @@ GITLAB_HOST=gitlab.example.com glab issue view {number} --repo {org/repo} --comm
 GITLAB_HOST=gitlab.example.com glab mr view {number} --repo {org/repo} --comments
 ```
 
+### Jira (acli)
+`acli` is already authenticated against a single Atlassian site, so it takes a
+bare key (not a URL). Pass the full key (`PROJ-NNN`), not just the numeric suffix.
+```bash
+acli jira workitem view {key} --json   # {key} = MAXX-6859
+```
+The summary is at `.fields.summary`; use it as `{ticket_title}`.
+
 ### Provider Detection from URL
 
 | URL Contains | Provider | CLI | GITLAB_HOST |
 |---|---|---|---|
 | `github.com` | github | gh | - |
+| `atlassian.net` / `/browse/` / bare `PROJ-123` | jira | acli | - |
 | `gitlab.example.com` | gitlab | glab | gitlab.example.com |
 | `gitlab.com` | gitlab | glab | gitlab.com |
 | `gitlab-il2.example.com` | gitlab | glab | gitlab-il2.example.com |
+
+**Jira is task-only** (no code/VCS surface): the ticket lives in Jira while code
+lands in the workspace's configured GitHub/GitLab repo. Detect it *before* the
+loose GitLab match. The Jira key is `PROJ-NNN` (e.g. `MAXX-6859`).
+
+**Resolving `{ticket_number}` for Jira:** Jira keys have no standalone numeric
+id, so use the **numeric suffix** of the key — `MAXX-6859` → `6859`. Pass that as
+`--ticket-number`, the full Atlassian browse URL as `--ticket-url`
+(`https://<site>.atlassian.net/browse/MAXX-6859`), and the summary as
+`--ticket-title`. The worktree/branch/session slug uses the full lowercased key,
+e.g. `{repo}-maxx-6859-{brief_slug}`.
 
 ## PR Detection
 
@@ -225,6 +245,13 @@ gh api repos/{owner}/{repo}/issues/{number}/comments
 ```bash
 GITLAB_HOST={host} glab issue view {number} --repo {org/repo} --comments
 ```
+
+**Jira (acli — task-only):**
+```bash
+acli jira workitem view {key} --json   # {key} = MAXX-6859 (full key, not the suffix)
+```
+Use `.fields.summary` for `{ticket_title}`. The code provider/PR detection below
+still runs against the workspace's configured GitHub/GitLab repo, not Jira.
 
 **If an existing PR was detected for this ticket**, also fetch the PR view so it can be embedded:
 ```bash

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -376,12 +376,16 @@ create_session() {
     log "Using existing session: $SESSION_ID"
   fi
 
-  # Step 2: Set ticket metadata (if URL provided)
-  if [[ -n "$TICKET_URL" && -n "$TICKET_NUMBER" ]]; then
+  # Step 2: Set ticket metadata (if URL provided). The number is optional —
+  # Jira keys (e.g. MAXX-6846) have no standalone numeric id, so gate on the
+  # URL and add --number only when it's actually numeric. (crow set-ticket
+  # accepts --url/--title without --number; a non-numeric --number would make
+  # ArgumentParser reject the whole call and drop url+title too.)
+  if [[ -n "$TICKET_URL" ]]; then
     log "Setting ticket metadata..."
     local ticket_args=(crow set-ticket --session "$SESSION_ID" --url "$TICKET_URL")
     [[ -n "$TICKET_TITLE" ]] && ticket_args+=(--title "$TICKET_TITLE")
-    ticket_args+=(--number "$TICKET_NUMBER")
+    [[ "$TICKET_NUMBER" =~ ^[0-9]+$ ]] && ticket_args+=(--number "$TICKET_NUMBER")
     "${ticket_args[@]}" >/dev/null 2>&1 \
       || log "Warning: set-ticket failed (may already be set)"
   fi


### PR DESCRIPTION
Closes #463

After the Jira `TaskBackend` integration (#460), Jira-tasked sessions (task = Jira, code = GitHub) never got their PR linked and skipped ticket metadata. Root cause across the defects: bootstrap/refresh paths route by the single `Session.provider` field (the task-only `.jira`) instead of the established `session.codeProvider ?? session.provider` convention used by `SessionService.findPRLink` and `AutoRespondCoordinator`.

## Bug A — PR links never attach (confirmed, highest value)
`IssueTracker.reconcileMissingPRLinks` buckets reconcile candidates into `.github`/`.gitlab` only, so a `.jira` candidate produced by `buildReconcileCandidates` matched neither and was silently dropped — the GitHub PR was never queried.

- Extracted a pure `resolveReconcileProvider(codeProvider:provider:host:)` static helper that routes by the **code** provider, skips task-only providers, and falls back to host sniffing (mirrors the existing convention + the static-helper pattern already in this file).
- `buildReconcileCandidates` now calls it. Net: a Jira-task + GitHub-code session yields a `.github` candidate, so the PR on the session branch links on the normal refresh cycle.
- **Regression test:** new `IssueTracker reconcile provider routing` suite covering the Jira+GitHub case plus precedence, host-sniff fallback, and no-regression for plain GitHub/GitLab.

## Bug C — Jira ticket metadata skipped on setup (confirmed)
`skills/crow-workspace/setup.sh` gated `crow set-ticket` on a non-empty `TICKET_NUMBER`; Jira keys have no standalone numeric id, so metadata was skipped (only the `add-link` ticket link was created). Now gates on `TICKET_URL` and adds `--number` only when numeric (a non-numeric value would make ArgumentParser reject the whole call and drop url+title too). `crow-batch-workspace` delegates to the same script, so this covers both.

## Bug B — orphan-recovery path (intentionally out of scope)
`recoverOrphan`/`parseTicketInfo` (GitHub-only) only fires for *truly orphaned* worktrees. The common interactive "Work on issue" picker already passes the real Jira `AssignedIssue.url` to `/crow-workspace`, so it persists the correct ticket once Bug C lands. Making the rare disk-recovery path Jira-aware was deliberately deferred (no reliable Jira signal beyond the dir name + workspace config); worth a follow-up ticket if needed.

## Verification
- `make app` — clean build.
- `swift test` — 196 tests across 21 suites pass, including the new reconcile-provider suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)