### PR TITLE
Add Edit menu so ⌘V/dictation work in Settings text fields

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -1080,6 +1080,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appMenuItem.submenu = appMenu
         mainMenu.addItem(appMenuItem)
 
+        // Edit menu — registers the standard cut/copy/paste/select-all/undo
+        // selectors on the responder chain so ⌘V and dictation work in SwiftUI
+        // text fields (Settings). Routed to the first responder (target nil).
+        // The terminal is unaffected: GhosttySurfaceView.performKeyEquivalent
+        // intercepts ⌘V/⌘C at the view level before the main menu sees them. (#512)
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        editMenu.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "Z")
+        editMenu.addItem(.separator())
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
+
         NSApp.mainMenu = mainMenu
     }
 


### PR DESCRIPTION
Closes #512

## Problem
Text fields across the **Settings** screens couldn't accept a paste — `⌘V` did nothing and dictation/voice insertion failed.

## Root cause
`setupMenu()` in `AppDelegate.swift` built a custom `NSApp.mainMenu` containing **only** an App menu — no Edit menu. On macOS the standard `cut:`/`copy:`/`paste:`/`selectAll:`/undo selectors are registered and routed through the Edit menu's items; with no Edit menu, `⌘V` in a plain SwiftUI `TextField`/`TextEditor` was silently dropped (dictation uses the same responder-chain path).

## Fix
Add a standard **Edit menu** (Undo/Redo/Cut/Copy/Paste/Select All) wired to the first responder in `setupMenu()`. App-wide fix — restores cut/copy/paste/select-all/undo everywhere.

The terminal is **unaffected**: `GhosttySurfaceView.performKeyEquivalent` returns `true` for any Cmd/Ctrl key when the surface is focused, and in macOS the key window's view hierarchy receives `performKeyEquivalent` before the main menu — so a focused terminal intercepts `⌘V`/`⌘C` before the Edit-menu item can fire.

## Verification
- `make app` builds clean; full test suite passes (226 tests).
- Edit menu appears with Cut/Copy/Paste/Select All (+ Undo/Redo); `⌘V` pastes in Settings fields; terminal paste still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)