### PR TITLE
Hot-trigger corveil skill install when picker value changes (CROW-490)

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -275,14 +275,7 @@ public struct SettingsView: View {
                 HStack {
                     TextField("Path to corveil binary", text: corveilBinding)
                         .textFieldStyle(.roundedBorder)
-                        .onSubmit {
-                            save()
-                            // Hot-trigger install on Enter — passes nil if the
-                            // user committed an empty field so callers can
-                            // clear any stale warning banner (CROW-490).
-                            let path = corveilBinding.wrappedValue
-                            onCorveilReinstall?(path.isEmpty ? nil : path)
-                        }
+                        .onSubmit { commitCorveilPath() }
                     Button("Browse...") {
                         let panel = NSOpenPanel()
                         panel.canChooseFiles = true
@@ -290,11 +283,9 @@ public struct SettingsView: View {
                         panel.allowsMultipleSelection = false
                         if panel.runModal() == .OK, let url = panel.url {
                             corveilBinding.wrappedValue = url.path
-                            save()
                             // Clear stale verify result — it's about a previous binary.
                             corveilVerifyResult = nil
-                            // Hot-trigger install on Browse confirm (CROW-490).
-                            onCorveilReinstall?(url.path)
+                            commitCorveilPath()
                         }
                     }
                     Button(corveilVerifying ? "Verifying…" : "Verify") { verifyCorveil() }
@@ -610,6 +601,21 @@ public struct SettingsView: View {
 
     private func save() {
         onSave?(devRoot, config)
+    }
+
+    /// Commit a corveil picker change: persist the config and hot-trigger
+    /// the `/query-corveil` install for the new path (CROW-490). Both
+    /// commit sites (Browse confirm and TextField `onSubmit`) funnel
+    /// through here so the "persist → reinstall" pair stays atomic and
+    /// the `nil`-on-empty rule has a single source of truth. We read the
+    /// path through `corveilBinding.wrappedValue` rather than the raw
+    /// input so the binding's whitespace-trim normalization wins — the
+    /// install closure sees the same string that the next launch's
+    /// scaffolder would see.
+    private func commitCorveilPath() {
+        save()
+        let path = corveilBinding.wrappedValue
+        onCorveilReinstall?(path.isEmpty ? nil : path)
     }
 
     /// Two-way binding into `config.defaults.binaries["corveil"]` that treats

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -27,15 +27,24 @@ public struct SettingsView: View {
 
     public var onSave: ((String, AppConfig) -> Void)?
     public var onRescaffold: ((String) -> Void)?
+    /// Fired when the user commits a new value into the corveil picker
+    /// (Browse confirm or Enter on the TextField), so AppDelegate can
+    /// re-run just `Scaffolder.installCorveilSkill` instead of waiting for
+    /// the next app restart (CROW-490). `nil` argument means "the user
+    /// cleared the field" — the install is a no-op then but the caller
+    /// still gets the signal to clear any stale warning banner.
+    public var onCorveilReinstall: ((String?) -> Void)?
 
     public init(appState: AppState, devRoot: String, config: AppConfig,
                 onSave: ((String, AppConfig) -> Void)? = nil,
-                onRescaffold: ((String) -> Void)? = nil) {
+                onRescaffold: ((String) -> Void)? = nil,
+                onCorveilReinstall: ((String?) -> Void)? = nil) {
         self.appState = appState
         self._devRoot = State(initialValue: devRoot)
         self._config = State(initialValue: config)
         self.onSave = onSave
         self.onRescaffold = onRescaffold
+        self.onCorveilReinstall = onCorveilReinstall
     }
 
     /// Names of all workspaces except the one currently being edited.
@@ -266,7 +275,14 @@ public struct SettingsView: View {
                 HStack {
                     TextField("Path to corveil binary", text: corveilBinding)
                         .textFieldStyle(.roundedBorder)
-                        .onSubmit { save() }
+                        .onSubmit {
+                            save()
+                            // Hot-trigger install on Enter — passes nil if the
+                            // user committed an empty field so callers can
+                            // clear any stale warning banner (CROW-490).
+                            let path = corveilBinding.wrappedValue
+                            onCorveilReinstall?(path.isEmpty ? nil : path)
+                        }
                     Button("Browse...") {
                         let panel = NSOpenPanel()
                         panel.canChooseFiles = true
@@ -277,6 +293,8 @@ public struct SettingsView: View {
                             save()
                             // Clear stale verify result — it's about a previous binary.
                             corveilVerifyResult = nil
+                            // Hot-trigger install on Browse confirm (CROW-490).
+                            onCorveilReinstall?(url.path)
                         }
                     }
                     Button(corveilVerifying ? "Verifying…" : "Verify") { verifyCorveil() }

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -53,6 +53,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// replaced.
     private var reviewKickoffTail: Task<Void, Never>?
 
+    /// Tail of the serial corveil-skill-install queue. Settings picker
+    /// commits (`SettingsView.onCorveilReinstall`) chain new installs onto
+    /// this tail so two rapid picks don't race on `query-corveil.md`
+    /// (concurrent `corveil skill install` subprocesses writing the same
+    /// `--path`) or on `corveilSkillInstallWarning` (out-of-order
+    /// completion clobbering a fresher banner with a stale one). The last
+    /// committed path is also the last to write the banner. See the
+    /// CROW-490 review for the race this replaced.
+    private var corveilInstallTail: Task<Void, Never>?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Must be the very first call so the next exit (graceful or not)
         // lands somewhere readable. Also redirects stderr so Swift runtime
@@ -184,6 +194,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if i > 0 { await Task.yield() }
                 _ = await service.createReviewSession(prURL: url, selectAfterCreate: false)
             }
+        }
+    }
+
+    /// Hot-trigger a single `corveil skill install` run for a path the user
+    /// just committed in Settings (CROW-490). Mirrors the
+    /// `reviewKickoffTail` pattern: writes to `corveilInstallTail` happen
+    /// on the main actor, and each task awaits its predecessor before
+    /// running, so the last-committed path is also the last to update the
+    /// banner. The blocking subprocess runs in a nested `Task.detached`
+    /// (bounded by `Scaffolder.corveilInstallTimeout`) so it can't freeze
+    /// the Settings window, then the result is assigned back on main.
+    /// `nil` path is a deliberate no-op for the subprocess but still
+    /// clears any stale warning, matching the launch-time scaffolder's
+    /// "always assign" semantics at the `onRescaffold` call site.
+    @MainActor
+    private func enqueueCorveilInstall(path: String?, devRoot: String) {
+        let previous = corveilInstallTail
+        corveilInstallTail = Task { @MainActor [weak self] in
+            await previous?.value
+            let warning = await Task.detached {
+                let scaffolder = Scaffolder(devRoot: devRoot)
+                return scaffolder.installCorveilSkill(path)
+            }.value
+            self?.appState.corveilSkillInstallWarning = warning
         }
     }
 
@@ -1102,28 +1136,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             },
             onCorveilReinstall: { [weak self] newPath in
                 // CROW-490: when the user commits a new corveil binary path in
-                // Settings, re-run just the `corveil skill install` step —
+                // Settings, hot-trigger just the `corveil skill install` step —
                 // not the whole Scaffolder pass — so `/query-corveil` reflects
                 // the new binary without requiring an app restart.
                 //
-                // `installCorveilSkill` calls `proc.waitUntilExit()` (bounded
-                // by `Scaffolder.corveilInstallTimeout`), so it must run off
-                // the main thread or it would freeze the Settings window for
-                // up to 5s. Result is always assigned: `nil` (success or
-                // empty/cleared path) clears any prior banner; non-nil shows
-                // the same diagnostic the launch-time path produces via the
-                // existing `AppState.corveilSkillInstallWarning` surface.
-                guard let self else { return }
-                // `devRoot` is the non-optional local from the outer guard at
-                // `showSettings()` line 1066 — captured here so the closure
-                // doesn't need to re-unwrap `self.devRoot`.
-                Task.detached {
-                    let scaffolder = Scaffolder(devRoot: devRoot)
-                    let warning = scaffolder.installCorveilSkill(newPath)
-                    await MainActor.run {
-                        self.appState.corveilSkillInstallWarning = warning
-                    }
-                }
+                // `enqueueCorveilInstall` serializes back-to-back picks
+                // through `corveilInstallTail` (mirrors the `reviewKickoffTail`
+                // pattern) so two rapid commits can't race on
+                // `query-corveil.md` or on the warning banner.
+                self?.enqueueCorveilInstall(path: newPath, devRoot: devRoot)
             }
         )
 

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1099,6 +1099,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.appState.corveilSkillInstallWarning =
                         "Re-scaffold failed: \(error.localizedDescription)"
                 }
+            },
+            onCorveilReinstall: { [weak self] newPath in
+                // CROW-490: when the user commits a new corveil binary path in
+                // Settings, re-run just the `corveil skill install` step —
+                // not the whole Scaffolder pass — so `/query-corveil` reflects
+                // the new binary without requiring an app restart.
+                //
+                // `installCorveilSkill` calls `proc.waitUntilExit()` (bounded
+                // by `Scaffolder.corveilInstallTimeout`), so it must run off
+                // the main thread or it would freeze the Settings window for
+                // up to 5s. Result is always assigned: `nil` (success or
+                // empty/cleared path) clears any prior banner; non-nil shows
+                // the same diagnostic the launch-time path produces via the
+                // existing `AppState.corveilSkillInstallWarning` surface.
+                guard let self else { return }
+                // `devRoot` is the non-optional local from the outer guard at
+                // `showSettings()` line 1066 — captured here so the closure
+                // doesn't need to re-unwrap `self.devRoot`.
+                Task.detached {
+                    let scaffolder = Scaffolder(devRoot: devRoot)
+                    let warning = scaffolder.installCorveilSkill(newPath)
+                    await MainActor.run {
+                        self.appState.corveilSkillInstallWarning = warning
+                    }
+                }
             }
         )
 

