### PR TITLE
Jobs: don't silently drop bare-org alwaysInclude specs (fix empty repo dropdown)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -158,9 +158,10 @@ public final class AppState {
     public var onPromoteToGlobal: ((Set<String>) -> Void)?
 
     /// Lists the repos available to a workspace, as `owner/repo` slugs, by
-    /// expanding its `alwaysInclude` specs against the provider. Wired in
-    /// AppDelegate; used by the Jobs form's repo picker.
-    public var onListWorkspaceRepos: ((WorkspaceInfo) async -> [String])?
+    /// expanding its `alwaysInclude` specs against the provider — along with any
+    /// specs that couldn't be resolved. Wired in AppDelegate; used by the Jobs
+    /// form's repo picker.
+    public var onListWorkspaceRepos: ((WorkspaceInfo) async -> WorkspaceRepoListing)?
 
     /// Called when the user clicks the gear icon in the sidebar toolbar.
     /// AppDelegate wires this to its `showSettings()` method.

--- a/Packages/CrowCore/Sources/CrowCore/Models/WorkspaceRepoListing.swift
+++ b/Packages/CrowCore/Sources/CrowCore/Models/WorkspaceRepoListing.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Result of expanding a workspace's `alwaysInclude` specs into repos for the
+/// Jobs form's repo picker.
+///
+/// Carries the resolved `owner/repo` slugs *and* any specs that couldn't be
+/// resolved, so the UI can tell apart "nothing configured" / "invalid spec(s)" /
+/// "valid specs that returned nothing" instead of showing a bare "No repos found".
+public struct WorkspaceRepoListing: Sendable, Equatable {
+    /// A spec that classified as unusable, with a suggested fix when there is a
+    /// clean one (e.g. a bare org name `securityscorecard` → `securityscorecard/*`).
+    public struct InvalidSpec: Sendable, Equatable {
+        public let raw: String
+        public let suggestion: String?
+        public init(raw: String, suggestion: String?) {
+            self.raw = raw
+            self.suggestion = suggestion
+        }
+    }
+
+    /// Resolved, sorted, de-duplicated `owner/repo` slugs.
+    public let repos: [String]
+    /// Specs that couldn't be resolved (surfaced to the user with a hint).
+    public let invalidSpecs: [InvalidSpec]
+
+    public init(repos: [String], invalidSpecs: [InvalidSpec]) {
+        self.repos = repos
+        self.invalidSpecs = invalidSpecs
+    }
+
+    public static let empty = WorkspaceRepoListing(repos: [], invalidSpecs: [])
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/ProviderManager.swift
@@ -228,15 +228,18 @@ public actor ProviderManager {
 
     // MARK: - Repo listing (Jobs repo picker)
 
-    /// Expand a workspace's repo specs into a sorted, de-duplicated list of
-    /// `owner/repo` slugs.
+    /// Expand a workspace's repo specs into resolved `owner/repo` slugs plus any
+    /// specs that couldn't be resolved.
     ///
     /// Each spec is either a glob (`owner/*` — list every repo owned by `owner`
-    /// via the provider) or an explicit slug (`owner/repo` — passed through
-    /// verbatim). Used to populate the Jobs form's repo picker from a
-    /// workspace's `alwaysInclude` entries.
-    public func reposForSpecs(_ specs: [String], provider: Provider, host: String?) async -> [String] {
+    /// via the provider), an explicit slug (`owner/repo` — passed through
+    /// verbatim), or invalid. Invalid specs (e.g. a bare org name like
+    /// `securityscorecard`) are *surfaced* in `invalidSpecs` — with a suggested
+    /// fix when there is one — rather than silently dropped, so the Jobs form's
+    /// repo picker can explain why it's empty.
+    public func reposForSpecs(_ specs: [String], provider: Provider, host: String?) async -> WorkspaceRepoListing {
         var slugs: Set<String> = []
+        var invalid: [WorkspaceRepoListing.InvalidSpec] = []
         for spec in specs {
             switch Self.classifySpec(spec) {
             case .glob(let owner):
@@ -246,10 +249,14 @@ public actor ProviderManager {
             case .explicit(let slug):
                 slugs.insert(slug)
             case .invalid:
-                continue
+                // Skip whitespace-only entries so the UI never shows "'' is invalid".
+                guard !spec.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+                invalid.append(
+                    .init(raw: spec, suggestion: Self.suggestion(forInvalidSpec: spec))
+                )
             }
         }
-        return slugs.sorted()
+        return WorkspaceRepoListing(repos: slugs.sorted(), invalidSpecs: invalid)
     }
 
     /// List every repo owned by `owner` as `owner/repo` slugs.
@@ -308,6 +315,15 @@ public actor ProviderManager {
         // A usable explicit entry needs an owner and a repo (at least one "/").
         guard spec.contains("/"), !spec.contains("*") else { return .invalid }
         return .explicit(slug: spec)
+    }
+
+    /// Suggest a clean fix for an invalid spec, or `nil` if there isn't an
+    /// obvious one. A bare org name (no `/`, no `*`) is almost always meant as
+    /// "every repo in this org", so we suggest `<name>/*`.
+    nonisolated static func suggestion(forInvalidSpec raw: String) -> String? {
+        let spec = raw.trimmingCharacters(in: .whitespaces)
+        guard !spec.isEmpty, !spec.contains("/"), !spec.contains("*") else { return nil }
+        return "\(spec)/*"
     }
 
     private static func nonEmptyLines(_ output: String) -> [String] {

--- a/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/ProviderManagerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import CrowCore
 @testable import CrowProvider
 
 @Suite("ProviderManager")
@@ -277,7 +278,8 @@ struct ProviderManagerTests {
     }
 
     @Test func classifySpecBareNameIsInvalid() {
-        // No owner — can't list or clone it.
+        // No owner — can't list or clone it. Bare names stay invalid; rather than
+        // coerce them to a glob, `reposForSpecs` surfaces them with a suggested fix.
         #expect(ProviderManager.classifySpec("api") == .invalid)
     }
 
@@ -300,13 +302,48 @@ struct ProviderManagerTests {
     }
 
     @Test func reposForSpecsKeepsExplicitSlugsSortedAndDeduped() async {
-        // Explicit-only specs need no provider call, so this exercises the
-        // merge/dedup/sort path without shelling out.
+        // Explicit + invalid specs need no provider call, so this exercises the
+        // merge/dedup/sort path (and invalid-spec surfacing) without shelling out.
         let result = await manager.reposForSpecs(
             ["org/zeta", "org/alpha", "org/alpha", "bare"],
             provider: .github, host: nil
         )
-        #expect(result == ["org/alpha", "org/zeta"])
+        #expect(result.repos == ["org/alpha", "org/zeta"])
+        // The bare token is surfaced (not silently dropped) with a suggested fix.
+        #expect(result.invalidSpecs == [.init(raw: "bare", suggestion: "bare/*")])
+    }
+
+    @Test func reposForSpecsSurfacesBareOrgTokenWithSuggestion() async {
+        // A bare org name (the CROW-516 repro) is surfaced as invalid with a
+        // "did you mean owner/*" hint while valid explicit slugs still resolve.
+        let result = await manager.reposForSpecs(
+            ["securityscorecard", "org/repo"],
+            provider: .github, host: nil
+        )
+        #expect(result.repos == ["org/repo"])
+        #expect(result.invalidSpecs == [
+            .init(raw: "securityscorecard", suggestion: "securityscorecard/*"),
+        ])
+    }
+
+    @Test func reposForSpecsSkipsWhitespaceOnlySpecs() async {
+        // Empty/whitespace entries aren't user-meaningful, so they're dropped
+        // rather than surfaced as "'' is invalid".
+        let result = await manager.reposForSpecs(
+            ["   ", "org/repo"],
+            provider: .github, host: nil
+        )
+        #expect(result.repos == ["org/repo"])
+        #expect(result.invalidSpecs.isEmpty)
+    }
+
+    @Test func suggestionForInvalidSpecGlobsBareOrgName() {
+        #expect(ProviderManager.suggestion(forInvalidSpec: "securityscorecard") == "securityscorecard/*")
+        #expect(ProviderManager.suggestion(forInvalidSpec: "  acme  ") == "acme/*")
+        // No clean fix for these.
+        #expect(ProviderManager.suggestion(forInvalidSpec: "foo*") == nil)
+        #expect(ProviderManager.suggestion(forInvalidSpec: "/*") == nil)
+        #expect(ProviderManager.suggestion(forInvalidSpec: "") == nil)
     }
 
     // MARK: - ProviderError

--- a/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/JobFormView.swift
@@ -23,13 +23,15 @@ public struct JobFormView: View {
 
     /// Repo slugs for the selected workspace, loaded via `listRepos`.
     @State private var repoOptions: [String] = []
+    /// `alwaysInclude` specs that couldn't be resolved, surfaced in the empty state.
+    @State private var invalidSpecs: [WorkspaceRepoListing.InvalidSpec] = []
     @State private var isLoadingRepos = false
     @State private var didLoadRepos = false
     /// Bumped on each load so a stale slow response can't clobber a newer one.
     @State private var loadGeneration = 0
 
     private let workspaces: [WorkspaceInfo]
-    private let listRepos: (WorkspaceInfo) async -> [String]
+    private let listRepos: (WorkspaceInfo) async -> WorkspaceRepoListing
     private let existingID: UUID?
     private let existingLastRunAt: Date?
     private let existingCreatedAt: Date
@@ -70,7 +72,7 @@ public struct JobFormView: View {
         isDuplicate: Bool = false,
         workspaces: [WorkspaceInfo] = [],
         existingNames: [String] = [],
-        listRepos: @escaping (WorkspaceInfo) async -> [String] = { _ in [] },
+        listRepos: @escaping (WorkspaceInfo) async -> WorkspaceRepoListing = { _ in .empty },
         onSave: @escaping (JobConfig) -> Void
     ) {
         self.workspaces = workspaces
@@ -137,6 +139,25 @@ public struct JobFormView: View {
         return choices
     }
 
+    /// Message shown when the repo picker has no options, distinguishing
+    /// "nothing configured" from "invalid spec(s)" from "valid specs that
+    /// returned nothing" (e.g. gh/glab not authenticated).
+    private var repoEmptyStateMessage: String {
+        if selectedWorkspace?.alwaysInclude.isEmpty != false {
+            return "No repos configured for this workspace. In Workspaces settings, set this workspace's Always Include Repos to e.g. owner/* or owner/repo."
+        }
+        if !invalidSpecs.isEmpty {
+            let lines = invalidSpecs.map { spec -> String in
+                if let suggestion = spec.suggestion {
+                    return "“\(spec.raw)” isn’t a valid repo spec — did you mean \(suggestion)?"
+                }
+                return "“\(spec.raw)” isn’t a valid repo spec — use owner/* or owner/repo."
+            }
+            return lines.joined(separator: "\n")
+        }
+        return "No repos found. Check that gh/glab is authenticated and that the configured specs match repos."
+    }
+
     private var isValid: Bool {
         nameValidationError == nil
             && !workspace.isEmpty
@@ -150,6 +171,7 @@ public struct JobFormView: View {
     private func loadRepos() async {
         guard let ws = selectedWorkspace else {
             repoOptions = []
+            invalidSpecs = []
             return
         }
         loadGeneration += 1
@@ -158,7 +180,8 @@ public struct JobFormView: View {
         let result = await listRepos(ws)
         // A newer load started while we were awaiting — drop this stale result.
         guard generation == loadGeneration else { return }
-        repoOptions = result
+        repoOptions = result.repos
+        invalidSpecs = result.invalidSpecs
         isLoadingRepos = false
         didLoadRepos = true
     }
@@ -192,7 +215,7 @@ public struct JobFormView: View {
                     }
                 }
                 if didLoadRepos, !isLoadingRepos, repoOptions.isEmpty {
-                    Text("No repos found. In Workspaces settings, set this workspace's Always Include Repos to e.g. owner/* or owner/repo — and check that gh/glab is authenticated.")
+                    Text(repoEmptyStateMessage)
                         .font(.caption).foregroundStyle(.secondary)
                 }
 

--- a/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/SettingsView.swift
@@ -115,7 +115,7 @@ public struct SettingsView: View {
             JobFormView(
                 workspaces: config.workspaces,
                 existingNames: otherJobNames(),
-                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? [] }
+                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? .empty }
             ) { job in
                 config.jobs.append(job)
                 save()
@@ -126,7 +126,7 @@ public struct SettingsView: View {
                 job: job,
                 workspaces: config.workspaces,
                 existingNames: otherJobNames(excluding: job.id),
-                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? [] }
+                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? .empty }
             ) { updated in
                 if let idx = config.jobs.firstIndex(where: { $0.id == updated.id }) {
                     config.jobs[idx] = updated
@@ -140,7 +140,7 @@ public struct SettingsView: View {
                 isDuplicate: true,
                 workspaces: config.workspaces,
                 existingNames: otherJobNames(),
-                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? [] }
+                listRepos: { ws in await appState.onListWorkspaceRepos?(ws) ?? .empty }
             ) { newJob in
                 config.jobs.append(newJob)
                 save()

--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -43,7 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Cache of expanded `alwaysInclude` repo lists, keyed by workspace name +
     /// its specs, with a short TTL so repeated form opens don't re-hit the
     /// provider CLI.
-    private var workspaceRepoCache: [String: (fetchedAt: Date, repos: [String])] = [:]
+    private var workspaceRepoCache: [String: (fetchedAt: Date, listing: WorkspaceRepoListing)] = [:]
     private let workspaceRepoCacheTTL: TimeInterval = 300
 
     /// Tail of the serial review-kickoff queue. Each call to
@@ -902,7 +902,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // owner/repo) into the repos available from its provider. Results are
         // cached per (workspace, specs) with a short TTL.
         appState.onListWorkspaceRepos = { [weak self] ws in
-            guard let self else { return [] }
+            guard let self else { return .empty }
             let provider: Provider
             if let p = Provider(rawValue: ws.provider) {
                 provider = p
@@ -918,13 +918,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ].joined(separator: "\u{1}")
             if let cached = self.workspaceRepoCache[key],
                Date().timeIntervalSince(cached.fetchedAt) < self.workspaceRepoCacheTTL {
-                return cached.repos
+                return cached.listing
             }
-            let repos = await self.providerManager.reposForSpecs(
+            let listing = await self.providerManager.reposForSpecs(
                 ws.alwaysInclude, provider: provider, host: ws.host
             )
-            self.workspaceRepoCache[key] = (Date(), repos)
-            return repos
+            self.workspaceRepoCache[key] = (Date(), listing)
+            return listing
         }
 
         // Hydrate mute state from config and wire toggle


### PR DESCRIPTION
Closes #516

## Problem
In **Settings → Jobs**, creating a job for an org whose workspace config has a **bare org name** in `alwaysInclude` (e.g. SecurityScorecard's `["securityscorecard"]`) showed **"No repos found"** with no explanation — you couldn't pick a repo, so you couldn't create the job.

The Jobs dropdown is populated by expanding `alwaysInclude` via `ProviderManager.reposForSpecs` → `classifySpec`. A bare token (no `/`, no `*`) classifies as `.invalid` and was **silently skipped**, so every entry got dropped and the single generic empty-state message couldn't explain why.

## Fix
Rather than auto-coercing bare tokens to `owner/*` (which could mask a malformed `owner/repo` typo — those always contain a `/`), bare tokens stay `.invalid` but are now **surfaced** with an actionable hint.

- **`WorkspaceRepoListing` (CrowCore, new):** resolved `repos` + `invalidSpecs`, each with an optional suggested fix.
- **`reposForSpecs`** returns the listing, collecting invalid specs (with a "did you mean `owner/*`" suggestion for bare org names) instead of silently skipping. Whitespace-only entries are still dropped. `classifySpec` itself is unchanged.
- **`JobFormView`** distinguishes three empty states: *nothing configured* / *invalid spec(s)* (with the suggestion) / *valid specs that returned nothing* (e.g. `gh`/`glab` not authenticated).
- `AppState`, `AppDelegate` (incl. its repo cache), and `SettingsView` updated to the richer return type.

## Tests
- `classifySpecBareNameIsInvalid` kept (behavior unchanged) with a clarifying comment.
- `reposForSpecsKeepsExplicitSlugsSortedAndDeduped` now also asserts the bare token is surfaced with a suggestion.
- Added `reposForSpecsSurfacesBareOrgTokenWithSuggestion` (the CROW-516 repro), `reposForSpecsSkipsWhitespaceOnlySpecs`, and `suggestionForInvalidSpecGlobsBareOrgName`.

`make app` builds clean; CrowProvider/CrowCore/CrowUI/Crow test suites pass. (The only failing tests are pre-existing `CrowGit` `RebaseTests` that need a global git identity in the sandbox — unrelated to this change.)

## Notes / follow-ups
- **Config workaround (separate):** SecurityScorecard's `alwaysInclude` should be `["securityscorecard/*"]`. Not changed here.
- **Out of scope:** a live `gh repo list <org>` / on-disk fallback when `alwaysInclude` yields nothing — flagged in #516 as a larger design call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)