### PR TITLE
Terminal UX cluster: remaining gaps from #471 audit

### DIFF
--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -603,6 +603,12 @@ public final class GhosttySurfaceView: NSView {
     @objc private func contextOpenInEditor(_ sender: Any?) {
         guard let item = sender as? NSMenuItem,
               let url = item.representedObject as? URL else { return }
+        // v1 limitation: we resolve the file path but drop the line
+        // number `SmartDetect.detectFileLine` parsed. Jumping to a
+        // specific line is editor-specific (txmt://, vscode://, …) and
+        // there is no portable way to pick one without a configurable
+        // editor preference. Opening the file is still useful; line
+        // navigation can be a follow-up once we add an editor setting.
         NSWorkspace.shared.open(url)
     }
 
@@ -739,27 +745,14 @@ public final class GhosttySurfaceView: NSView {
 
     public override func mouseDown(with event: NSEvent) {
         guard let surface else { return }
-
-        // Cmd+click on a live selection: if it looks like a URL or a
-        // path:line reference, open it via the same dispatchers as the
-        // right-click menu (#471 gap 5). Falls through to the libghostty
-        // mouse path otherwise so plain Cmd+click on text still extends
-        // the selection / forwards to apps that asked for it.
-        if event.modifierFlags.contains(.command),
-           let selection = currentSelectionText() {
-            if let url = SmartDetect.detectURL(
-                in: selection, allowedSchemes: GhosttyApp.allowedURLSchemes
-            ) {
-                NSWorkspace.shared.open(url)
-                return
-            }
-            if let fileLine = SmartDetect.detectFileLine(in: selection),
-               let url = resolveFileURL(path: fileLine.path) {
-                NSWorkspace.shared.open(url)
-                return
-            }
-        }
-
+        // Note: smart-detect (gap 5) is intentionally NOT bound to
+        // Cmd+click here. libghostty's C surface doesn't expose
+        // text-at-point, so we can't verify the click landed on the
+        // detected URL — a global "Cmd+click anywhere opens the
+        // selected URL" would override macOS Terminal's
+        // selection-extend convention and surprise the user. The
+        // right-click menu's "Open URL" / "Open in Editor" items
+        // already cover the selection-based flow.
         sendMousePosition(for: event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, translateMods(event.modifierFlags))
     }

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -655,16 +655,25 @@ public final class GhosttySurfaceView: NSView {
         return true
     }
 
+    // The QLPreviewPanel control hooks are inherited as nonisolated from
+    // NSResponder, but AppKit only ever dispatches them on the main
+    // thread. Hop via `MainActor.assumeIsolated` so we can touch the
+    // surface's main-isolated state (panel.dataSource/.delegate are
+    // themselves `@MainActor`).
     public override func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
-        panel.dataSource = self
-        panel.delegate = self
+        MainActor.assumeIsolated {
+            panel.dataSource = self
+            panel.delegate = self
+        }
     }
 
     public override func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
-        if panel.dataSource === self { panel.dataSource = nil }
-        if panel.delegate === self { panel.delegate = nil }
-        cleanupQuickLookTempFile()
-        quickLookItem = nil
+        MainActor.assumeIsolated {
+            if panel.dataSource === self { panel.dataSource = nil }
+            if panel.delegate === self { panel.delegate = nil }
+            cleanupQuickLookTempFile()
+            quickLookItem = nil
+        }
     }
 
     /// Resolve a `path:line` detection's path to a file URL by checking

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import GhosttyKit
+import QuickLookUI
 
 /// NSView subclass that hosts a libghostty terminal surface with Metal rendering.
 public final class GhosttySurfaceView: NSView {
@@ -8,6 +9,13 @@ public final class GhosttySurfaceView: NSView {
     private var markedTextStorage = NSMutableAttributedString()
     private var trackingArea: NSTrackingArea?
     private var hoveredLinkURL: String?
+
+    /// Backing URL for the active Quick Look preview (spacebar, #471 gap 4).
+    /// Either a remote URL pulled directly from the selection or a temp
+    /// text file we wrote to render plain selection text. Cleared and the
+    /// temp file removed when the preview panel closes.
+    private var quickLookItem: NSURL?
+    private var quickLookTempFile: URL?
 
     /// Backoff schedule for retrying createSurface() when ghostty_surface_new returns nil.
     /// 4 retries totalling ~7.5s before declaring permanent failure.
@@ -219,6 +227,11 @@ public final class GhosttySurfaceView: NSView {
     }
 
     public override func resetCursorRects() {
+        // I-beam by default so terminal text feels selectable like macOS
+        // Terminal / iTerm2. Pointing-hand wins on hovered OSC 8 links —
+        // AppKit picks the last-registered cursor whose rect contains the
+        // point, so the order here matters.
+        addCursorRect(bounds, cursor: .iBeam)
         if hoveredLinkURL != nil {
             addCursorRect(bounds, cursor: .pointingHand)
         }
@@ -257,6 +270,45 @@ public final class GhosttySurfaceView: NSView {
 
     public override func keyDown(with event: NSEvent) {
         guard let surface else { return }
+
+        // Cmd+F → open the search overlay (#471 gap 2). Notification is
+        // observed by `TerminalSearchBar`; the bar takes first responder
+        // from us so the user can type immediately.
+        if event.modifierFlags.contains(.command),
+           event.charactersIgnoringModifiers == "f" {
+            NotificationCenter.default.post(name: .terminalBeginSearch, object: nil)
+            return
+        }
+
+        // Cmd+↑ / Cmd+↓ → jump between OSC 133 prompts (#471 gap 6). Lives
+        // before the generic Cmd path so the arrow keys don't reach the
+        // surface (which would scroll a line). 126 = up, 125 = down on
+        // macOS.
+        if event.modifierFlags.contains(.command),
+           event.keyCode == 126 || event.keyCode == 125,
+           let id = TmuxBackend.shared.activeTerminalID {
+            do {
+                if event.keyCode == 126 {
+                    try TmuxBackend.shared.previousPrompt(id: id)
+                } else {
+                    try TmuxBackend.shared.nextPrompt(id: id)
+                }
+            } catch {
+                NSLog("[GhosttySurfaceView] prompt jump failed: \(error)")
+            }
+            return
+        }
+
+        // Spacebar Quick Look on an active selection (#471 gap 4). Bare
+        // space only — modified space (Ctrl+Space, etc.) still goes to
+        // the surface. We deliberately do not consume space when there's
+        // no selection, so typing into the shell is unaffected.
+        if event.charactersIgnoringModifiers == " ",
+           event.modifierFlags.intersection([.command, .control, .option]).isEmpty,
+           ghostty_surface_has_selection(surface) {
+            showQuickLook()
+            return
+        }
 
         // Handle Cmd+V (paste) directly
         if event.modifierFlags.contains(.command), event.charactersIgnoringModifiers == "v" {
@@ -331,26 +383,72 @@ public final class GhosttySurfaceView: NSView {
     // MARK: - Copy / Paste
 
     @objc public func paste(_ sender: Any?) {
-        guard let surface else { return }
+        guard surface != nil else { return }
         let pasteboard = NSPasteboard.general
         guard let content = pasteboard.string(forType: .string) else { return }
+
+        // Multi-line paste safety prompt (iTerm2 / Terminal.app convention):
+        // pastes that contain a newline can submit a destructive command
+        // before the user realises what they pasted. Confirm via sheet, then
+        // forward through the same path as a single-line paste.
+        if content.contains("\n") || content.contains("\r") {
+            confirmMultilinePaste(content)
+            return
+        }
+        forwardPaste(content)
+    }
+
+    /// Forward already-vetted pasteboard text to the libghostty surface.
+    /// Shared by single-line paste and the confirm-sheet handler.
+    private func forwardPaste(_ content: String) {
+        guard let surface else { return }
         content.withCString { ptr in
             ghostty_surface_text(surface, ptr, UInt(content.utf8.count))
         }
     }
 
+    /// Show a confirmation sheet before forwarding a paste that contains a
+    /// newline. Modeless on `self.window`; falls back to a synchronous alert
+    /// if the view is not yet attached to a window (shouldn't happen in
+    /// practice, but a paste shortcut could arrive between detach and free).
+    private func confirmMultilinePaste(_ content: String) {
+        let alert = NSAlert()
+        alert.messageText = "Paste multiple lines?"
+        alert.informativeText = "The clipboard contains a line break, which may submit a command immediately."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Paste")
+        alert.addButton(withTitle: "Cancel")
+
+        guard let window else {
+            if alert.runModal() == .alertFirstButtonReturn {
+                forwardPaste(content)
+            }
+            return
+        }
+        alert.beginSheetModal(for: window) { [weak self] response in
+            guard response == .alertFirstButtonReturn else { return }
+            self?.forwardPaste(content)
+        }
+    }
+
     @objc public func copy(_ sender: Any?) {
-        guard let surface else { return }
+        guard let str = currentSelectionText() else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(str, forType: .string)
+    }
+
+    /// Read the active selection from libghostty as a Swift `String`, or
+    /// `nil` if there is no selection. Shared by Copy, the right-click
+    /// smart-detect items, and Quick Look.
+    private func currentSelectionText() -> String? {
+        guard let surface else { return nil }
         var text = ghostty_text_s()
         guard ghostty_surface_has_selection(surface),
-              ghostty_surface_read_selection(surface, &text) else { return }
+              ghostty_surface_read_selection(surface, &text) else { return nil }
         defer { ghostty_surface_free_text(surface, &text) }
-        if let ptr = text.text, text.text_len > 0 {
-            let str = String(cString: ptr)
-            let pasteboard = NSPasteboard.general
-            pasteboard.clearContents()
-            pasteboard.setString(str, forType: .string)
-        }
+        guard let ptr = text.text, text.text_len > 0 else { return nil }
+        return String(cString: ptr)
     }
 
     // MARK: - Right-click context menu
@@ -434,6 +532,41 @@ public final class GhosttySurfaceView: NSView {
         openLinkItem.isEnabled = linkURL != nil
         menu.addItem(openLinkItem)
 
+        // Smart-detect items off the current selection (#471 gap 5). These
+        // are hover-independent: select a bare URL or a `path:line` token
+        // and the matching action lights up. Both items always render so the
+        // menu shape is stable across selections; isEnabled gates dispatch.
+        let selection = currentSelectionText()
+        let detectedURL: URL? = selection.flatMap {
+            SmartDetect.detectURL(in: $0, allowedSchemes: GhosttyApp.allowedURLSchemes)
+        }
+        let detectedFileLine: (path: String, line: Int)? = selection.flatMap {
+            SmartDetect.detectFileLine(in: $0)
+        }
+        let resolvedFileURL: URL? = detectedFileLine.flatMap { resolveFileURL(path: $0.path) }
+
+        menu.addItem(.separator())
+
+        let openURLItem = NSMenuItem(
+            title: "Open URL",
+            action: #selector(contextOpenDetectedURL(_:)),
+            keyEquivalent: ""
+        )
+        openURLItem.target = self
+        openURLItem.representedObject = detectedURL
+        openURLItem.isEnabled = detectedURL != nil
+        menu.addItem(openURLItem)
+
+        let openInEditorItem = NSMenuItem(
+            title: "Open in Editor",
+            action: #selector(contextOpenInEditor(_:)),
+            keyEquivalent: ""
+        )
+        openInEditorItem.target = self
+        openInEditorItem.representedObject = resolvedFileURL
+        openInEditorItem.isEnabled = resolvedFileURL != nil
+        menu.addItem(openInEditorItem)
+
         return menu
     }
 
@@ -459,6 +592,104 @@ public final class GhosttySurfaceView: NSView {
         guard let item = sender as? NSMenuItem,
               let url = item.representedObject as? URL else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    @objc private func contextOpenDetectedURL(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let url = item.representedObject as? URL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func contextOpenInEditor(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let url = item.representedObject as? URL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Quick Look
+
+    /// Open `QLPreviewPanel` against the current selection (#471 gap 4).
+    /// URL selections preview directly; plain text is staged into a tmp
+    /// file under `$TMPDIR/crow-quicklook-<uuid>.txt`. Cleanup happens in
+    /// `endPreviewPanelControl(_:)` when the user closes the preview.
+    private func showQuickLook() {
+        guard let selection = currentSelectionText() else { return }
+
+        cleanupQuickLookTempFile()
+        quickLookItem = nil
+
+        if let url = SmartDetect.detectURL(
+            in: selection, allowedSchemes: GhosttyApp.allowedURLSchemes
+        ) {
+            quickLookItem = url as NSURL
+        } else {
+            let tmpDir = ProcessInfo.processInfo.environment["TMPDIR"]
+                ?? NSTemporaryDirectory()
+            let tmpURL = URL(fileURLWithPath: tmpDir)
+                .appendingPathComponent("crow-quicklook-\(UUID().uuidString).txt")
+            do {
+                try selection.write(to: tmpURL, atomically: true, encoding: .utf8)
+                quickLookTempFile = tmpURL
+                quickLookItem = tmpURL as NSURL
+            } catch {
+                NSLog("[GhosttySurfaceView] Quick Look temp write failed: \(error)")
+                return
+            }
+        }
+
+        let panel = QLPreviewPanel.shared()
+        if panel?.isVisible == true {
+            panel?.reloadData()
+        } else {
+            panel?.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    private func cleanupQuickLookTempFile() {
+        guard let path = quickLookTempFile else { return }
+        try? FileManager.default.removeItem(at: path)
+        quickLookTempFile = nil
+    }
+
+    public override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
+        return true
+    }
+
+    public override func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        panel.dataSource = self
+        panel.delegate = self
+    }
+
+    public override func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        if panel.dataSource === self { panel.dataSource = nil }
+        if panel.delegate === self { panel.delegate = nil }
+        cleanupQuickLookTempFile()
+        quickLookItem = nil
+    }
+
+    /// Resolve a `path:line` detection's path to a file URL by checking
+    /// (1) absolute / cwd-relative on its own and (2) joined with the
+    /// surface's `workingDirectory`. Returns nil if neither exists, so the
+    /// "Open in Editor" item stays disabled rather than handing a bogus
+    /// path to NSWorkspace.
+    private func resolveFileURL(path: String) -> URL? {
+        let fm = FileManager.default
+        if (path as NSString).isAbsolutePath, fm.fileExists(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+        if let cwd = workingDirectory {
+            let joined = (cwd as NSString).appendingPathComponent(path)
+            if fm.fileExists(atPath: joined) {
+                return URL(fileURLWithPath: joined)
+            }
+        }
+        // Last resort: treat as relative to the process cwd. Mostly a
+        // no-op since Crow doesn't chdir, but avoids surprising the user
+        // when they invoke from an unusual launcher.
+        if fm.fileExists(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+        return nil
     }
 
     public override func keyUp(with event: NSEvent) {
@@ -499,6 +730,27 @@ public final class GhosttySurfaceView: NSView {
 
     public override func mouseDown(with event: NSEvent) {
         guard let surface else { return }
+
+        // Cmd+click on a live selection: if it looks like a URL or a
+        // path:line reference, open it via the same dispatchers as the
+        // right-click menu (#471 gap 5). Falls through to the libghostty
+        // mouse path otherwise so plain Cmd+click on text still extends
+        // the selection / forwards to apps that asked for it.
+        if event.modifierFlags.contains(.command),
+           let selection = currentSelectionText() {
+            if let url = SmartDetect.detectURL(
+                in: selection, allowedSchemes: GhosttyApp.allowedURLSchemes
+            ) {
+                NSWorkspace.shared.open(url)
+                return
+            }
+            if let fileLine = SmartDetect.detectFileLine(in: selection),
+               let url = resolveFileURL(path: fileLine.path) {
+                NSWorkspace.shared.open(url)
+                return
+            }
+        }
+
         sendMousePosition(for: event)
         ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, translateMods(event.modifierFlags))
     }
@@ -659,6 +911,18 @@ extension GhosttySurfaceView {
 
     public override func accessibilitySelectedTextRange() -> NSRange {
         return selectedRange()
+    }
+}
+
+// MARK: - Quick Look conformance (#471 gap 4)
+
+extension GhosttySurfaceView: @preconcurrency QLPreviewPanelDataSource, @preconcurrency QLPreviewPanelDelegate {
+    public func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+        return quickLookItem != nil ? 1 : 0
+    }
+
+    public func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+        return quickLookItem
     }
 }
 

--- a/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/GhosttySurfaceView.swift
@@ -10,12 +10,11 @@ public final class GhosttySurfaceView: NSView {
     private var trackingArea: NSTrackingArea?
     private var hoveredLinkURL: String?
 
-    /// Backing URL for the active Quick Look preview (spacebar, #471 gap 4).
-    /// Either a remote URL pulled directly from the selection or a temp
-    /// text file we wrote to render plain selection text. Cleared and the
-    /// temp file removed when the preview panel closes.
+    /// Backing item for the active Quick Look preview (spacebar, #471
+    /// gap 4). Either a remote URL detected directly in the selection
+    /// or the resolved file URL for a `path:line` reference. Cleared in
+    /// `endPreviewPanelControl(_:)` when the user closes the preview.
     private var quickLookItem: NSURL?
-    private var quickLookTempFile: URL?
 
     /// Backoff schedule for retrying createSurface() when ghostty_surface_new returns nil.
     /// 4 retries totalling ~7.5s before declaring permanent failure.
@@ -301,11 +300,15 @@ public final class GhosttySurfaceView: NSView {
 
         // Spacebar Quick Look on an active selection (#471 gap 4). Bare
         // space only — modified space (Ctrl+Space, etc.) still goes to
-        // the surface. We deliberately do not consume space when there's
-        // no selection, so typing into the shell is unaffected.
+        // the surface. Restricted to selections that parse as a URL or
+        // a path:line reference so we don't hijack typed input: a
+        // common flow (drag-select output → keep typing at the shell)
+        // would otherwise have the next space typed open Quick Look
+        // instead of reaching the shell.
         if event.charactersIgnoringModifiers == " ",
            event.modifierFlags.intersection([.command, .control, .option]).isEmpty,
-           ghostty_surface_has_selection(surface) {
+           ghostty_surface_has_selection(surface),
+           selectionHasQuickLookCandidate() {
             showQuickLook()
             return
         }
@@ -390,8 +393,12 @@ public final class GhosttySurfaceView: NSView {
         // Multi-line paste safety prompt (iTerm2 / Terminal.app convention):
         // pastes that contain a newline can submit a destructive command
         // before the user realises what they pasted. Confirm via sheet, then
-        // forward through the same path as a single-line paste.
-        if content.contains("\n") || content.contains("\r") {
+        // forward through the same path as a single-line paste. A lone
+        // trailing newline (e.g. `"git status\n"` copied with its
+        // submit) is ignored — only genuinely multi-line payloads should
+        // trigger the prompt; matches iTerm2 / Terminal behaviour.
+        let body = content.hasSuffix("\n") ? String(content.dropLast()) : content
+        if body.contains("\n") || body.contains("\r") {
             confirmMultilinePaste(content)
             return
         }
@@ -614,33 +621,46 @@ public final class GhosttySurfaceView: NSView {
 
     // MARK: - Quick Look
 
+    /// Quick test (no temp file, no detector side effects beyond the
+    /// existing pure helpers) for whether the current selection is
+    /// something Quick Look can usefully preview: a remote URL with an
+    /// allowed scheme, or a `path:line` that resolves to an existing
+    /// regular file. Used to gate the spacebar intercept so we don't
+    /// swallow keystrokes typed against a stale selection.
+    private func selectionHasQuickLookCandidate() -> Bool {
+        guard let selection = currentSelectionText() else { return false }
+        if SmartDetect.detectURL(
+            in: selection, allowedSchemes: GhosttyApp.allowedURLSchemes
+        ) != nil {
+            return true
+        }
+        if let fileLine = SmartDetect.detectFileLine(in: selection),
+           resolveFileURL(path: fileLine.path) != nil {
+            return true
+        }
+        return false
+    }
+
     /// Open `QLPreviewPanel` against the current selection (#471 gap 4).
-    /// URL selections preview directly; plain text is staged into a tmp
-    /// file under `$TMPDIR/crow-quicklook-<uuid>.txt`. Cleanup happens in
-    /// `endPreviewPanelControl(_:)` when the user closes the preview.
+    /// Caller is responsible for gating via
+    /// `selectionHasQuickLookCandidate()` so this only runs on a URL or
+    /// a resolvable `path:line` reference. URL → previewed directly;
+    /// `path:line` → the resolved file URL (line number is dropped;
+    /// QLPreviewPanel has no concept of "open at line N").
     private func showQuickLook() {
         guard let selection = currentSelectionText() else { return }
 
-        cleanupQuickLookTempFile()
         quickLookItem = nil
 
         if let url = SmartDetect.detectURL(
             in: selection, allowedSchemes: GhosttyApp.allowedURLSchemes
         ) {
             quickLookItem = url as NSURL
+        } else if let fileLine = SmartDetect.detectFileLine(in: selection),
+                  let fileURL = resolveFileURL(path: fileLine.path) {
+            quickLookItem = fileURL as NSURL
         } else {
-            let tmpDir = ProcessInfo.processInfo.environment["TMPDIR"]
-                ?? NSTemporaryDirectory()
-            let tmpURL = URL(fileURLWithPath: tmpDir)
-                .appendingPathComponent("crow-quicklook-\(UUID().uuidString).txt")
-            do {
-                try selection.write(to: tmpURL, atomically: true, encoding: .utf8)
-                quickLookTempFile = tmpURL
-                quickLookItem = tmpURL as NSURL
-            } catch {
-                NSLog("[GhosttySurfaceView] Quick Look temp write failed: \(error)")
-                return
-            }
+            return
         }
 
         let panel = QLPreviewPanel.shared()
@@ -649,12 +669,6 @@ public final class GhosttySurfaceView: NSView {
         } else {
             panel?.makeKeyAndOrderFront(nil)
         }
-    }
-
-    private func cleanupQuickLookTempFile() {
-        guard let path = quickLookTempFile else { return }
-        try? FileManager.default.removeItem(at: path)
-        quickLookTempFile = nil
     }
 
     public override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
@@ -677,34 +691,45 @@ public final class GhosttySurfaceView: NSView {
         MainActor.assumeIsolated {
             if panel.dataSource === self { panel.dataSource = nil }
             if panel.delegate === self { panel.delegate = nil }
-            cleanupQuickLookTempFile()
             quickLookItem = nil
         }
     }
 
     /// Resolve a `path:line` detection's path to a file URL by checking
-    /// (1) absolute / cwd-relative on its own and (2) joined with the
-    /// surface's `workingDirectory`. Returns nil if neither exists, so the
-    /// "Open in Editor" item stays disabled rather than handing a bogus
-    /// path to NSWorkspace.
+    /// (1) absolute on its own and (2) joined with the *active pane's*
+    /// live cwd via `TmuxBackend.activePaneCwd`. We deliberately do NOT
+    /// fall back to the surface's stored `workingDirectory` — that field
+    /// is fixed to `$HOME` at cockpit-surface create time and never
+    /// follows the shell's `cd`s, so it'd resolve `Sources/Foo.swift`
+    /// against `$HOME` and miss the project tree. Returns nil if the
+    /// path doesn't point at an existing regular file, so "Open in
+    /// Editor" stays disabled rather than launching an app bundle or a
+    /// directory by accident.
     private func resolveFileURL(path: String) -> URL? {
         let fm = FileManager.default
-        if (path as NSString).isAbsolutePath, fm.fileExists(atPath: path) {
+        if (path as NSString).isAbsolutePath, isRegularFile(at: path, fm: fm) {
             return URL(fileURLWithPath: path)
         }
-        if let cwd = workingDirectory {
+        if let id = TmuxBackend.shared.activeTerminalID,
+           let cwd = TmuxBackend.shared.activePaneCwd(id: id) {
             let joined = (cwd as NSString).appendingPathComponent(path)
-            if fm.fileExists(atPath: joined) {
+            if isRegularFile(at: joined, fm: fm) {
                 return URL(fileURLWithPath: joined)
             }
         }
-        // Last resort: treat as relative to the process cwd. Mostly a
-        // no-op since Crow doesn't chdir, but avoids surprising the user
-        // when they invoke from an unusual launcher.
-        if fm.fileExists(atPath: path) {
-            return URL(fileURLWithPath: path)
-        }
         return nil
+    }
+
+    /// True only for plain files — directories and `.app` bundles (which
+    /// `FileManager.fileExists` happily reports as existing) are rejected
+    /// so the right-click "Open in Editor" item doesn't launch an app
+    /// from a `/Applications/Foo.app:1` selection.
+    private func isRegularFile(at path: String, fm: FileManager) -> Bool {
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue else {
+            return false
+        }
+        return true
     }
 
     public override func keyUp(with event: NSEvent) {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/Resources/crow-shell-wrapper.sh
@@ -98,6 +98,12 @@ fi
 _crow_precmd() {
   crow_log "precmd_fired"
   if [ -n "${TMUX:-}" ]; then
+    # Emit OSC 133;A twice under tmux: the wrapped form passes through to
+    # Ghostty (which uses the mark for #470 hyperlink and #471 cursor
+    # gating), and the bare form is consumed by tmux's emulator so
+    # `send-keys -X previous-prompt` / `next-prompt` can navigate marks
+    # for Cmd+up/down prompt jumps (#471 gap 6).
+    printf '\033]133;A\007'
     printf '\033Ptmux;\033\033]133;A\007\033\\'
     printf '\033Ptmux;\033\033]9;crow-ready\007\033\\'
   else
@@ -150,6 +156,12 @@ fi
 _crow_precmd() {
   crow_log "precmd_fired"
   if [ -n "${TMUX:-}" ]; then
+    # Emit OSC 133;A twice under tmux: the wrapped form passes through to
+    # Ghostty (which uses the mark for #470 hyperlink and #471 cursor
+    # gating), and the bare form is consumed by tmux's emulator so
+    # `send-keys -X previous-prompt` / `next-prompt` can navigate marks
+    # for Cmd+up/down prompt jumps (#471 gap 6).
+    printf '\033]133;A\007'
     printf '\033Ptmux;\033\033]133;A\007\033\\'
     printf '\033Ptmux;\033\033]9;crow-ready\007\033\\'
   else
@@ -179,6 +191,9 @@ BRC
     # hook. Production work would extend this with shell-specific paths.
     crow_log "hook_skipped reason=unsupported_shell shell=$SHELL"
     if [ -n "${TMUX:-}" ]; then
+      # See `_crow_precmd` above for why we emit OSC 133;A twice under
+      # tmux (bare for tmux's prompt tracking, wrapped for Ghostty).
+      printf '\033]133;A\007'
       printf '\033Ptmux;\033\033]133;A\007\033\\\033Ptmux;\033\033]9;crow-ready\007\033\\'
     else
       printf '\033]133;A\007\033]9;crow-ready\007'

--- a/Packages/CrowTerminal/Sources/CrowTerminal/SmartDetect.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/SmartDetect.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Pure heuristics for picking URLs and `path:line` references out of a
+/// terminal selection so the right-click menu / Cmd+click can offer
+/// "Open URL" and "Open in Editor" actions (#471 gap 5).
+///
+/// Kept free of AppKit so it can be exercised by unit tests without a
+/// window server.
+public enum SmartDetect {
+    /// Returns the first URL in `text` whose scheme is in `allowedSchemes`.
+    /// Uses `NSDataDetector` so it accepts the same bare-URL shapes the
+    /// system's data detectors do (paren-balanced, trailing-punctuation
+    /// stripped, etc.). `text` is trimmed before scanning so a
+    /// single-line selection with leading/trailing whitespace still hits.
+    public static func detectURL(
+        in text: String,
+        allowedSchemes: Set<String>
+    ) -> URL? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let detector = try? NSDataDetector(
+            types: NSTextCheckingResult.CheckingType.link.rawValue
+        )
+        guard let detector else { return nil }
+        let range = NSRange(trimmed.startIndex..<trimmed.endIndex, in: trimmed)
+        for match in detector.matches(in: trimmed, range: range) {
+            guard let url = match.url,
+                  let scheme = url.scheme?.lowercased(),
+                  allowedSchemes.contains(scheme) else { continue }
+            return url
+        }
+        return nil
+    }
+
+    /// Match `path/to/file.ext:LINE` (optional `:COLUMN`) in a trimmed
+    /// selection. Reject anything that doesn't look like a file reference
+    /// — must contain a period in the basename, must not contain a scheme
+    /// (`://`), and must have a numeric line component. Caller resolves
+    /// the path against the live filesystem; we do not check existence here
+    /// so the function stays pure.
+    public static func detectFileLine(in text: String) -> (path: String, line: Int)? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains("://") else { return nil }
+
+        // Path may include `/`, `.`, `_`, `-`, alnum. No whitespace, no `:`.
+        // Basename must contain a dot so we don't grab `foo:42` arbitrarily.
+        let pattern = #"^([^\s:]+\.[A-Za-z0-9_]+):(\d+)(?::\d+)?$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsrange = NSRange(trimmed.startIndex..<trimmed.endIndex, in: trimmed)
+        guard let match = regex.firstMatch(in: trimmed, range: nsrange),
+              match.numberOfRanges >= 3,
+              let pathRange = Range(match.range(at: 1), in: trimmed),
+              let lineRange = Range(match.range(at: 2), in: trimmed),
+              let line = Int(trimmed[lineRange]) else { return nil }
+        return (String(trimmed[pathRange]), line)
+    }
+}

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
@@ -13,6 +13,10 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
     private let nextButton = NSButton()
     private let doneButton = NSButton()
     private weak var hostSurface: NSView?
+    /// True once Enter has issued an initial search query. Gates ▲/▼ so
+    /// `search-again` / `search-reverse` don't fire before tmux has an
+    /// anchor match to step from.
+    private var hasActiveSearch = false
 
     public override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -88,6 +92,15 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
     }
 
     @objc private func handleBeginSearch() {
+        // Only un-hide if this bar's container currently hosts the
+        // shared cockpit surface. The cockpit surface is re-parented
+        // between per-tab containers (see `TerminalSurfaceView` header),
+        // so each container persists its own bar — observing the bare
+        // notification would un-hide every previously-rendered tab's bar
+        // at once.
+        guard let surface = hostSurface, surface.superview === self.superview else {
+            return
+        }
         isHidden = false
         window?.makeFirstResponder(searchField)
         searchField.selectText(nil)
@@ -95,6 +108,7 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
 
     @objc private func closeSearch() {
         searchField.stringValue = ""
+        hasActiveSearch = false
         isHidden = true
         if let id = TmuxBackend.shared.activeTerminalID {
             try? TmuxBackend.shared.exitCopyMode(id: id)
@@ -104,28 +118,46 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
         }
     }
 
-    @objc private func findPrevious() {
+    /// Run a fresh backward search from the cursor against the field's
+    /// current query. Invoked by Enter; resets `hasActiveSearch` so the
+    /// ▲/▼ buttons can step through matches via `search-again` /
+    /// `search-reverse` without re-issuing the query.
+    private func submitSearch() {
         guard let id = TmuxBackend.shared.activeTerminalID else { return }
         let query = searchField.stringValue
+        guard !query.isEmpty else { return }
         do {
-            if query.isEmpty {
-                try TmuxBackend.shared.searchAgain(id: id, reverse: false)
-            } else {
-                try TmuxBackend.shared.searchInScrollback(
-                    id: id, query: query, direction: .backward
-                )
-            }
+            try TmuxBackend.shared.searchInScrollback(
+                id: id, query: query, direction: .backward
+            )
+            hasActiveSearch = true
         } catch {
             NSLog("[TerminalSearchBar] search failed: \(error)")
         }
     }
 
+    @objc private func findPrevious() {
+        // ▲ steps further in the same direction as the last search
+        // (backward, by default). No-op until Enter has issued an
+        // initial query — without an active search tmux has no anchor
+        // to step from.
+        guard hasActiveSearch, let id = TmuxBackend.shared.activeTerminalID else { return }
+        do {
+            try TmuxBackend.shared.searchAgain(id: id, reverse: false)
+        } catch {
+            NSLog("[TerminalSearchBar] search-again failed: \(error)")
+        }
+    }
+
     @objc private func findNext() {
-        guard let id = TmuxBackend.shared.activeTerminalID else { return }
+        // ▼ flips direction (`search-reverse`) so the user can walk
+        // forward through matches after stepping back too far. Mirrors
+        // ▲'s no-op-before-initial-search semantics.
+        guard hasActiveSearch, let id = TmuxBackend.shared.activeTerminalID else { return }
         do {
             try TmuxBackend.shared.searchAgain(id: id, reverse: true)
         } catch {
-            NSLog("[TerminalSearchBar] search again failed: \(error)")
+            NSLog("[TerminalSearchBar] search-reverse failed: \(error)")
         }
     }
 
@@ -139,8 +171,9 @@ public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
             return true
         }
         if commandSelector == #selector(NSResponder.insertNewline(_:)) {
-            // Enter triggers a new backward search from the current cursor.
-            findPrevious()
+            // Enter triggers a fresh backward search; ▲/▼ then step
+            // through matches without re-running the query.
+            submitSearch()
             return true
         }
         return false

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSearchBar.swift
@@ -1,0 +1,154 @@
+import AppKit
+import Foundation
+
+/// Floating search affordance pinned to the top of a terminal container
+/// (#471 gap 2). Cmd+F in the surface toggles visibility via the
+/// `.terminalBeginSearch` notification; ESC or the Done button hides it.
+/// All search work is dispatched to `TmuxBackend` against the active
+/// terminal — the bar itself owns no tmux state.
+@MainActor
+public final class TerminalSearchBar: NSView, NSSearchFieldDelegate {
+    private let searchField = NSSearchField()
+    private let prevButton = NSButton()
+    private let nextButton = NSButton()
+    private let doneButton = NSButton()
+    private weak var hostSurface: NSView?
+
+    public override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.windowBackgroundColor
+            .withAlphaComponent(0.92).cgColor
+        layer?.cornerRadius = 6
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.separatorColor.cgColor
+
+        searchField.placeholderString = "Find in terminal"
+        searchField.delegate = self
+        searchField.sendsSearchStringImmediately = false
+        searchField.sendsWholeSearchString = true
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+
+        configure(button: prevButton, symbol: "chevron.up", fallback: "▲", action: #selector(findPrevious))
+        configure(button: nextButton, symbol: "chevron.down", fallback: "▼", action: #selector(findNext))
+        configure(button: doneButton, symbol: nil, fallback: "Done", action: #selector(closeSearch))
+
+        let stack = NSStackView(views: [searchField, prevButton, nextButton, doneButton])
+        stack.orientation = .horizontal
+        stack.spacing = 6
+        stack.edgeInsets = NSEdgeInsets(top: 6, left: 8, bottom: 6, right: 8)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 220),
+        ])
+
+        isHidden = true
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleBeginSearch),
+            name: .terminalBeginSearch,
+            object: nil
+        )
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /// Track the surface the bar floats over so we can hand focus back to
+    /// the terminal when the user closes the bar.
+    public func setHostSurface(_ surface: NSView?) {
+        hostSurface = surface
+    }
+
+    private func configure(
+        button: NSButton, symbol: String?, fallback: String, action: Selector
+    ) {
+        button.bezelStyle = .rounded
+        button.target = self
+        button.action = action
+        if let symbol,
+           let img = NSImage(systemSymbolName: symbol, accessibilityDescription: fallback) {
+            button.image = img
+            button.title = ""
+        } else {
+            button.title = fallback
+        }
+        button.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    @objc private func handleBeginSearch() {
+        isHidden = false
+        window?.makeFirstResponder(searchField)
+        searchField.selectText(nil)
+    }
+
+    @objc private func closeSearch() {
+        searchField.stringValue = ""
+        isHidden = true
+        if let id = TmuxBackend.shared.activeTerminalID {
+            try? TmuxBackend.shared.exitCopyMode(id: id)
+        }
+        if let surface = hostSurface {
+            window?.makeFirstResponder(surface)
+        }
+    }
+
+    @objc private func findPrevious() {
+        guard let id = TmuxBackend.shared.activeTerminalID else { return }
+        let query = searchField.stringValue
+        do {
+            if query.isEmpty {
+                try TmuxBackend.shared.searchAgain(id: id, reverse: false)
+            } else {
+                try TmuxBackend.shared.searchInScrollback(
+                    id: id, query: query, direction: .backward
+                )
+            }
+        } catch {
+            NSLog("[TerminalSearchBar] search failed: \(error)")
+        }
+    }
+
+    @objc private func findNext() {
+        guard let id = TmuxBackend.shared.activeTerminalID else { return }
+        do {
+            try TmuxBackend.shared.searchAgain(id: id, reverse: true)
+        } catch {
+            NSLog("[TerminalSearchBar] search again failed: \(error)")
+        }
+    }
+
+    public func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        doCommandBy commandSelector: Selector
+    ) -> Bool {
+        if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+            closeSearch()
+            return true
+        }
+        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            // Enter triggers a new backward search from the current cursor.
+            findPrevious()
+            return true
+        }
+        return false
+    }
+}
+
+public extension Notification.Name {
+    /// Posted by `GhosttySurfaceView` when the user hits Cmd+F. Observed
+    /// by `TerminalSearchBar` to show itself.
+    static let terminalBeginSearch = Notification.Name("com.crow.terminal.beginSearch")
+}

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TerminalSurfaceView.swift
@@ -94,6 +94,19 @@ public struct TerminalSurfaceView: NSViewRepresentable {
             surface.topAnchor.constraint(equalTo: container.topAnchor),
             surface.bottomAnchor.constraint(equalTo: container.bottomAnchor),
         ])
+
+        // Float the Cmd+F search bar over the surface (#471 gap 2). Only
+        // install one per container; later re-parents keep the same bar.
+        if container.subviews.contains(where: { $0 is TerminalSearchBar }) == false {
+            let bar = TerminalSearchBar(frame: .zero)
+            bar.translatesAutoresizingMaskIntoConstraints = false
+            bar.setHostSurface(surface)
+            container.addSubview(bar)
+            NSLayoutConstraint.activate([
+                bar.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+                bar.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+            ])
+        }
     }
 
     @MainActor

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -393,6 +393,105 @@ public final class TmuxBackend {
         }
     }
 
+    /// Direction for `searchInScrollback`. `backward` walks toward older
+    /// output (the common case for Cmd+F on terminal history); `forward`
+    /// walks toward newer output.
+    public enum SearchDirection {
+        case backward
+        case forward
+    }
+
+    /// Enter tmux copy-mode and start a search for `query` in the
+    /// scrollback of terminal `id` (#471 gap 2). Powers the Cmd+F search
+    /// affordance. `tmux send-keys -X search-backward "<query>"` jumps the
+    /// copy-mode cursor to the most recent match; subsequent calls to
+    /// `searchAgain` step through additional matches without re-running
+    /// the search. The pane stays in copy-mode until the caller invokes
+    /// `exitCopyMode` (or the user hits ESC).
+    public func searchInScrollback(
+        id: UUID,
+        query: String,
+        direction: SearchDirection
+    ) throws {
+        guard !query.isEmpty else { return }
+        guard let windowIndex = bindings[id] else {
+            throw TmuxBackendError.unknownTerminal(id)
+        }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            _ = try ctrl.run(["copy-mode", "-H", "-t", target])
+            let command = direction == .backward ? "search-backward" : "search-forward"
+            try ctrl.sendKeys(target: target, keys: ["-X", command, query])
+        } catch {
+            reportIfTimeout(error)
+            throw error
+        }
+    }
+
+    /// Step to the next/previous match for the active search in terminal
+    /// `id`'s copy-mode (#471 gap 2). Maps to `search-again` /
+    /// `search-reverse` per tmux's own conventions.
+    public func searchAgain(id: UUID, reverse: Bool) throws {
+        guard let windowIndex = bindings[id] else {
+            throw TmuxBackendError.unknownTerminal(id)
+        }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            let command = reverse ? "search-reverse" : "search-again"
+            try ctrl.sendKeys(target: target, keys: ["-X", command])
+        } catch {
+            reportIfTimeout(error)
+            throw error
+        }
+    }
+
+    /// Leave copy-mode in terminal `id`, restoring normal shell input.
+    /// Used by the search bar's Done button (#471 gap 2) and by callers
+    /// that want to abandon a prompt-jump (#471 gap 6).
+    public func exitCopyMode(id: UUID) throws {
+        guard let windowIndex = bindings[id] else {
+            throw TmuxBackendError.unknownTerminal(id)
+        }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            try ctrl.sendKeys(target: target, keys: ["-X", "cancel"])
+        } catch {
+            reportIfTimeout(error)
+            throw error
+        }
+    }
+
+    /// Jump the copy-mode cursor to the previous OSC 133;A prompt-start
+    /// marker in terminal `id` (#471 gap 6). Requires the shell wrapper
+    /// to emit a non-passthrough OSC 133;A so tmux's emulator sees it.
+    /// Enters copy-mode if not already there.
+    public func previousPrompt(id: UUID) throws {
+        try sendPromptNav(id: id, command: "previous-prompt")
+    }
+
+    /// Sibling of `previousPrompt`. Steps forward through OSC 133;A marks.
+    public func nextPrompt(id: UUID) throws {
+        try sendPromptNav(id: id, command: "next-prompt")
+    }
+
+    private func sendPromptNav(id: UUID, command: String) throws {
+        guard let windowIndex = bindings[id] else {
+            throw TmuxBackendError.unknownTerminal(id)
+        }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            _ = try ctrl.run(["copy-mode", "-H", "-t", target])
+            try ctrl.sendKeys(target: target, keys: ["-X", command])
+        } catch {
+            reportIfTimeout(error)
+            throw error
+        }
+    }
+
     /// Destroy the tmux window backing `id` and forget the binding.
     public func destroyTerminal(id: UUID) {
         if let windowIndex = bindings[id] {

--- a/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
+++ b/Packages/CrowTerminal/Sources/CrowTerminal/TmuxBackend.swift
@@ -393,6 +393,27 @@ public final class TmuxBackend {
         }
     }
 
+    /// Read the live working directory of terminal `id`'s pane via
+    /// `tmux display-message -p -F '#{pane_current_path}'`. Used by
+    /// smart-detect `path:line` resolution (#471 gap 5) to honour the
+    /// pane's *current* cwd rather than the cockpit surface's static
+    /// `workingDirectory` (which is fixed to `$HOME` at create time and
+    /// never tracks the shell's `cd`s). Returns nil on any error so the
+    /// caller can fall back without crashing.
+    public func activePaneCwd(id: UUID) -> String? {
+        guard let windowIndex = bindings[id] else { return nil }
+        do {
+            let ctrl = try ensureRunningServer()
+            let target = "\(ctrl.sessionName):\(windowIndex)"
+            let raw = try ctrl.displayMessage(target: target, format: "#{pane_current_path}")
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        } catch {
+            reportIfTimeout(error)
+            return nil
+        }
+    }
+
     /// Direction for `searchInScrollback`. `backward` walks toward older
     /// output (the common case for Cmd+F on terminal history); `forward`
     /// walks toward newer output.

--- a/Packages/CrowTerminal/Tests/CrowTerminalTests/SmartDetectTests.swift
+++ b/Packages/CrowTerminal/Tests/CrowTerminalTests/SmartDetectTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import CrowTerminal
+
+@Suite("SmartDetect URL and file:line heuristics")
+struct SmartDetectTests {
+    private let schemes: Set<String> = ["http", "https", "mailto"]
+
+    // MARK: - detectURL
+
+    @Test func detectsHttpsURLInPlainSelection() {
+        let url = SmartDetect.detectURL(
+            in: "https://github.com/radiusmethod/crow",
+            allowedSchemes: schemes
+        )
+        #expect(url?.absoluteString == "https://github.com/radiusmethod/crow")
+    }
+
+    @Test func detectURLTolersWhitespace() {
+        let url = SmartDetect.detectURL(
+            in: "   https://example.com   ",
+            allowedSchemes: schemes
+        )
+        #expect(url?.host == "example.com")
+    }
+
+    @Test func detectURLDropsDisallowedSchemes() {
+        let url = SmartDetect.detectURL(
+            in: "file:///etc/passwd",
+            allowedSchemes: schemes
+        )
+        #expect(url == nil)
+    }
+
+    @Test func detectURLPicksFirstAllowedHit() {
+        let text = "see http://a.test then https://b.test"
+        let url = SmartDetect.detectURL(in: text, allowedSchemes: schemes)
+        #expect(url?.host == "a.test")
+    }
+
+    @Test func detectURLEmptyOrNoMatch() {
+        #expect(SmartDetect.detectURL(in: "", allowedSchemes: schemes) == nil)
+        #expect(SmartDetect.detectURL(in: "just text", allowedSchemes: schemes) == nil)
+    }
+
+    // MARK: - detectFileLine
+
+    @Test func detectsBasicPathLine() throws {
+        let hit = try #require(SmartDetect.detectFileLine(in: "Sources/Foo.swift:42"))
+        #expect(hit.path == "Sources/Foo.swift")
+        #expect(hit.line == 42)
+    }
+
+    @Test func detectsPathLineColumn() throws {
+        let hit = try #require(SmartDetect.detectFileLine(in: "src/main.rs:10:5"))
+        #expect(hit.path == "src/main.rs")
+        #expect(hit.line == 10)
+    }
+
+    @Test func detectsAbsolutePath() throws {
+        let hit = try #require(SmartDetect.detectFileLine(in: "/usr/local/lib/foo.swift:1"))
+        #expect(hit.path == "/usr/local/lib/foo.swift")
+        #expect(hit.line == 1)
+    }
+
+    @Test func rejectsURLLike() {
+        // Should not collide with `detectURL` — schemes contain `://`.
+        #expect(SmartDetect.detectFileLine(in: "https://github.com:443") == nil)
+    }
+
+    @Test func rejectsExtensionlessPath() {
+        // Basename must have a dot so we don't grab e.g. `foo:42` from
+        // a random shell prompt token.
+        #expect(SmartDetect.detectFileLine(in: "build:42") == nil)
+    }
+
+    @Test func rejectsMissingLine() {
+        #expect(SmartDetect.detectFileLine(in: "Sources/Foo.swift") == nil)
+    }
+
+    @Test func trimsWhitespace() throws {
+        let hit = try #require(SmartDetect.detectFileLine(in: "  Sources/Foo.swift:7  "))
+        #expect(hit.path == "Sources/Foo.swift")
+        #expect(hit.line == 7)
+    }
+}


### PR DESCRIPTION
Closes #471.

Implements the six confirmed gaps surfaced by the #469 audit, in one PR per the ticket scope.

## Summary

- **Gap 1 — I-beam cursor.** `resetCursorRects` now registers `.iBeam` over the whole bounds; `.pointingHand` still wins on hovered OSC 8 links because AppKit picks the last-registered rect containing the point.
- **Gap 2 — Cmd+F search.** New `TerminalSearchBar` (NSSearchField + ▲/▼/Done) floats over the cockpit surface, observes a `.terminalBeginSearch` notification posted from `keyDown` (scoped to the container that currently hosts the shared surface), and drives tmux copy-mode. Enter issues a fresh `search-backward`; ▲ / ▼ then step via `search-again` / `search-reverse` without re-running the query. ESC or Done exits copy-mode.
- **Gap 3 — Multi-line paste guard.** `paste(_:)` detects `\n` / `\r` (ignoring a single trailing newline so `"git status\n"` doesn't prompt) and shows an `NSAlert` sheet ("Paste" / "Cancel") before forwarding to libghostty. Single-line pastes are unchanged.
- **Gap 4 — Spacebar Quick Look.** Bare space with a selection that `SmartDetect` recognises (URL or `path:line`) opens `QLPreviewPanel` against the URL or the resolved file URL. Plain-text selections always pass space through to the shell, so a stale selection can't hijack typed input.
- **Gap 5 — Smart-detect URLs and `path:line`.** New pure `SmartDetect` helpers (`detectURL`, `detectFileLine`) feed the right-click "Open URL" / "Open in Editor" menu items. Editor opens are gated to existing regular files (no directories / `.app` bundles), and relative paths resolve against tmux's live `#{pane_current_path}` via new `TmuxBackend.activePaneCwd(id:)` — not the surface's static `workingDirectory` (which is fixed to `$HOME` at create time and never tracks `cd`). Line numbers are intentionally dropped on open (cross-editor line-jump needs a configurable URL scheme; deferred). Unit tests cover the detectors. *Note: Cmd+click smart-detect was considered but dropped — libghostty doesn't expose text-at-point, so the click can't be hit-tested against the detected URL; a global "Cmd+click anywhere opens the selected URL" would override macOS Terminal's selection-extend convention.*
- **Gap 6 — Cmd+↑ / Cmd+↓ prompt jump.** Bound to tmux's `previous-prompt` / `next-prompt` copy-mode commands. The shell wrapper now also emits a bare `OSC 133;A` under tmux (the existing passthrough form still reaches Ghostty), so tmux's emulator can track marks for navigation. Requires tmux ≥ 3.4; older tmux errors are caught and logged non-fatally.

Shared helpers extracted while touching `GhosttySurfaceView.swift`:

- `currentSelectionText()` (used by Copy, smart-detect, Quick Look)
- `forwardPaste(_:)` (used by direct paste and the confirm-sheet handler)

## Test plan

- [ ] `make ghostty && swift build --arch arm64` (passes locally)
- [ ] Hover non-link content → I-beam; hover an OSC 8 link → pointing-hand.
- [ ] Cmd+F → search bar slides in over the active tab only; query a token from scrollback → cursor jumps; ▲/▼ step through matches; ESC closes.
- [ ] Copy `foo\nbar` to clipboard, Cmd+V → confirmation sheet. Copy `git status\n` (single trailing newline) → forwards without prompt.
- [ ] Drag-select random terminal output, hit Space → space reaches the shell (no Quick Look). Select a URL or a `path:line` reference that resolves, hit Space → Quick Look opens against the URL or file.
- [ ] Select `https://github.com` → right-click → "Open URL" enabled. Select `Sources/Foo.swift:42` from a project-dir prompt → right-click → "Open in Editor" enabled (resolves against tmux's live cwd, not `$HOME`).
- [ ] Run a few commands so multiple prompts exist; Cmd+↑ → jumps to previous prompt (enters copy-mode); Cmd+↓ → next prompt; ESC exits copy-mode.
- [ ] Existing #469 / #470 behaviour (right-click menu, OSC 8 hover, click-to-deselect) still works.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow