### PR TITLE
Emit transitions on first observation when state warrants attention (CROW-477)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift
@@ -77,9 +77,15 @@ public struct PRStatusTransition: Sendable, Equatable {
 extension PRStatus {
     /// Compute the transitions implied by moving from `old` to `new`.
     ///
-    /// Returns an empty array on the first observation (`old == nil`) so
-    /// existing PR state never triggers a fire-on-startup. Otherwise emits
-    /// at most one `.changesRequested` and one `.checksFailing`, in that order.
+    /// On the first observation (`old == nil`), emits a transition only when
+    /// the new state is itself a "needs attention" condition — `.changesRequested`
+    /// or failing checks. A PR first observed as `.open` with passing/pending
+    /// checks emits nothing (the startup-flood safety the bare guard used to
+    /// provide). Persisted `emittedTransitionKeys` in `IssueTracker` (CROW-456)
+    /// suppress restart re-fires of transitions already emitted by a prior run.
+    ///
+    /// Otherwise emits at most one `.changesRequested` and one `.checksFailing`,
+    /// in that order.
     ///
     /// `.changesRequested` fires when the bucket is entered (`old` wasn't
     /// `.changesRequested`) or when the latest CHANGES_REQUESTED review ID
@@ -99,7 +105,36 @@ extension PRStatus {
         prURL: String,
         prNumber: Int?
     ) -> [PRStatusTransition] {
-        guard let old else { return [] } // first observation — never fire
+        guard let old else {
+            // First observation (CROW-477): emit only when the new state is
+            // itself attention-needing, so a PR Crow first sees already in
+            // CHANGES_REQUESTED (or with failing checks) still routes to
+            // auto-respond. Restart-spurious re-fires are prevented by the
+            // persisted dedupe keys at the IssueTracker layer, not here.
+            var out: [PRStatusTransition] = []
+            if new.reviewStatus == .changesRequested {
+                out.append(PRStatusTransition(
+                    kind: .changesRequested,
+                    sessionID: sessionID,
+                    prURL: prURL,
+                    prNumber: prNumber,
+                    headSha: new.headSha,
+                    latestReviewID: new.latestReviewID,
+                    failedCheckNames: []
+                ))
+            }
+            if new.checksPass == .failing {
+                out.append(PRStatusTransition(
+                    kind: .checksFailing,
+                    sessionID: sessionID,
+                    prURL: prURL,
+                    prNumber: prNumber,
+                    headSha: new.headSha,
+                    failedCheckNames: new.failedCheckNames
+                ))
+            }
+            return out
+        }
 
         var out: [PRStatusTransition] = []
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/PRStatusTransitionTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/PRStatusTransitionTests.swift
@@ -33,13 +33,45 @@ struct PRStatusTransitionTests {
     // MARK: - First-observation gate
 
     @Test
-    func firstObservationNeverFires() {
-        // No prior status — even if the PR is already in a transition state,
-        // we must not fire (it'd flood the user with notifications on every
-        // app launch).
-        #expect(compute(from: nil, to: status(review: .changesRequested)).isEmpty)
-        #expect(compute(from: nil, to: status(checks: .failing, sha: shaA)).isEmpty)
-        #expect(compute(from: nil, to: status(review: .changesRequested, checks: .failing, sha: shaA)).isEmpty)
+    func firstObservationOpenWithNoReviewDoesNotFire() {
+        // No prior status AND the new state isn't attention-needing — must not
+        // fire. Protects the startup-flood case the original guard was meant
+        // to cover.
+        #expect(compute(from: nil, to: status(review: .reviewRequired, checks: .pending)).isEmpty)
+        #expect(compute(from: nil, to: status(review: .approved, checks: .passing)).isEmpty)
+    }
+
+    @Test
+    func firstObservationChangesRequestedFires() {
+        // CROW-477: PR was already in CHANGES_REQUESTED when Crow first observed
+        // it (poll missed the open → changes-requested window, or session was
+        // created after the review landed). Must still route to auto-respond.
+        // IssueTracker's persisted dedupe (CROW-456) prevents restart re-fires.
+        let ts = compute(from: nil, to: status(review: .changesRequested, sha: shaA, reviewID: "R_1"))
+        #expect(ts.count == 1)
+        #expect(ts.first?.kind == .changesRequested)
+        #expect(ts.first?.latestReviewID == "R_1")
+        #expect(ts.first?.headSha == shaA)
+        #expect(ts.first?.sessionID == sessionID)
+        #expect(ts.first?.prURL == prURL)
+    }
+
+    @Test
+    func firstObservationFailingChecksFires() {
+        // CROW-477: same idea for failing CI on first observation.
+        let ts = compute(from: nil, to: status(checks: .failing, sha: shaA, failed: ["lint"]))
+        #expect(ts.count == 1)
+        #expect(ts.first?.kind == .checksFailing)
+        #expect(ts.first?.headSha == shaA)
+        #expect(ts.first?.failedCheckNames == ["lint"])
+    }
+
+    @Test
+    func firstObservationBothChangesRequestedAndFailingFiresBoth() {
+        let ts = compute(from: nil, to: status(review: .changesRequested, checks: .failing, sha: shaA, reviewID: "R_1", failed: ["lint"]))
+        #expect(ts.count == 2)
+        #expect(ts.contains(where: { $0.kind == .changesRequested && $0.latestReviewID == "R_1" }))
+        #expect(ts.contains(where: { $0.kind == .checksFailing && $0.failedCheckNames == ["lint"] }))
     }
 
     // MARK: - Changes requested


### PR DESCRIPTION
Closes #477

## Summary

- Relax the `guard let old else { return [] }` in `PRStatus.transitions(from:to:...)` (`Packages/CrowCore/Sources/CrowCore/Models/PRStatusTransition.swift`) so a PR Crow first observes already in `CHANGES_REQUESTED` or with `failing` checks emits a transition and routes to auto-respond.
- The startup-flood safety the original guard provided is preserved: `nil`-old with an attention-neutral state (`.reviewRequired`/`.approved`, `passing`/`pending` checks) still emits nothing.
- Restart-spurious re-fires are prevented by the persisted `emittedTransitionKeys` that shipped in #457 — not by this guard. If a key was emitted in a prior run, the `IssueTracker.swift:1485-1495` dedup correctly suppresses the synthesized first-observation candidate.

## Why this was missed before

`PRStatus.transitions(from:to:...)` returned `[]` on first observation to avoid re-firing every active PR at startup. But the IssueTracker poll interval is wide enough that a PR can be opened and receive a `CHANGES_REQUESTED` review entirely between two polls (real-world hit on corveil#1298 today: 6 minutes between PR open and the review). First observation was already `changesRequested` → guard returned `[]` → auto-respond silent → agent never nudged.

The `#456`/`#457` work that landed dedup-key persistence (`PersistedIssueTrackerState.emittedTransitionKeys` round-tripping through `JSONStore`) is the prerequisite that makes this guard safe to relax. Confirmed it shipped before writing this fix.

## Test plan

- [x] `arch -arm64 swift test --arch arm64 --package-path Packages/CrowCore --filter PRStatusTransitionTests` — 18/18 pass including 4 new first-observation tests:
  - `firstObservationChangesRequestedFires`
  - `firstObservationFailingChecksFires`
  - `firstObservationBothChangesRequestedAndFailingFiresBoth`
  - `firstObservationOpenWithNoReviewDoesNotFire` (replaces the old `firstObservationNeverFires`; covers the startup-flood-safety case)
- [x] `arch -arm64 swift test --arch arm64 --package-path Packages/CrowPersistence --filter JSONStoreTests` — persistence round-trip still green (no schema change, sanity only).
- [ ] Manual: open a Crow session whose linked PR is already in `CHANGES_REQUESTED`. Confirm auto-respond fires once on first poll. Restart Crow with same PR still in `CHANGES_REQUESTED` — confirm it does NOT re-fire (persisted dedup key suppresses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)