### PR TITLE
Terminal UX cluster: click-to-deselect + right-click context menu (CROW-469)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttyApp.swift
@@ -102,8 +102,10 @@ public final class GhosttyApp {
     /// URL schemes Crow will hand to `NSWorkspace.shared.open()` from an OSC 8
     /// click. Anything else (file, javascript, data, vbscript, …) is dropped on
     /// the floor — the URL is still rendered, but clicking it is a no-op. Keep
-    /// this tight; OSC 8 emitters are not always trustworthy.
-    nonisolated private static let allowedURLSchemes: Set<String> = [
+    /// this tight; OSC 8 emitters are not always trustworthy. Exposed at module
+    /// scope so the right-click menu in `GhosttySurfaceView` can gate its "Open
+    /// Link" item against the same allowlist as the action callback.
+    nonisolated static let allowedURLSchemes: Set<String> = [
         "http", "https", "mailto", "ftp", "ftps",
     ]
 
@@ -128,15 +130,23 @@ public final class GhosttyApp {
             return true
         }
         // OSC 8 hover: libghostty reports the mouse entering/leaving a hyperlink
-        // cell. Non-zero `len` = entering, zero = leaving. We don't need the URL
-        // itself — Ghostty tracks it internally and re-emits via OPEN_URL on click.
+        // cell. Non-zero `len` = entering, zero = leaving. The URL bytes ride
+        // along on entry so the right-click "Open Link" menu item can fire
+        // without waiting for a click to re-emit OPEN_URL.
         if action.tag == GHOSTTY_ACTION_MOUSE_OVER_LINK {
             if target.tag == GHOSTTY_TARGET_SURFACE,
                let userdata = ghostty_surface_userdata(target.target.surface) {
-                let hovering = action.action.mouse_over_link.len > 0
+                let payload = action.action.mouse_over_link
+                let url: String? = {
+                    guard payload.len > 0, let ptr = payload.url else { return nil }
+                    return String(
+                        decoding: UnsafeRawBufferPointer(start: ptr, count: Int(payload.len)),
+                        as: UTF8.self
+                    )
+                }()
                 DispatchQueue.main.async {
                     let view = Unmanaged<GhosttySurfaceView>.fromOpaque(userdata).takeUnretainedValue()
-                    view.setHoveringLink(hovering)
+                    view.setHoveringLink(url)
                 }
             }
             return true

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -7,7 +7,7 @@ public final class GhosttySurfaceView: NSView {
     private var pendingText: [String] = []
     private var markedTextStorage = NSMutableAttributedString()
     private var trackingArea: NSTrackingArea?
-    private var isHoveringLink: Bool = false
+    private var hoveredLinkURL: String?
 
     /// Backoff schedule for retrying createSurface() when ghostty_surface_new returns nil.
     /// 4 retries totalling ~7.5s before declaring permanent failure.
@@ -206,16 +206,20 @@ public final class GhosttySurfaceView: NSView {
     }
 
     /// Toggle the pointing-hand cursor when libghostty reports the mouse is
-    /// hovering an OSC 8 hyperlink. Fed from `GHOSTTY_ACTION_MOUSE_OVER_LINK`
-    /// in `GhosttyApp.handleAction()`.
-    public func setHoveringLink(_ hovering: Bool) {
-        guard isHoveringLink != hovering else { return }
-        isHoveringLink = hovering
-        window?.invalidateCursorRects(for: self)
+    /// hovering an OSC 8 hyperlink, and stash the URL for the right-click
+    /// "Open Link" menu item. Fed from `GHOSTTY_ACTION_MOUSE_OVER_LINK` in
+    /// `GhosttyApp.handleAction()`. Pass `nil` when the mouse leaves the link.
+    public func setHoveringLink(_ url: String?) {
+        guard hoveredLinkURL != url else { return }
+        let wasHovering = hoveredLinkURL != nil
+        hoveredLinkURL = url
+        if wasHovering != (url != nil) {
+            window?.invalidateCursorRects(for: self)
+        }
     }
 
     public override func resetCursorRects() {
-        if isHoveringLink {
+        if hoveredLinkURL != nil {
             addCursorRect(bounds, cursor: .pointingHand)
         }
     }
@@ -347,6 +351,108 @@ public final class GhosttySurfaceView: NSView {
             pasteboard.clearContents()
             pasteboard.setString(str, forType: .string)
         }
+    }
+
+    // MARK: - Right-click context menu
+
+    /// Build a context menu matching macOS terminal conventions: Copy / Paste /
+    /// Select All / Clear / Open Link. Items are enabled/disabled at
+    /// construction time against the current surface state (selection present,
+    /// pasteboard contents, hovered link, known active terminal). Right-click
+    /// position has already driven `mouseMoved` → `MOUSE_OVER_LINK`, so
+    /// `hoveredLinkURL` already reflects what's under the cursor.
+    public override func menu(for event: NSEvent) -> NSMenu? {
+        guard event.type == .rightMouseDown || event.type == .rightMouseUp else {
+            return super.menu(for: event)
+        }
+
+        let menu = NSMenu(title: "Terminal")
+
+        let hasSelection: Bool = {
+            guard let surface else { return false }
+            return ghostty_surface_has_selection(surface)
+        }()
+        let canPaste = NSPasteboard.general.canReadObject(
+            forClasses: [NSString.self], options: nil
+        )
+        let activeTerminalID = TmuxBackend.shared.activeTerminalID
+        let linkURL: URL? = {
+            guard let raw = hoveredLinkURL,
+                  let url = URL(string: raw),
+                  let scheme = url.scheme?.lowercased(),
+                  GhosttyApp.allowedURLSchemes.contains(scheme) else { return nil }
+            return url
+        }()
+
+        let copyItem = NSMenuItem(
+            title: "Copy", action: #selector(copy(_:)), keyEquivalent: ""
+        )
+        copyItem.target = self
+        copyItem.isEnabled = hasSelection
+        menu.addItem(copyItem)
+
+        let pasteItem = NSMenuItem(
+            title: "Paste", action: #selector(paste(_:)), keyEquivalent: ""
+        )
+        pasteItem.target = self
+        pasteItem.isEnabled = canPaste
+        menu.addItem(pasteItem)
+
+        let selectAllItem = NSMenuItem(
+            title: "Select All",
+            action: #selector(contextSelectAll(_:)),
+            keyEquivalent: ""
+        )
+        selectAllItem.target = self
+        selectAllItem.isEnabled = activeTerminalID != nil
+        menu.addItem(selectAllItem)
+
+        let clearItem = NSMenuItem(
+            title: "Clear",
+            action: #selector(contextClear(_:)),
+            keyEquivalent: ""
+        )
+        clearItem.target = self
+        clearItem.isEnabled = activeTerminalID != nil
+        menu.addItem(clearItem)
+
+        menu.addItem(.separator())
+
+        let openLinkItem = NSMenuItem(
+            title: "Open Link",
+            action: #selector(contextOpenLink(_:)),
+            keyEquivalent: ""
+        )
+        openLinkItem.target = self
+        openLinkItem.representedObject = linkURL
+        openLinkItem.isEnabled = linkURL != nil
+        menu.addItem(openLinkItem)
+
+        return menu
+    }
+
+    @objc private func contextSelectAll(_ sender: Any?) {
+        guard let id = TmuxBackend.shared.activeTerminalID else { return }
+        do {
+            try TmuxBackend.shared.selectAll(id: id)
+        } catch {
+            NSLog("[GhosttySurfaceView] selectAll failed: \(error)")
+        }
+    }
+
+    @objc private func contextClear(_ sender: Any?) {
+        guard let id = TmuxBackend.shared.activeTerminalID else { return }
+        do {
+            try TmuxBackend.shared.clearHistory(id: id)
+        } catch {
+            NSLog("[GhosttySurfaceView] clearHistory failed: \(error)")
+        }
+    }
+
+    @objc private func contextOpenLink(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let url = item.representedObject as? URL else { return }
+        NSWorkspace.shared.open(url)
     }
 
     public override func keyUp(with event: NSEvent) {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -367,6 +367,12 @@ public final class GhosttySurfaceView: NSView {
         }
 
         let menu = NSMenu(title: "Terminal")
+        // AppKit's default `autoenablesItems = true` ignores per-item
+        // `isEnabled` and instead enables anything whose target responds to
+        // its action selector — which would render every item enabled
+        // regardless of selection / pasteboard / hover state. Disable so the
+        // gating below is what users see.
+        menu.autoenablesItems = false
 
         let hasSelection: Bool = {
             guard let surface else { return false }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -46,6 +46,15 @@ unbind-key -a
 bind -T copy-mode    MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"
 bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear "pbcopy"
 
+# Single click outside the current selection should clear it (macOS Terminal /
+# iTerm2 convention). #452 keeps the copy-mode selection alive after mouse-up
+# via `copy-pipe-no-clear`; without this binding a follow-up click leaves the
+# old highlight stuck. Mirrors the DoubleClick1Pane wrapper below: forward to
+# the inner app if it captured mouse, otherwise cancel copy-mode so the
+# selection dismisses. MouseDrag1Pane (which initiates a new selection) still
+# fires after this and re-enters copy-mode cleanly.
+bind -T root MouseDown1Pane select-pane -t = \; if -F -t = "#{mouse_any_flag}" "send-keys -M" { if -F -t = "#{pane_in_mode}" "send-keys -X cancel" }
+
 # Same fix for double-click (select-word) and triple-click (select-line)
 # on the root table — the defaults also end in `copy-pipe-and-cancel`
 # and would otherwise clear the highlight after copying, inconsistent

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -352,6 +352,47 @@ public final class TmuxBackend {
         }
     }
 
+    /// Drop the scrollback buffer for terminal `id` via `tmux clear-history`.
+    /// On-screen rows survive — only the off-screen history is wiped — matching
+    /// what macOS Terminal "Clear" and iTerm2 "Clear Buffer" do. Surfaced from
+    /// the right-click context menu in `GhosttySurfaceView`.
+    public func clearHistory(id: UUID) throws {
+        guard let windowIndex = bindings[id] else {
+            throw TmuxBackendError.unknownTerminal(id)
+        }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            _ = try ctrl.run(["clear-history", "-t", target])
+        } catch {
+            reportIfTimeout(error)
+            throw error
+        }
+    }
+
+    /// Enter tmux copy-mode and select the entire scrollback for terminal
+    /// `id` — the "Select All" equivalent for a terminal pane. Surfaced from
+    /// the right-click context menu in `GhosttySurfaceView`. After this, Copy
+    /// (or Cmd+C) writes the captured text to the macOS pasteboard via the
+    /// existing `copy-pipe-no-clear` binding.
+    public func selectAll(id: UUID) throws {
+        guard let windowIndex = bindings[id] else {
+            throw TmuxBackendError.unknownTerminal(id)
+        }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            // -H makes copy-mode enter without scrolling the screen first.
+            _ = try ctrl.run(["copy-mode", "-H", "-t", target])
+            try ctrl.sendKeys(target: target, keys: ["-X", "history-top"])
+            try ctrl.sendKeys(target: target, keys: ["-X", "begin-selection"])
+            try ctrl.sendKeys(target: target, keys: ["-X", "history-bottom"])
+        } catch {
+            reportIfTimeout(error)
+            throw error
+        }
+    }
+
     /// Destroy the tmux window backing `id` and forget the binding.
     public func destroyTerminal(id: UUID) {
         if let windowIndex = bindings[id] {


### PR DESCRIPTION
Closes #469

Lands items 1 and 3 of #469. Item 2 (OSC 8 hover/click) already shipped via #468 / PR #470 and item 3's "Open Link" layers on top of it. Audit follow-ups filed as #471.

## What changed

### Item 1 — click-to-deselect (`crow-tmux.conf`)

After drag-selecting text, the highlight survived a subsequent click anywhere in the pane. Root cause: the default `MouseDown1Pane` binding (`select-pane`) doesn't dismiss the copy-mode selection that #452's `copy-pipe-no-clear` deliberately preserves to keep the clipboard intact.

Added a new `bind -T root MouseDown1Pane` that mirrors the existing `DoubleClick1Pane` wrapper shape: forward to the inner app when it captured the mouse, otherwise `send-keys -X cancel` to dismiss copy-mode. `MouseDrag1Pane` still re-enters copy-mode cleanly for a new selection.

### Item 3 — right-click context menu (`GhosttySurfaceView.swift`)

Overrode `menu(for:) -> NSMenu?` with the five items called out in the ticket's acceptance criteria. Items are enabled/disabled at construction time:

| Item | Enabled when |
|---|---|
| Copy | `ghostty_surface_has_selection` returns true |
| Paste | NSPasteboard has a string |
| Select All | `TmuxBackend.shared.activeTerminalID` is known |
| Clear | `TmuxBackend.shared.activeTerminalID` is known |
| Open Link | `hoveredLinkURL != nil` and its scheme is in `GhosttyApp.allowedURLSchemes` |

Surfaced two new `TmuxBackend` methods mirroring the existing `sendText(id:text:)` binding-lookup pattern:

- `clearHistory(id:)` — `tmux clear-history -t <target>`. Matches macOS Terminal "Clear" / iTerm2 "Clear Buffer": on-screen rows survive, scrollback is wiped.
- `selectAll(id:)` — `copy-mode -H` → `history-top` → `begin-selection` → `history-bottom`. After this, the existing `copy-pipe-no-clear` MouseDragEnd binding (or Cmd+C / context-menu Copy) writes the captured text to the pasteboard.

### Item 3a — extend `setHoveringLink` to carry the URL

#468 stored only a `Bool` for hover state because `GHOSTTY_ACTION_OPEN_URL` re-emits the URL on click. The right-click "Open Link" item needs the URL *without* a click. Widened `setHoveringLink(_:)` from `Bool` to `String?`, decoded the `mouse_over_link.url`/`len` payload in `GhosttyApp.handleAction()`, and promoted `allowedURLSchemes` to module scope so the menu gates Open Link against the same allowlist as the action callback.

## Audit verdict

Code-static pass against the 14 candidates in #469's audit section. Per-item verdicts:

**Already wired (no work):**
- Double/triple-click word/line selection — `crow-tmux.conf:57-58`.
- Drag-and-drop file path → text — `GhosttySurfaceView.draggingEntered` / `performDragOperation`.
- Cmd+Shift+V plain-text paste — `paste(_:)` reads `.string` only, so paste is already plain text.

**Confirmed gap, filed under #471:**
- Cursor I-beam over terminal content (only pointing-hand on links is wired).
- Cmd+F search-in-scrollback.
- Bracketed-paste safety prompt for multi-line pastes.
- Spacebar Quick Look on selection.
- Smart-detect bare URLs + `path:line` references.
- Cmd+up/down to jump between prompts.

**Needs a live test — noted in #471, not filed:**
- IME under tmux.
- Selection survival under wheel-scroll (#452 covered mouse-up only).
- Triple-click + drag for line-by-line extension.
- Tab keyboard navigation from a focused terminal.

## Coordination

- Built on top of #468 (PR #470) which merged before this PR was opened. Rebased onto `main` to inherit it.
- #466 (SwiftTerm spike) closed NO-GO, so the Ghostty embed is the path forward.

## Test plan

- [ ] `make ghostty && swift build --arch arm64` — Crow app builds clean (note: `swift build` without Xcode hits a pre-existing `BuildInfo` symbol gap in `AboutView.swift` — that's the Xcode build-phase generator, not this PR).
- [ ] Drag-select text in a Crow terminal; click elsewhere in the pane → highlight dismisses, NSPasteboard text survives (no #446 regression).
- [ ] Drag-select again immediately → new selection forms cleanly.
- [ ] Run `vim` / `htop` inside the pane → mouse-using TUIs still receive mouse events (the `mouse_any_flag` short-circuit in the new binding).
- [ ] With a selection: right-click → Copy enabled; click it → pasteboard matches the selection.
- [ ] Without a selection: right-click → Copy disabled.
- [ ] Right-click → Paste sends the pasteboard string as text.
- [ ] Right-click → Select All highlights the entire scrollback; subsequent Cmd+C copies it.
- [ ] Right-click → Clear; `tmux capture-pane -p -S - -t <target>` shows only on-screen rows.
- [ ] Print an OSC 8 link (`printf '\\e]8;;https://example.com\\e\\\\example\\e]8;;\\e\\\\\\n'`). Hover → pointing-hand cursor (#468). Right-click *on* the link → Open Link enabled; click → opens in default browser. Right-click off the link → Open Link disabled.
- [ ] Regression sweep: Cmd+C, Cmd+V, typing, IME, scroll wheel, drag-select all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)