### PR TITLE
Add Reload Terminal Config menu item (CROW-475)

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -577,6 +577,33 @@ public final class TmuxBackend {
         }
     }
 
+    /// Re-source the bundled `crow-tmux.conf` against the live tmux server
+    /// unconditionally — driven by the "Reload Terminal Config" menu item
+    /// (#475), where the user has explicitly asked for a reload. Unlike
+    /// `reconcileBundledConfigIfStale`, this skips the mtime gate.
+    ///
+    /// Returns `nil` on success, or a human-readable error string the caller
+    /// can surface in a banner. Idempotent: `source-file` against a live
+    /// server updates server-scoped options in place; existing windows and
+    /// sessions are unaffected.
+    @MainActor
+    public func reloadBundledConfig() -> String? {
+        guard let ctrl = controller, ctrl.hasSession() else {
+            return "tmux server is not running"
+        }
+        guard let confURL = BundledResources.tmuxConfURL else {
+            return "bundled crow-tmux.conf not found"
+        }
+        do {
+            try ctrl.run(["source-file", confURL.path])
+            NSLog("[CrowTelemetry tmux:config_reloaded_by_user path=\(confURL.path)]")
+            return nil
+        } catch {
+            NSLog("[CrowTelemetry tmux:config_reload_failed error=\"\(error)\"]")
+            return "\(error)"
+        }
+    }
+
     /// Pure policy: reconcile when either timestamp is missing (conservative
     /// — a redundant `source-file` is cheap) or when the conf is newer than
     /// the running server.

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -976,6 +976,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let restartTmuxItem = NSMenuItem(title: "Restart tmux Server", action: #selector(restartTmuxServer), keyEquivalent: "")
         restartTmuxItem.target = self
         appMenu.addItem(restartTmuxItem)
+        // Non-destructive — re-sources the bundled tmux conf against the live
+        // server. No keyEquivalent for now (#475); can be added if asked.
+        let reloadConfigItem = NSMenuItem(title: "Reload Terminal Config", action: #selector(reloadTerminalConfig), keyEquivalent: "")
+        reloadConfigItem.target = self
+        appMenu.addItem(reloadConfigItem)
         appMenu.addItem(NSMenuItem.separator())
         appMenu.addItem(withTitle: "Hide Crow", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h")
         let hideOthersItem = NSMenuItem(title: "Hide Others", action: #selector(NSApplication.hideOtherApplications(_:)), keyEquivalent: "h")
@@ -1010,6 +1015,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if alert.runModal() == .alertFirstButtonReturn {
             appState.onRestartTmuxServer?()
         }
+    }
+
+    @objc private func reloadTerminalConfig() {
+        NSLog("[CrowTelemetry tmux:config_reload_by_user]")
+        let errorText = TmuxBackend.shared.reloadBundledConfig()
+        notificationManager?.notifyConfigReloaded(errorText: errorText)
     }
 
     @objc private func showAbout() {

--- a/Sources/Crow/App/NotificationManager.swift
+++ b/Sources/Crow/App/NotificationManager.swift
@@ -159,6 +159,31 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         )
     }
 
+    // MARK: - Terminal Config Reload (#475)
+
+    /// One-shot banner for the "Reload Terminal Config" menu item. Pass
+    /// `nil` for success; any non-nil string is shown as the failure body.
+    func notifyConfigReloaded(errorText: String?) {
+        guard !settings.globalMute else { return }
+        guard settings.systemNotificationsEnabled else { return }
+
+        if let errorText {
+            postSystemNotification(
+                title: "Terminal config reload failed",
+                body: errorText,
+                sessionID: UUID(),
+                eventName: "ConfigReloadFailed"
+            )
+        } else {
+            postSystemNotification(
+                title: "Terminal config reloaded",
+                body: "Sourced crow-tmux.conf into the running tmux server.",
+                sessionID: UUID(),
+                eventName: "ConfigReloaded"
+            )
+        }
+    }
+
     // MARK: - Auto-Rebase Notifications (CROW-318)
 
     /// Notify the user that Crow rebased a PR branch onto its base and


### PR DESCRIPTION
## Summary
- Adds **Crow → Reload Terminal Config** menu item that re-sources the bundled `crow-tmux.conf` against the live tmux server without restarting it.
- Manual counterpart to #451's reconcile-on-attach: covers conf edits mid-session and the "reset hot-patched bindings to canonical state" workflow.
- Success/failure surfaced via a system notification (`Terminal config reloaded` / `Terminal config reload failed`).

## Implementation
- **`TmuxBackend.reloadBundledConfig()`** — new public method that unconditionally runs `source-file <bundled conf>` against the cached controller. Returns `nil` on success, error string on failure. Pairs with the existing `reconcileBundledConfigIfStale` (which is mtime-gated, appropriate for the attach path; the menu item is user-initiated so we skip the gate).
- **`NotificationManager.notifyConfigReloaded(errorText:)`** — surface result via existing system-notification path, gated by `globalMute` / `systemNotificationsEnabled` like other notify methods.
- **`AppDelegate`** — menu item placed alongside "Restart tmux Server" (sibling dev/recovery action). No confirmation alert (reload is non-destructive — windows/sessions survive). No keyEquivalent, mirroring the sibling item.

Server-not-running case: `reloadBundledConfig` returns "tmux server is not running" and the notification surfaces it. Cleaner than wiring `NSMenuItemValidation` to gray out the item.

#473's cosmetic `unbind-key -a` exit-1 was fixed in `e526131`, so this needs no workaround.

Closes #475

## Test plan
- [ ] Launch Crow and confirm **Crow → Reload Terminal Config** appears between "Restart tmux Server" and "Hide Crow"
- [ ] Click on a running server; expect "Terminal config reloaded" notification + `tmux:config_reloaded_by_user` telemetry line
- [ ] Edit `crow-tmux.conf`, click reload, verify the change is live without restarting Crow
- [ ] Quit without server-restart, relaunch, click before any pane exists; expect "tmux server is not running" notification (no crash)
- [ ] Confirm Restart tmux Server still works and still shows its confirmation alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)