### PR TITLE
Fail gracefully on GitHub org SAML enforcement (recover accessible-org tickets)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -219,6 +219,12 @@ public final class AppState {
     /// Set by `IssueTracker` when the token lacks a required scope; cleared on next success.
     public var githubScopeWarning: String?
 
+    /// Non-fatal GitHub SAML warning surfaced in Settings. `nil` means no warning.
+    /// Set by `IssueTracker` when an org's SAML enforcement blocks the OAuth
+    /// token (accessible-org tickets still load); cleared on the next poll with
+    /// no SAML restriction.
+    public var githubSAMLWarning: String?
+
     /// Last observed GitHub GraphQL rate-limit snapshot. `nil` before the first
     /// successful query. Populated from the `rateLimit` block on each refresh.
     public var githubRateLimit: GitHubRateLimit?

--- a/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/BackendTypes.swift
@@ -183,17 +183,24 @@ public struct AssignedListing: Sendable {
     /// user knows to refresh their token. The successful path returns the
     /// best-effort data alongside the scope marker; no error is thrown.
     public let missingScope: String?
+    /// True when the response was degraded because an org's SAML enforcement
+    /// blocked the OAuth token. The accessible-org issues GitHub still
+    /// returned are in `open`/`closed`; callers should surface a one-time UI
+    /// warning. Like `missingScope`, no error is thrown for this case.
+    public let samlRestricted: Bool
 
     public init(
         open: [AssignedIssue],
         closed: [AssignedIssue],
         rateLimit: GitHubRateLimit? = nil,
-        missingScope: String? = nil
+        missingScope: String? = nil,
+        samlRestricted: Bool = false
     ) {
         self.open = open
         self.closed = closed
         self.rateLimit = rateLimit
         self.missingScope = missingScope
+        self.samlRestricted = samlRestricted
     }
 }
 
@@ -204,11 +211,16 @@ public struct MonitoredPRListing: Sendable {
     public let reviewRequests: [ReviewRequest]
     public let viewerLogin: String
     public let rateLimit: GitHubRateLimit?
+    /// True when the response was degraded because an org's SAML enforcement
+    /// blocked the OAuth token. The accessible-org PRs/reviews GitHub still
+    /// returned are present; callers should surface a one-time UI warning.
+    public let samlRestricted: Bool
 
-    public init(viewerPRs: [PRRecord], reviewRequests: [ReviewRequest], viewerLogin: String, rateLimit: GitHubRateLimit? = nil) {
+    public init(viewerPRs: [PRRecord], reviewRequests: [ReviewRequest], viewerLogin: String, rateLimit: GitHubRateLimit? = nil, samlRestricted: Bool = false) {
         self.viewerPRs = viewerPRs
         self.reviewRequests = reviewRequests
         self.viewerLogin = viewerLogin
         self.rateLimit = rateLimit
+        self.samlRestricted = samlRestricted
     }
 }

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubCodeBackend.swift
@@ -73,7 +73,14 @@ public struct GitHubCodeBackend: CodeBackend {
                 "-F", "reviewQuery=\(reviewQuery)"
             )
         } catch ShellRunnerError.nonZeroExit(_, let stderr) {
-            throw GitHubTaskBackend.classifyGraphQLError(stderr)
+            let err = GitHubTaskBackend.classifyGraphQLError(stderr)
+            if case .samlRestricted(let blob) = err {
+                // An org's SAML enforcement blocked the token. Recover the
+                // accessible-org PRs/reviews GitHub still returned and flag the
+                // listing degraded instead of failing the whole cycle.
+                return Self.recoverPartialMonitoredPRs(fromSAMLBlob: blob)
+            }
+            throw err
         }
         return try Self.parseMonitoredPRsResponse(output)
     }
