### PR TITLE
Wire OSC 8 hyperlink hover/click in libghostty embed

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
@@ -99,6 +99,14 @@ public final class GhosttyApp {
     /// remain discoverable.
     nonisolated private static let silencedActionTags: Set<UInt32> = [26, 32, 36, 56]
 
+    /// URL schemes Crow will hand to `NSWorkspace.shared.open()` from an OSC 8
+    /// click. Anything else (file, javascript, data, vbscript, …) is dropped on
+    /// the floor — the URL is still rendered, but clicking it is a no-op. Keep
+    /// this tight; OSC 8 emitters are not always trustworthy.
+    nonisolated private static let allowedURLSchemes: Set<String> = [
+        "http", "https", "mailto", "ftp", "ftps",
+    ]
+
     nonisolated static func handleAction(
         app: ghostty_app_t?,
         target: ghostty_target_s,
@@ -116,6 +124,40 @@ public final class GhosttyApp {
                     guard let terminalID = view.terminalID else { return }
                     GhosttyApp.shared.onChildExited?(terminalID, exitCode)
                 }
+            }
+            return true
+        }
+        // OSC 8 hover: libghostty reports the mouse entering/leaving a hyperlink
+        // cell. Non-zero `len` = entering, zero = leaving. We don't need the URL
+        // itself — Ghostty tracks it internally and re-emits via OPEN_URL on click.
+        if action.tag == GHOSTTY_ACTION_MOUSE_OVER_LINK {
+            if target.tag == GHOSTTY_TARGET_SURFACE,
+               let userdata = ghostty_surface_userdata(target.target.surface) {
+                let hovering = action.action.mouse_over_link.len > 0
+                DispatchQueue.main.async {
+                    let view = Unmanaged<GhosttySurfaceView>.fromOpaque(userdata).takeUnretainedValue()
+                    view.setHoveringLink(hovering)
+                }
+            }
+            return true
+        }
+        // OSC 8 click: hand the URL to NSWorkspace after a scheme allowlist
+        // check. The C buffer is not null-terminated — read exactly `len` bytes.
+        if action.tag == GHOSTTY_ACTION_OPEN_URL {
+            let payload = action.action.open_url
+            guard payload.len > 0, let ptr = payload.url else { return true }
+            let urlString = String(
+                decoding: UnsafeRawBufferPointer(start: ptr, count: Int(payload.len)),
+                as: UTF8.self
+            )
+            guard let url = URL(string: urlString),
+                  let scheme = url.scheme?.lowercased(),
+                  GhosttyApp.allowedURLSchemes.contains(scheme) else {
+                NSLog("[GhosttyApp] OPEN_URL rejected (scheme not allowed): len=\(payload.len)")
+                return true
+            }
+            DispatchQueue.main.async {
+                NSWorkspace.shared.open(url)
             }
             return true
         }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -7,6 +7,7 @@ public final class GhosttySurfaceView: NSView {
     private var pendingText: [String] = []
     private var markedTextStorage = NSMutableAttributedString()
     private var trackingArea: NSTrackingArea?
+    private var isHoveringLink: Bool = false
 
     /// Backoff schedule for retrying createSurface() when ghostty_surface_new returns nil.
     /// 4 retries totalling ~7.5s before declaring permanent failure.
@@ -202,6 +203,21 @@ public final class GhosttySurfaceView: NSView {
         )
         addTrackingArea(area)
         trackingArea = area
+    }
+
+    /// Toggle the pointing-hand cursor when libghostty reports the mouse is
+    /// hovering an OSC 8 hyperlink. Fed from `GHOSTTY_ACTION_MOUSE_OVER_LINK`
+    /// in `GhosttyApp.handleAction()`.
+    public func setHoveringLink(_ hovering: Bool) {
+        guard isHoveringLink != hovering else { return }
+        isHoveringLink = hovering
+        window?.invalidateCursorRects(for: self)
+    }
+
+    public override func resetCursorRects() {
+        if isHoveringLink {
+            addCursorRect(bounds, cursor: .pointingHand)
+        }
     }
 
     public override var acceptsFirstResponder: Bool { true }


### PR DESCRIPTION
## Summary

- `GhosttyApp.handleAction()` now dispatches `GHOSTTY_ACTION_MOUSE_OVER_LINK` and `GHOSTTY_ACTION_OPEN_URL` (previously only `SHOW_CHILD_EXITED` was wired, so OSC 8 actions were silently dropped).
- `GhosttySurfaceView.setHoveringLink(_:)` + a `resetCursorRects()` override swap the pointing-hand cursor on/off when the mouse enters/leaves a hyperlinked cell.
- `OPEN_URL` is gated by a hard-coded scheme allowlist (`http`, `https`, `mailto`, `ftp`, `ftps`); `file`, `javascript`, `data`, etc. are logged and dropped.

Closes #468

## Test plan

- [ ] `make ghostty && swift build` — clean.
- [ ] In any Crow terminal pane (including a tmux'd one), run:
      `printf '\e]8;;https://github.com/radiusmethod/crow/issues/466\e\\Crow #466\e]8;;\e\\\n'`
      → hover swaps to pointing hand; click opens browser.
- [ ] Negative test: `printf '\e]8;;javascript:alert(1)\e\\xss\e]8;;\e\\\n'` → click is dropped with `[GhosttyApp] OPEN_URL rejected` in Console.app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)