### PR TITLE
Per-workspace exclude-repos for code review requests

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/AppConfig.swift
@@ -66,6 +66,14 @@ public struct AppConfig: Codable, Sendable, Equatable {
     /// apply to non-Manager sessions only (CROW-402).
     public var managerGateway: WorkspaceGateway?
 
+    /// Effective review-exclude patterns: the global `defaults.excludeReviewRepos`
+    /// unioned with every workspace's per-workspace `excludeReviewRepos`. A repo
+    /// excluded by any workspace (or the global default) is hidden from the review
+    /// board. Order is irrelevant — `repoMatchesPatterns` matches on any pattern.
+    public var effectiveExcludeReviewRepos: [String] {
+        defaults.excludeReviewRepos + workspaces.flatMap(\.excludeReviewRepos)
+    }
+
     public init(
         workspaces: [WorkspaceInfo] = [],
         defaults: ConfigDefaults = ConfigDefaults(),
@@ -268,6 +276,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
     public var host: String?          // GitLab host (e.g., "gitlab.example.com")
     public var alwaysInclude: [String] // repos to always list in prompt table
     public var autoReviewRepos: [String] // repos where review requests auto-create a review session
+    public var excludeReviewRepos: [String] // repos whose review requests are hidden from the review board
     public var customInstructions: String? // free-text instructions appended to session prompts
     /// Optional AI gateway. When set, `claude` launches into this workspace
     /// inherit `ANTHROPIC_BASE_URL`/`ANTHROPIC_CUSTOM_HEADERS` derived from it;
@@ -312,6 +321,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         host: String? = nil,
         alwaysInclude: [String] = [],
         autoReviewRepos: [String] = [],
+        excludeReviewRepos: [String] = [],
         customInstructions: String? = nil,
         taskProvider: String? = nil,
         jiraProjectKey: String? = nil,
@@ -326,6 +336,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         self.host = host
         self.alwaysInclude = alwaysInclude
         self.autoReviewRepos = autoReviewRepos
+        self.excludeReviewRepos = excludeReviewRepos
         self.customInstructions = customInstructions
         self.taskProvider = taskProvider
         self.jiraProjectKey = jiraProjectKey
@@ -343,6 +354,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
         host = try container.decodeIfPresent(String.self, forKey: .host)
         alwaysInclude = try container.decodeIfPresent([String].self, forKey: .alwaysInclude) ?? []
         autoReviewRepos = try container.decodeIfPresent([String].self, forKey: .autoReviewRepos) ?? []
+        excludeReviewRepos = try container.decodeIfPresent([String].self, forKey: .excludeReviewRepos) ?? []
         customInstructions = try container.decodeIfPresent(String.self, forKey: .customInstructions)
         taskProvider = try container.decodeIfPresent(String.self, forKey: .taskProvider)
         jiraProjectKey = try container.decodeIfPresent(String.self, forKey: .jiraProjectKey)
@@ -352,7 +364,7 @@ public struct WorkspaceInfo: Identifiable, Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, provider, cli, host, alwaysInclude, autoReviewRepos, customInstructions
+        case id, name, provider, cli, host, alwaysInclude, autoReviewRepos, excludeReviewRepos, customInstructions
         case taskProvider, jiraProjectKey, jiraJQL, jiraSite, gateway
     }
 

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppConfigTests.swift
@@ -242,6 +242,52 @@ import Testing
     #expect(config.workspaces[0].alwaysInclude.isEmpty)
 }
 
