### PR TITLE
Fix source-file exit-1 from bare unbind-key -a on prefix table

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-tmux.conf
@@ -30,13 +30,23 @@ set -gs status off
 # still works alongside this.
 set -gs mouse on
 
-# Crow owns the keyboard namespace. `unbind-key -a` (no `-T`) clears the
-# `prefix` table only — `root`, `copy-mode`, and `copy-mode-vi` are left
-# intact (use `-a -T <table>` to clear a non-prefix table). That's
-# load-bearing here: the mouse fix depends on the root-table defaults
-# (`WheelUpPane`, `MouseDrag1Pane`, …) surviving — wiping root with
-# `unbind-key -a -T root` would re-break #452 wheel scrollback.
-unbind-key -a
+# Crow owns the keyboard namespace: the prefix table must end up empty so
+# tmux's default `C-b <key>` shortcuts can't fire in the surface. A bare
+# `unbind-key -a` (no `-T`) targets the prefix table, but it fails with
+# `table prefix doesn't exist` once the table has been cleared — and that
+# failure made `source-file` return exit 1 on every reconcile-on-attach
+# pass (#451 path), poisoning #451's gating logic (#473).
+#
+# Pre-creating the table with a stub `Any` binding guarantees `unbind-key
+# -a -T prefix` always has something to clear, so the command stays
+# idempotent across fresh startup AND `source-file` reloads. Net result is
+# the same empty prefix table as before — without the exit-1.
+#
+# Do NOT widen this to `unbind-key -a -T root`: the mouse fix below relies
+# on root-table defaults (`WheelUpPane`, `MouseDrag1Pane`, …) surviving;
+# wiping root would re-break #452 wheel scrollback.
+bind-key -T prefix Any send-keys
+unbind-key -a -T prefix
 
 # Default MouseDragEnd1Pane is `send-keys -X copy-pipe-and-cancel`; the
 # -and-cancel exits copy mode after copying, which wipes the visual

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/BundledResourcesTests.swift
@@ -62,4 +62,33 @@ struct BundledResourcesTests {
         #expect(body.contains(#"send-keys -X select-word ; run -d0.3 ; send-keys -X copy-pipe-no-clear "pbcopy""#))
         #expect(body.contains(#"send-keys -X select-line ; run -d0.3 ; send-keys -X copy-pipe-no-clear "pbcopy""#))
     }
+
+    @Test func tmuxConfHasNoBarePrefixUnbind() throws {
+        // #473: a bare `unbind-key -a` (no `-T`) defaults to the prefix
+        // table, which is empty/non-existent after the first clear on
+        // Crow's tmux server. The command errored with `table prefix
+        // doesn't exist` and made `source-file` return exit 1 — breaking
+        // #451's reconcile-on-attach gating. The fix uses an explicit
+        // `bind-key -T prefix Any …` stub followed by
+        // `unbind-key -a -T prefix` so the clear is idempotent. This test
+        // pins both invariants: the bare form is gone, and the
+        // stub-then-clear pair is present in that order.
+        let url = try #require(BundledResources.tmuxConfURL)
+        let body = try String(contentsOf: url, encoding: .utf8)
+        for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.hasPrefix("#") else { continue }
+            #expect(
+                trimmed != "unbind-key -a" && trimmed != "unbind -a",
+                "bare `unbind-key -a` would re-introduce the #473 exit-1 bug"
+            )
+        }
+        let stubIdx = body.range(of: "bind-key -T prefix Any send-keys")
+        let clearIdx = body.range(of: "unbind-key -a -T prefix")
+        #expect(stubIdx != nil, "missing stub bind that pre-creates the prefix table")
+        #expect(clearIdx != nil, "missing explicit `unbind-key -a -T prefix`")
+        if let s = stubIdx, let c = clearIdx {
+            #expect(s.lowerBound < c.lowerBound, "stub must precede the clear")
+        }
+    }
 }


### PR DESCRIPTION
Closes #473

## Summary

- The bare `unbind-key -a` at `crow-tmux.conf:39` defaulted to the prefix table. Once the table is empty (which is the steady state on Crow's server) the command errors with `table prefix doesn't exist`, making `source-file <conf>` return **exit 1** even though every other binding loaded cleanly.
- That broken exit status was poisoning #451's reconcile-on-attach path (`TmuxBackend.reconcileBundledConfigIfStale` in `Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift:572-577`), which then logs `[CrowTelemetry tmux:config_reconcile_failed …]` on every successful reload.
- Fix: stub-bind `Any` into the prefix table before `unbind-key -a -T prefix`, so the clear always has at least one binding to remove. End state is the same empty prefix table — without the exit 1.
- Comment block updated to explain the new pattern and why; existing warning about not widening to `-T root` (would re-break #452 wheel scrollback) preserved.

## Verification

```
new-session exit: 0
1st source-file: exit 0
2nd source-file: exit 0  (idempotent reload)
show-messages: no 'table prefix' errors
list-keys -T prefix: 'table prefix doesn't exist'  (same end state)
mouse on / allow-passthrough on / status off  ✓
root MouseDown1Pane, DoubleClick1Pane, TripleClick1Pane bound  ✓
copy-mode + copy-mode-vi MouseDragEnd1Pane copy-pipe-no-clear  ✓
root WheelUpPane / MouseDrag1Pane defaults preserved (#452)  ✓
```

Regression test added in `BundledResourcesTests.tmuxConfHasNoBarePrefixUnbind` pins three invariants: no bare `unbind-key -a`/`unbind -a` outside comments, presence of the stub bind and the explicit clear, and stub-precedes-clear ordering.

## Test plan

- [x] `swift test --package-path Packages/CrowTerminal --filter BundledResourcesTests` — 7/7 pass (including the new regression test)
- [x] Manual `tmux -S <sock> source-file <conf>` on a fresh server: exit 0
- [x] Manual second `source-file` (reload path): exit 0
- [x] `tmux show-messages` after both: no `table prefix doesn't exist`
- [x] Prefix table empty (`list-keys -T prefix` → doesn't exist); root defaults preserved
- [ ] In-app smoke: launch with `CROW_TMUX_BACKEND=1`, restart so reconcile-on-attach fires, confirm `[CrowTelemetry tmux:config_reconciled …]` in logs (no `tmux:config_reconcile_failed`)

🐦‍⬛ Generated with Claude Code, orchestrated by Crow