### PR TITLE
Session card: indicator for auto-merge sessions (CROW-504)

### DIFF
--- a/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SessionListView.swift
@@ -641,6 +641,13 @@ struct SessionRow: View {
                     RemoteControlBadge(compact: true)
                 }
                 Spacer()
+                if session.autoMergeEnabledAt != nil {
+                    Image(systemName: "arrow.triangle.merge")
+                        .font(.caption)
+                        .foregroundStyle(CorveilTheme.textSecondary)
+                        .help("Auto-merge enabled")
+                        .accessibilityLabel("Auto-merge enabled")
+                }
                 if isDeleting {
                     ProgressView()
                         .controlSize(.small)


### PR DESCRIPTION
Closes #504

## Summary

Adds a small, muted `arrow.triangle.merge` SF Symbol to each session card in the left pane when the session has had GitHub native auto-merge enabled on its PR. Lets users tell at a glance which sessions are on the auto-merge track without opening each one — useful especially under the multi-workspace flow.

## Source of truth

Reads `Session.autoMergeEnabledAt: Date?` directly — the same persisted flag the existing `IssueTracker` auto-merge watcher writes via `attemptEnableAutoMerge` (and the same flag its one-shot guard reads). No new state, no new wiring. Because `AppState` is `@Observable`, the icon appears/disappears reactively when the watcher mutates that field.

## Design choices

- **Glyph**: `arrow.triangle.merge` — already used in this codebase at `SessionListView.swift:342` for the "Add label crow:merge to PR" context-menu action, so the vocabulary is consistent.
- **Color**: `.foregroundStyle(CorveilTheme.textSecondary)` — informational, not a status alert (per ticket request for muted tone).
- **Size**: `.font(.caption)` — matches the existing inReview/completed status icons.
- **Placement**: in the top HStack between `Spacer()` and the existing status indicator, so it sits in the upper-right corner of the card without disturbing the session name or other affordances.
- **Tooltip**: `.help("Auto-merge enabled")` on hover.
- **Accessibility**: `.accessibilityLabel("Auto-merge enabled")` for VoiceOver.
- **Scope**: `SessionRow` only. `ManagerSessionRow` is intentionally excluded — the watcher explicitly skips managers (`IssueTracker.swift:1662`).

## Test plan

- [x] `swift build --arch arm64` — clean
- [x] `swift test --arch arm64` — 211 tests pass, including the existing `IssueTrackerAutoMergeTests` covering `autoMergeEnabledAt`
- [ ] Manual: session with `autoMergeEnabledAt` set shows the icon; one without doesn't
- [ ] Manual: hover the icon → "Auto-merge enabled" tooltip appears
- [ ] Manual: clear `autoMergeEnabledAt` → icon disappears without restart (reactive via `@Observable`)
- [ ] Manual: drag left pane to minimum width — session name truncates as before, icon sits between name and status indicator without layout breakage
- [ ] Manual: VoiceOver reads "Auto-merge enabled" when focused on the icon
- [ ] Manual: Increase Contrast on — icon still legible

## Out of scope (per ticket)

- Other automation-mode indicators (auto-create, auto-rebase, auto-respond)
- Toggle auto-merge from the card itself (read-only indicator for v1)
- Session-card redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)