### PR TITLE
Fix Codex launch — deliver prompt + drop deprecated/async hook config (CROW-492)

### DIFF
--- a/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
+++ b/Packages/CrowCodex/Sources/CrowCodex/OpenAICodexAgent.swift
@@ -50,10 +50,15 @@ public struct OpenAICodexAgent: CodingAgent {
         // log and skip rather than producing a malformed command.
         guard session.kind == .work else { return nil }
 
-        // Bare `codex` launch — the user types their prompt into the TUI.
-        // No env prefix (Codex has no OTEL equivalent), no `--continue`
-        // (MVP doesn't auto-resume), no `--rc` (Codex doesn't do remote
-        // control). The terminal's cwd is already the worktree path.
+        // Bare `codex` launch in-app. First-launch prompt delivery happens
+        // in the workspace skill (`crow-workspace/setup.sh launch_codex`),
+        // which passes the prompt file as Codex's positional argv before
+        // handing the terminal off to Crow. In-app re-launches resume the
+        // existing TUI rather than re-running the original prompt — same
+        // shape as `CursorAgent` `.work` (no `--continue` equivalent in MVP).
+        // No env prefix (Codex has no OTEL equivalent), no `--rc` (Codex
+        // doesn't do remote control). The terminal's cwd is already the
+        // worktree path.
         return "codex\n"
     }
 

--- a/Resources/crow-workspace-setup.sh.template
+++ b/Resources/crow-workspace-setup.sh.template
@@ -714,11 +714,11 @@ launch_codex() {
       die "launch_agent" "codex binary not found at PATH or known locations; provide --agent-binary"
   fi
   log "Resolved codex binary: $bin"
-  # Codex has no prompt-argv form (matches OpenAICodexAgent.autoLaunchCommand
-  # — bare `codex` only). The prompt file is still written; the user can
-  # paste from it into the TUI.
-  log "Note: Codex has no prompt-argv form; prompt file is at $prompt_path (paste manually if needed)."
-  local launch_cmd="cd $WORKTREE_PATH && $bin"
+  # Codex 0.129+ accepts the initial prompt as a positional argv that
+  # pre-fills the TUI composer — same mechanism Cursor's `agent` uses.
+  # The prompt-argv form was deferred in MVP because older Codex CLIs
+  # ignored extra argv; unblocked here (#492).
+  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
   create_agent_terminal "OpenAI Codex" "$launch_cmd"
 }
 

--- a/skills/crow-workspace/setup.sh
+++ b/skills/crow-workspace/setup.sh
@@ -837,11 +837,11 @@ launch_codex() {
       die "launch_agent" "codex binary not found at PATH or known locations; provide --agent-binary"
   fi
   log "Resolved codex binary: $bin"
-  # Codex has no prompt-argv form (matches OpenAICodexAgent.autoLaunchCommand
-  # — bare `codex` only). The prompt file is still written; the user can
-  # paste from it into the TUI.
-  log "Note: Codex has no prompt-argv form; prompt file is at $prompt_path (paste manually if needed)."
-  local launch_cmd="cd $WORKTREE_PATH && $bin"
+  # Codex 0.129+ accepts the initial prompt as a positional argv that
+  # pre-fills the TUI composer — same mechanism Cursor's `agent` uses.
+  # The prompt-argv form was deferred in MVP because older Codex CLIs
+  # ignored extra argv; unblocked here (#492).
+  local launch_cmd="cd $WORKTREE_PATH && $bin \"\$(cat $prompt_path)\""
   create_agent_terminal "OpenAI Codex" "$launch_cmd"
 }
 


### PR DESCRIPTION
Closes #492

## Summary
- **Bug 1 — Codex launched bare.** `launch_codex` in the workspace skill (and its template copy) now passes `\"\$(cat \$prompt_path)\"` as Codex's positional argv so the TUI starts with the ticket prompt pre-filled, matching Codex 0.129+ behavior and mirroring `launch_cursor`. The stale "Codex has no prompt-argv form" log + comment go with it. `OpenAICodexAgent.autoLaunchCommand` keeps the bare `codex\n` for in-app re-launches (matches `CursorAgent` `.work` shape); the misleading comment is refreshed to point at the skill as the first-launch prompt path.
- **Bug 2 — deprecated TOML key.** `CodexHookConfigWriter.installGlobalTomlConfig` now writes `[features].hooks = true` (renamed in Codex 0.129; the old `codex_hooks` alias emits a deprecation warning). Any legacy `codex_hooks` entry is migrated/removed via a new `removeTomlSectionLine` helper — idempotent on subsequent runs.
- **Bug 2 — unsupported async hooks.** Dropped `\"async\": true` from `PostToolUse` and `Stop` hook entries. Codex 0.139 still silently skips async hooks at execution, which meant `CodexSignalSource`'s state-signal pipeline (card-color updates, auto-respond, completion detection) was silently broken for those two events — not just noisy. All six hooks now run sync and reach Crow.

## Test plan
- [x] `arch -arm64 swift test --package-path Packages/CrowCodex` — all 31 tests pass, including:
  - `installGlobalTomlConfigCreatesFreshFile` updated to expect `hooks = true` and reject `codex_hooks`.
  - `installGlobalTomlConfigPreservesUserSettings` updated the same way.
  - New `installGlobalTomlConfigMigratesLegacyCodexHooksKey` — pre-seeds `codex_hooks = true`, asserts it is replaced with `hooks = true`, and asserts idempotency on a second run.
  - New `installGlobalConfigDoesNotDeclareAsyncHooks` — walks every event in `hooks.json` and asserts no entry sets `"async"`.
- [ ] Manual: launch a Codex coding session via the workspace skill — TUI opens with the ticket prompt already in the composer, zero startup warnings.
- [ ] Manual: pre-seed `~/.codex/config.toml` with `[features].codex_hooks = true`, restart Crow, confirm migration to `hooks = true`.
- [ ] Manual: trigger a tool call in a Codex session and watch the card color reflect `PreToolUse` → `PostToolUse` → `Stop`. None of this worked before.

🐦‍⬛ Generated with Claude Code, orchestrated by Crow