+@Test func workspaceExcludeReviewReposRoundTrip() throws {
+    let config = AppConfig(workspaces: [
+        WorkspaceInfo(name: "Org", excludeReviewRepos: ["org/repo1", "org/*"])
+    ])
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.workspaces[0].excludeReviewRepos == ["org/repo1", "org/*"])
+}
+
+@Test func workspaceExcludeReviewReposDefaultsEmptyWhenKeyMissing() throws {
+    // Legacy configs without the key should default to empty (feature off).
+    let json = """
+    {"workspaces": [{"id": "00000000-0000-0000-0000-000000000001", "name": "Org", "provider": "github", "cli": "gh"}]}
+    """.data(using: .utf8)!
+    let config = try JSONDecoder().decode(AppConfig.self, from: json)
+    #expect(config.workspaces[0].excludeReviewRepos.isEmpty)
+}
+
+@Test func effectiveExcludeReviewReposUnionsGlobalAndWorkspaces() {
+    // Effective set is the global default unioned with every workspace's list.
+    var config = AppConfig(workspaces: [
+        WorkspaceInfo(name: "Org1", excludeReviewRepos: ["ws1/repo"]),
+        WorkspaceInfo(name: "Org2"), // empty — contributes nothing
+        WorkspaceInfo(name: "Org3", excludeReviewRepos: ["ws3/*"])
+    ])
+    config.defaults.excludeReviewRepos = ["global/*"]
+
+    let effective = config.effectiveExcludeReviewRepos
+    #expect(effective.contains("global/*"))
+    #expect(effective.contains("ws1/repo"))
+    #expect(effective.contains("ws3/*"))
+
+    // A repo excluded by any workspace (or the global default) is matched.
+    #expect(repoMatchesPatterns("ws1/repo", patterns: effective) == true)
+    #expect(repoMatchesPatterns("global/anything", patterns: effective) == true)
+    #expect(repoMatchesPatterns("ws3/something", patterns: effective) == true)
+    // A repo excluded by no one is not matched.
+    #expect(repoMatchesPatterns("other/repo", patterns: effective) == false)
+}
+
+@Test func effectiveExcludeReviewReposEmptyWhenNothingConfigured() {
+    // No global and no per-workspace exclusions → empty effective set, no filtering.
+    let config = AppConfig(workspaces: [WorkspaceInfo(name: "Org")])
+    #expect(config.effectiveExcludeReviewRepos.isEmpty)
+}
+
 @Test func workspaceCustomInstructionsRoundTrip() throws {
     let config = AppConfig(workspaces: [
         WorkspaceInfo(name: "Org", customInstructions: "Always run npm test before committing")

--- a/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
@@ -21,6 +21,7 @@ public struct WorkspaceFormView: View {
     @State private var jiraJQL: String
     @State private var alwaysIncludeText: String
     @State private var autoReviewReposText: String
+    @State private var excludeReviewReposText: String
     @State private var customInstructionsText: String
     @State private var gatewayBaseURL: String
     @State private var gatewayHeadersText: String
@@ -51,6 +52,7 @@ public struct WorkspaceFormView: View {
         self._jiraJQL = State(initialValue: workspace?.jiraJQL ?? "")
         self._alwaysIncludeText = State(initialValue: workspace?.alwaysInclude.joined(separator: ", ") ?? "")
         self._autoReviewReposText = State(initialValue: workspace?.autoReviewRepos.joined(separator: ", ") ?? "")
+        self._excludeReviewReposText = State(initialValue: workspace?.excludeReviewRepos.joined(separator: ", ") ?? "")
         self._customInstructionsText = State(initialValue: workspace?.customInstructions ?? "")
         self._gatewayBaseURL = State(initialValue: workspace?.gateway?.baseURL ?? "")
         self._gatewayHeadersText = State(initialValue: workspace?.gateway.map {
@@ -176,6 +178,12 @@ public struct WorkspaceFormView: View {
                 Text("Comma-separated repos or patterns (e.g. org/repo, org/*). New review requests from matching repos will automatically create a review session.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                TextField("Excluded Review Repos", text: $excludeReviewReposText)
+                    .textFieldStyle(.roundedBorder)
+                Text("Comma-separated repos or patterns (e.g. org/repo, org/*). Review requests from matching repos are hidden from the review board and don't trigger notifications.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Custom Instructions") {
@@ -236,6 +244,7 @@ public struct WorkspaceFormView: View {
     private func buildWorkspace() -> WorkspaceInfo {
         let alwaysInclude = parseCSV(alwaysIncludeText)
         let autoReviewRepos = parseCSV(autoReviewReposText)
+        let excludeReviewRepos = parseCSV(excludeReviewReposText)
         let trimmedInstructions = customInstructionsText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // Persist taskProvider only when it diverges from the code provider;
@@ -251,6 +260,7 @@ public struct WorkspaceFormView: View {
             host: provider == "gitlab" && !host.isEmpty ? host : nil,
             alwaysInclude: alwaysInclude,
             autoReviewRepos: autoReviewRepos,
+            excludeReviewRepos: excludeReviewRepos,
             customInstructions: trimmedInstructions.isEmpty ? nil : trimmedInstructions,
             taskProvider: resolvedTaskProvider,
             jiraProjectKey: isJira ? nonEmpty(jiraProjectKey) : nil,

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -460,7 +460,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
-        appState.excludeReviewRepos = config.defaults.excludeReviewRepos
+        appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
         appState.defaultAgentKind = config.defaultAgentKind
@@ -1122,7 +1122,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.remoteControlEnabled = config.remoteControlEnabled
         appState.managerAutoPermissionMode = config.managerAutoPermissionMode
         appState.jobsAutoPermissionMode = config.jobsAutoPermissionMode
-        appState.excludeReviewRepos = config.defaults.excludeReviewRepos
+        appState.excludeReviewRepos = config.effectiveExcludeReviewRepos
         appState.excludeTicketRepos = config.defaults.excludeTicketRepos
         appState.ignoreReviewLabels = config.defaults.ignoreReviewLabels
         appState.defaultAgentKind = config.defaultAgentKind

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -442,7 +442,7 @@ final class IssueTracker {
                 }
             }
             let allCurrentIDs = Set(reviews.map(\.id))
-            let reviewExcludePatterns = config.defaults.excludeReviewRepos
+            let reviewExcludePatterns = config.effectiveExcludeReviewRepos
             if !reviewExcludePatterns.isEmpty {
                 reviews = reviews.filter { !repoMatchesPatterns($0.repo, patterns: reviewExcludePatterns) }
             }


### PR DESCRIPTION
Closes #480

## What

Adds a **per-workspace** "Excluded Review Repos" setting so a workspace can hide review requests from specific repos. Previously review exclusion was **global-only** (`defaults.excludeReviewRepos`, surfaced in the Automation settings tab).

## Changes

- **Model** — `excludeReviewRepos: [String]` on `WorkspaceInfo` (mirrors `autoReviewRepos`; defaults to `[]` so existing configs are unchanged).
- **Union helper** — `AppConfig.effectiveExcludeReviewRepos` unions the global default with every workspace's per-workspace list. A repo excluded by **any** workspace (or the global default) is hidden from the review board.
- **Form UI** — "Excluded Review Repos" `TextField` in `WorkspaceFormView` (Repos section, next to "Auto-Review Repos"). Comma-separated, same wildcard convention (`org/repo`, `org/*`).
- **Filtering** — both filter sites now use the unioned effective set:
  - `IssueTracker.refresh` poll-time filter (also gates new-review notifications).
  - `AppState.filteredReviewRequests` (review-board display) via `AppDelegate` wiring.

## Acceptance criteria

- ✅ Workspace can specify repos to exclude in the Workspace settings form; value persists to the workspace config.
- ✅ Review requests from an excluded repo no longer appear on the review board and don't trigger notifications (excluded by any workspace or the global default).
- ✅ Existing global `defaults.excludeReviewRepos` behavior preserved; empty per-workspace lists change nothing.
- ✅ Wildcards behave the same as the global field.

## Tests

Added to `AppConfigTests`: union semantics (`effectiveExcludeReviewReposUnionsGlobalAndWorkspaces`), round-trip, and legacy-decode-defaults-to-empty. Full suite (260 tests) passes; `make app` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)