@@ -292,6 +299,34 @@ public struct GitHubCodeBackend: CodeBackend {
             reviewRequests: reviewRequests,
             viewerLogin: viewerLogin,
             rateLimit: rate
+        )
+    }
+
+    /// Recover the accessible-org PRs/reviews GitHub returned alongside a SAML
+    /// `errors` entry. Mirrors `GitHubTaskBackend.recoverPartialIssues`: extract
+    /// the leading JSON object from the merged `gh` blob, parse what resolved,
+    /// and mark `samlRestricted`. Degrades to an empty listing (never throws)
+    /// when no body is recoverable.
+    static func recoverPartialMonitoredPRs(fromSAMLBlob blob: String) -> MonitoredPRListing {
+        guard let dataObj = GitHubTaskBackend.decodeGraphQLData(blob) else {
+            return MonitoredPRListing(viewerPRs: [], reviewRequests: [], viewerLogin: "", samlRestricted: true)
+        }
+        let dateFmt = ISO8601DateFormatter()
+        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let viewerLogin = (dataObj["viewer"] as? [String: Any])?["login"] as? String ?? ""
+        let viewerPRs = parseViewerPRs(dataObj["viewerPRs"] as? [String: Any])
+        let reviewRequests = parseReviewRequests(
+            dataObj["reviewPRs"] as? [String: Any],
+            dateFormatter: dateFmt,
+            viewerLogin: viewerLogin.isEmpty ? nil : viewerLogin
+        )
+        let rate = GitHubTaskBackend.parseRateLimit(dataObj["rateLimit"] as? [String: Any])
+        return MonitoredPRListing(
+            viewerPRs: viewerPRs,
+            reviewRequests: reviewRequests,
+            viewerLogin: viewerLogin,
+            rateLimit: rate,
+            samlRestricted: true
         )
     }
 

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/GitHubTaskBackend.swift
@@ -62,12 +62,25 @@ public struct GitHubTaskBackend: TaskBackend {
             let listing = try Self.parseIssuesResponse(output, missingScope: nil)
             return includeClosed ? listing : Self.stripClosed(listing)
         } catch ProviderError.insufficientScope(let scope) {
-            let output = try await runIssuesQuery(
-                query: Self.consolidatedIssuesQueryNoProjects,
-                openQuery: openQuery,
-                closedQuery: closedQuery
-            )
-            let listing = try Self.parseIssuesResponse(output, missingScope: scope)
+            do {
+                let output = try await runIssuesQuery(
+                    query: Self.consolidatedIssuesQueryNoProjects,
+                    openQuery: openQuery,
+                    closedQuery: closedQuery
+                )
+                let listing = try Self.parseIssuesResponse(output, missingScope: scope)
+                return includeClosed ? listing : Self.stripClosed(listing)
+            } catch ProviderError.samlRestricted(let blob) {
+                // Rare: the no-projects retry also hit SAML. Recover what
+                // resolved; the scope warning is sacrificed for this cycle.
+                let listing = Self.recoverPartialIssues(fromSAMLBlob: blob)
+                return includeClosed ? listing : Self.stripClosed(listing)
+            }
+        } catch ProviderError.samlRestricted(let blob) {
+            // An org's SAML enforcement blocked the token. GitHub still
+            // returned the accessible-org issues in `data`; recover them and
+            // flag the listing degraded instead of failing the whole cycle.
+            let listing = Self.recoverPartialIssues(fromSAMLBlob: blob)
             return includeClosed ? listing : Self.stripClosed(listing)
         }
     }
@@ -77,7 +90,8 @@ public struct GitHubTaskBackend: TaskBackend {
             open: listing.open,
             closed: [],
             rateLimit: listing.rateLimit,
-            missingScope: listing.missingScope
+            missingScope: listing.missingScope,
+            samlRestricted: listing.samlRestricted
         )
     }
 