--- a/Sources/Crow/App/Scaffolder.swift
+++ b/Sources/Crow/App/Scaffolder.swift
@@ -227,7 +227,12 @@ struct Scaffolder {
     /// window drawn yet. The hard wall-clock timeout bounds the worst case:
     /// after `corveilInstallTimeout` seconds the process is sent SIGTERM and
     /// the install reports a warning rather than blocking forever.
-    private func installCorveilSkill(_ corveilBinaryPath: String?) -> String? {
+    ///
+    /// Settings can also call this directly (CROW-490) when the user picks a
+    /// new corveil binary, to avoid the "must restart" gap. Those callers
+    /// dispatch the call off the main thread (`Task.detached`) so the 5s
+    /// worst-case doesn't freeze the Settings window.
+    func installCorveilSkill(_ corveilBinaryPath: String?) -> String? {
         guard let path = corveilBinaryPath?.trimmingCharacters(in: .whitespacesAndNewlines),
               !path.isEmpty else {
             return nil


### PR DESCRIPTION
## Summary

- Settings → Corveil CLI picker now re-runs `corveil skill install` the moment a new path is committed (Browse confirm or Enter), so `/query-corveil` reflects the picked binary without an app restart.
- Promoted `Scaffolder.installCorveilSkill` from private to internal and added a new `onCorveilReinstall` closure to `SettingsView` so AppDelegate can dispatch just the install step (off the main thread, bounded by the existing 5s `corveilInstallTimeout`) instead of re-running the whole `Scaffolder.scaffold(...)` pass.
- Result is always assigned to the existing `AppState.corveilSkillInstallWarning` banner — successful or empty/cleared paths clear stale warnings; failures show the same diagnostic as the launch-time path. Verify stays `--version` only.

Closes #490

## Test plan

- [ ] **Initial pick:** Clear `defaults.binaries.corveil` and delete `{devRoot}/.claude/commands/query-corveil.md`. Open Settings → Browse to a working corveil binary. Without restarting Crow, confirm `query-corveil.md` is created.
- [ ] **Path change:** Point the picker at a freshly rebuilt corveil binary. Confirm `query-corveil.md` content updates to match `<newPath> skill install --path /dev/stdout`.
- [ ] **Clear:** Empty the field and press Enter. `query-corveil.md` stays in place; any prior banner clears.
- [ ] **Broken path:** Browse to a non-executable file. Banner shows the same "Corveil skill install skipped — binary at … is missing or not executable" warning that the launch-time path produces. No crash.
- [ ] **Verify still `--version` only:** Click Verify with a stable path; `query-corveil.md` mtime is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)