@@ -235,6 +249,13 @@ public struct GitHubTaskBackend: TaskBackend {
     /// and scope failures get their own cases so callers can route them to
     /// dedicated UI; everything else collapses to `.commandFailed`.
     static func classifyGraphQLError(_ stderr: String) -> ProviderError {
+        // Check SAML first: GitHub returns partial `data` alongside the SAML
+        // `errors` entry, so we carry the whole blob to recover accessible-org
+        // results. A SAML blob won't also contain the rate-limit/scope tokens.
+        if stderr.contains("Resource protected by organization SAML enforcement")
+            || stderr.contains("protected by SAML") {
+            return .samlRestricted(stderr)
+        }
         if stderr.contains("RATE_LIMITED") || stderr.contains("API rate limit exceeded") {
             return .rateLimited(stderr)
         }
@@ -378,6 +399,93 @@ public struct GitHubTaskBackend: TaskBackend {
         )
         let rate = parseRateLimit(dataObj["rateLimit"] as? [String: Any])
         return AssignedListing(open: open, closed: closed, rateLimit: rate, missingScope: missingScope)
+    }
+
+    /// Recover the accessible-org issues GitHub returned alongside a SAML
+    /// `errors` entry. `blob` is the merged `gh` stdout+stderr — partial JSON
+    /// body followed by the `gh:` error line — so we extract the leading JSON
+    /// object before parsing. When nothing is recoverable (gh emitted no body),
+    /// returns an empty listing rather than throwing, so the cycle degrades to
+    /// "no tickets, warning shown" instead of failing. Always marks
+    /// `samlRestricted` so callers light the warning UI.
+    static func recoverPartialIssues(fromSAMLBlob blob: String) -> AssignedListing {
+        guard let dataObj = decodeGraphQLData(blob) else {
+            return AssignedListing(open: [], closed: [], rateLimit: nil, samlRestricted: true)
+        }
+        let dateFmt = ISO8601DateFormatter()
+        dateFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let open = parseIssueNodes(
+            dataObj["openIssues"] as? [String: Any],
+            defaultState: "open",
+            dateFormatter: dateFmt
+        )
+        let closed = parseIssueNodes(
+            dataObj["closedIssues"] as? [String: Any],
+            defaultState: "closed",
+            dateFormatter: dateFmt,
+            projectStatusOverride: .done
+        )
+        let rate = parseRateLimit(dataObj["rateLimit"] as? [String: Any])
+        return AssignedListing(open: open, closed: closed, rateLimit: rate, samlRestricted: true)
+    }
+
+    /// Pull the `data` object out of a `gh api graphql` output blob that may
+    /// have trailing non-JSON text appended — e.g. the `gh: …` error line that
+    /// lands in the same merged stdout+stderr stream after the response body on
+    /// a partial (SAML/FORBIDDEN) failure. Fast path parses the whole string
+    /// (the success case stays zero-overhead); the fallback extracts the first
+    /// balanced top-level `{…}` object and parses that. Returns `json["data"]`,
+    /// or nil if no JSON object is present.
+    static func decodeGraphQLData(_ blob: String) -> [String: Any]? {
+        func dataObject(from string: String) -> [String: Any]? {
+            guard let data = string.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return json["data"] as? [String: Any]
+        }
+        if let dataObj = dataObject(from: blob) {
+            return dataObj
+        }
+        guard let sliced = firstBalancedJSONObject(in: blob) else { return nil }
+        return dataObject(from: sliced)
+    }
+
+    /// Return the substring spanning the first complete, brace-balanced `{…}`
+    /// object in `blob`, ignoring braces inside JSON strings (and escapes).
+    /// Used to peel the response body off a blob with trailing `gh:` error text.
+    static func firstBalancedJSONObject(in blob: String) -> String? {
+        let chars = Array(blob)
+        guard let start = chars.firstIndex(of: "{") else { return nil }
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var i = start
+        while i < chars.count {
+            let c = chars[i]
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if c == "\\" {
+                    escaped = true
+                } else if c == "\"" {
+                    inString = false
+                }
+            } else {
+                switch c {
+                case "\"": inString = true
+                case "{": depth += 1
+                case "}":
+                    depth -= 1
+                    if depth == 0 {
+                        return String(chars[start...i])
+                    }
+                default: break
+                }
+            }
+            i += 1
+        }
+        return nil
     }
 
     static func parseIssueNodes(

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -357,4 +357,12 @@ public enum ProviderError: Error {
     /// GitHub GraphQL `RATE_LIMITED`. Callers should skip the cycle and retry
     /// after the documented reset time.
     case rateLimited(String)
+    /// GitHub org SAML enforcement on an org the OAuth token isn't authorized
+    /// for. GitHub returns the issues/PRs that *did* resolve from accessible
+    /// orgs in `data`, alongside a `FORBIDDEN`/SAML entry in `errors`; `gh`
+    /// then exits non-zero. The associated value is the FULL merged `gh`
+    /// output blob (partial JSON body + the trailing `gh:` error line) so
+    /// call sites can recover the accessible-org data instead of dropping the
+    /// whole cycle. See `GitHubTaskBackend.recoverPartialIssues`.
+    case samlRestricted(String)
 }

--- a/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/BackendsTests.swift
@@ -132,6 +132,98 @@ final class BackendsTests: XCTestCase {
         XCTAssertEqual(listing.missingScope, "read:project")
     }
 
+    // MARK: - SAML enforcement (graceful degradation)
+
+    func testClassifyGraphQLErrorDetectsSAML() {
+        let blob = #"{"data":{"openIssues":{"nodes":[]}},"errors":[{"type":"FORBIDDEN","message":"Resource protected by organization SAML enforcement. You must grant your OAuth token access to an organization within this enterprise."}]}"#
+        guard case .samlRestricted(let carried) = GitHubTaskBackend.classifyGraphQLError(blob) else {
+            return XCTFail("expected .samlRestricted")
+        }
+        // The full blob is carried so call sites can recover partial data.
+        XCTAssertEqual(carried, blob)
+    }
+
+    func testClassifyGraphQLErrorSAMLTakesPrecedenceOverScope() {
+        // A SAML blob shouldn't be misrouted to the scope branch even if it
+        // happened to mention a scope-ish token.
+        let blob = "Resource protected by organization SAML enforcement"
+        guard case .samlRestricted = GitHubTaskBackend.classifyGraphQLError(blob) else {
+            return XCTFail("expected .samlRestricted")
+        }
+    }
+
+    func testDecodeGraphQLDataExtractsLeadingObjectWithTrailingGhError() {
+        // Merged stdout+stderr: response body followed by gh's error line, plus
+        // a brace inside a string value to exercise the string-aware scanner.
+        let blob = """
+        {"data":{"openIssues":{"nodes":[{"title":"weird }{ title"}]}}}
+        gh: Resource protected by organization SAML enforcement.
+        """
+        let dataObj = GitHubTaskBackend.decodeGraphQLData(blob)
+        XCTAssertNotNil(dataObj)
+        let nodes = ((dataObj?["openIssues"] as? [String: Any])?["nodes"] as? [[String: Any]])
+        XCTAssertEqual(nodes?.first?["title"] as? String, "weird }{ title")
+    }
+
+    func testListAssignedRecoversAccessibleIssuesOnSAML() async throws {
+        // GitHub returns the accessible-org issue in `data` alongside the SAML
+        // `errors` entry; gh exits non-zero and the merged blob carries both,
+        // with gh's error line appended after the body.
+        let blob = """
+        {"data":{
+          "openIssues":{"nodes":[
+            {"number":7,"title":"Accessible","url":"https://github.com/ok/repo/issues/7","state":"open",
+             "repository":{"nameWithOwner":"ok/repo"},"labels":{"nodes":[]}}
+          ]},
+          "closedIssues":{"nodes":[]},
+          "rateLimit":{"remaining":4990,"limit":5000,"resetAt":"2026-01-01T00:00:00Z","cost":1}
+        },"errors":[{"type":"FORBIDDEN","path":["openIssues","nodes",3],"message":"Resource protected by organization SAML enforcement. You must grant your OAuth token access to an organization within this enterprise."}]}
+        gh: Resource protected by organization SAML enforcement. You must grant your OAuth token access to an organization within this enterprise.
+        """
+        let fake = FakeShellRunner()
+        fake.responses = [.failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: blob))]
+        let backend = GitHubTaskBackend(shellRunner: fake)
+        let listing = try await backend.listAssigned()
+        XCTAssertTrue(listing.samlRestricted)
+        XCTAssertEqual(listing.open.count, 1)
+        XCTAssertEqual(listing.open.first?.title, "Accessible")
+        XCTAssertEqual(listing.rateLimit?.remaining, 4990)
+    }
+
+    func testRecoverPartialIssuesEmptyWhenNoJSON() {
+        // gh emitted only an error line, no body — degrade to empty + flagged,
+        // never throw.
+        let listing = GitHubTaskBackend.recoverPartialIssues(
+            fromSAMLBlob: "gh: Resource protected by organization SAML enforcement."
+        )
+        XCTAssertTrue(listing.samlRestricted)
+        XCTAssertTrue(listing.open.isEmpty)
+        XCTAssertTrue(listing.closed.isEmpty)
+    }
+
+    func testListMonitoredPRsRecoversAccessiblePRsOnSAML() async throws {
+        let blob = """
+        {"data":{
+          "viewerPRs":{"pullRequests":{"nodes":[
+            {"number":12,"url":"https://github.com/ok/repo/pull/12","state":"OPEN",
+             "headRefName":"feat","baseRefName":"main","repository":{"nameWithOwner":"ok/repo"}}
+          ]}},
+          "reviewPRs":{"nodes":[]},
+          "viewer":{"login":"me"},
+          "rateLimit":{"remaining":4980,"limit":5000,"resetAt":"2026-01-01T00:00:00Z","cost":1}
+        },"errors":[{"type":"FORBIDDEN","message":"Resource protected by organization SAML enforcement. You must grant your OAuth token access to an organization within this enterprise."}]}
+        gh: Resource protected by organization SAML enforcement. You must grant your OAuth token access to an organization within this enterprise.
+        """
+        let fake = FakeShellRunner()
+        fake.responses = [.failure(ShellRunnerError.nonZeroExit(exitCode: 1, output: blob))]
+        let backend = GitHubCodeBackend(shellRunner: fake)
+        let listing = try await backend.listMonitoredPRs()
+        XCTAssertTrue(listing.samlRestricted)
+        XCTAssertEqual(listing.viewerPRs.count, 1)
+        XCTAssertEqual(listing.viewerPRs.first?.number, 12)
+        XCTAssertEqual(listing.viewerLogin, "me")
+    }
+
     func testGitHubTaskBackendSetTaskStatusRunsMutation() async throws {
         let fake = FakeShellRunner()
         // First call: lookup. Second call: mutation.

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -147,6 +147,23 @@ public struct SettingsView: View {
     }
 
     @ViewBuilder
+    private var githubSAMLWarningBanner: some View {
+        if let warning = appState.githubSAMLWarning {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "lock.shield.fill")
+                    .foregroundStyle(.orange)
+                Text(warning)
+                    .font(.caption)
+                    .textSelection(.enabled)
+                Spacer()
+            }
+            .padding(10)
+            .background(Color.orange.opacity(0.12))
+            .cornerRadius(6)
+        }
+    }
+
+    @ViewBuilder
     private var rateLimitWarningBanner: some View {
         if let warning = appState.rateLimitWarning {
             HStack(alignment: .top, spacing: 8) {
@@ -167,6 +184,9 @@ public struct SettingsView: View {
         Form {
             if appState.githubScopeWarning != nil {
                 Section { githubScopeWarningBanner }
+            }
+            if appState.githubSAMLWarning != nil {
+                Section { githubSAMLWarningBanner }
             }
             if appState.rateLimitWarning != nil {
                 Section { rateLimitWarningBanner }

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -163,6 +163,9 @@ final class IssueTracker {
     /// Guards the GitHub-scope console warning so it fires once per session.
     private var didLogGitHubScopeWarning = false
 
+    /// Guards the GitHub-SAML console warning so it fires once per session.
+    private var didLogGitHubSAMLWarning = false
+
     /// When non-nil and in the future, all polls are skipped.
     private var suspendedUntil: Date?
 
@@ -216,6 +219,29 @@ final class IssueTracker {
             appState.githubScopeWarning = nil
         }
         didLogGitHubScopeWarning = false
+    }
+
+    /// Surface a SAML-enforcement warning: console once per session, UI banner
+    /// every time. Fires when an org's SAML SSO blocks the OAuth token — the
+    /// backend recovers accessible-org tickets and flags the response, so this
+    /// is informational, not fatal.
+    private func reportSAMLWarning() {
+        let msg = "GitHub: an org enforces SAML SSO and your token isn't authorized — its tickets are hidden. "
+            + "Authorize it at github.com/settings/connections, or ignore if you don't use it on this machine."
+        if !didLogGitHubSAMLWarning {
+            print("[IssueTracker] \(msg)")
+            didLogGitHubSAMLWarning = true
+        }
+        appState.githubSAMLWarning = msg
+    }
+
+    /// Drop the SAML warning after a poll with no SAML restriction. Re-arms the
+    /// once-per-session log so a future regression will print again.
+    private func clearSAMLWarning() {
+        if appState.githubSAMLWarning != nil {
+            appState.githubSAMLWarning = nil
+        }
+        didLogGitHubSAMLWarning = false
     }
 
     private func reportRateLimitWarning(resetAt: Date) {
@@ -653,6 +679,16 @@ final class IssueTracker {
         } else {
             clearScopeWarning()
         }
+
+        // The backends recover accessible-org data on SAML enforcement and
+        // flag the listing rather than throwing, so the response is still
+        // assembled above. Light the one-time warning while any org stays
+        // blocked; clear it once a clean poll returns.
+        if assigned.samlRestricted || monitored.samlRestricted {
+            reportSAMLWarning()
+        } else {
+            clearSAMLWarning()
+        }
         return ConsolidatedGitHubResponse(
             openIssues: assigned.open,
             closedIssues: assigned.closed,
@@ -672,6 +708,11 @@ final class IssueTracker {
             reportScopeWarning(scope)
         case ProviderError.rateLimited(let stderr):
             _ = handleGraphQLRateLimit(stderr: stderr)
+        case ProviderError.samlRestricted:
+            // Secondary calls (prStates, findRecentPRsForBranches) don't
+            // recover partial data; route their SAML failures to the same
+            // one-time warning instead of spamming the console each cycle.
+            reportSAMLWarning()
         default:
             print("[IssueTracker] \(operation) failed: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Problem

The user joined a GitHub org that enforces SAML SSO. Their `gh` OAuth token isn't authorized for it, so the consolidated GraphQL poll failed **every** 60s cycle:

```
gh: Resource protected by organization SAML enforcement. You must grant your OAuth token access to an organization within this enterprise.
```

The whole poll aborted — the console got spammed and CRO showed **no tickets at all**, even from orgs the token *can* see. The user has no intention of using the protected org on this machine and just wants Crow to fail gracefully while accessible-org tickets keep loading.

## Key insight

GitHub returns the SAML failure as a **partial response** (HTTP 200): the issues/PRs that resolved from accessible orgs are in `data`, alongside a `FORBIDDEN`/SAML entry in `errors` whose path points at the *specific* protected node. `gh api graphql` refuses any response with an `errors` array and exits non-zero; `ProcessShellRunner` merges stdout+stderr and threw the whole blob away. The data we want was already in hand — just discarded.

## Approach

Extends the codebase's existing `INSUFFICIENT_SCOPES` graceful-degradation precedent (`AssignedListing.missingScope` → `reportScopeWarning`) to SAML:

- **Detect** — `classifyGraphQLError` matches the SAML message and returns a new `ProviderError.samlRestricted` carrying the full merged blob.
- **Recover** — `decodeGraphQLData` peels the leading JSON object off the blob (string-aware brace balancing, past gh's trailing `gh:` line); `recoverPartialIssues` / `recoverPartialMonitoredPRs` reuse the existing node parsers to surface accessible-org data and flag the listing `samlRestricted`. No body recoverable → empty listing, never throws.
- **Keep loading** — `listAssigned` / `listMonitoredPRs` recover instead of throwing; the protected org is silently dropped. Secondary calls (`prStates`, `findRecentPRsForBranches`) route to the warning.
- **Warn once** — `IssueTracker.reportSAMLWarning` mirrors `reportScopeWarning`: one-time console log + a persistent, selectable Settings → General banner (`appState.githubSAMLWarning`), cleared on the next clean poll.

## Behavior change

| | Before | After |
|---|---|---|
| Console | SAML error every 60s | One line per session |
| Ticket list | Empty | Accessible-org tickets load; protected org hidden |
| User signal | None | One-time Settings banner with remediation |

## Tests

6 new unit tests in `BackendsTests.swift` (via `FakeShellRunner` returning realistic merged blobs): SAML detection + precedence, the tolerant extractor (incl. `{`/`}` inside string values), partial recovery for issues and PRs, and the empty-on-no-JSON fallback. **62 CrowProvider XCTests pass, 0 failures.**

## Verification notes

- The `CrowProvider` package (all core logic) builds clean and its full suite passes.
- The macOS app target and `CrowUI`/`IssueTracker` could not be compiled in this environment — they link `Frameworks/GhosttyKit.xcframework`, which is a build artifact absent from the checkout (`make ghostty` / `scripts/build-ghostty.sh`, needs zig + Metal toolchain). The two app-target files were syntax-checked with `swiftc -parse` and mirror existing patterns exactly. **Please confirm a full `make build` on a machine with GhosttyKit before merge.**
- Real SAML can't be reproduced locally without a protected org, so runtime coverage rests on the unit blobs. The recovery degrades safely to warn-only if a future `gh` ever emits no body on error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
