### PR TITLE
Offer crow:merge on Jira-ticket sessions' GitHub PRs — gate on code backend, not task provider (#532)

### DIFF
--- a/Sources/Crow/App/AppDelegate.swift
+++ b/Sources/Crow/App/AppDelegate.swift
@@ -858,11 +858,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         appState.canAddMergeLabelResolver = { [providerManager] session in
-            guard let provider = session.provider else { return false }
-            return providerManager
-                .codeBackend(for: provider)?
-                .capabilities
-                .contains(.autoMergeLabel) ?? false
+            IssueTracker.canAddMergeLabel(session: session, providerManager: providerManager)
         }
 
         appState.onAddMergeLabel = { [weak tracker] id in

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -1121,6 +1121,16 @@ final class IssueTracker {
         return (.gitlab, host)
     }
 
+    /// Whether `session` may add the `crow:merge` label to its PR — i.e. its
+    /// **code** backend declares `.autoMergeLabel`. Resolves the code provider
+    /// via the `codeProvider ?? provider ?? .github` convention (ADR 0005) so a
+    /// Jira/Corveil-tasked GitHub-code session is gated on GitHub, not on its
+    /// task provider (CROW-532). Pure — easily unit-tested.
+    nonisolated static func canAddMergeLabel(session: Session, providerManager: ProviderManager) -> Bool {
+        let provider = session.codeProvider ?? session.provider ?? .github
+        return providerManager.codeBackend(for: provider)?.capabilities.contains(.autoMergeLabel) ?? false
+    }
+
     /// For each non-archived, non-review session missing a `.pr` link with a
     /// resolvable (repoSlug, branch), query the provider directly and upsert
     /// a link when a PR exists on that branch. Runs once per refresh cycle
@@ -1797,20 +1807,32 @@ final class IssueTracker {
         }
     }
 
+    /// Resolve the `CodeBackend` for a session's PR/merge actions, following the
+    /// `codeProvider ?? provider ?? .github` convention (ADR 0005) so a
+    /// Jira/Corveil-tasked GitHub-code session routes to GitHub rather than its
+    /// task provider (CROW-532). `nil` only for a task-only resolution with no
+    /// code surface — callers must bow out.
+    private func codeBackend(for session: Session) -> CodeBackend? {
+        providerManager.codeBackend(for: session.codeProvider ?? session.provider ?? .github)
+    }
+
     /// Verify Crow authorship, lazily ensure the label exists, then enable
     /// auto-merge with squash + delete branch. Idempotent: success persists
     /// `Session.autoMergeEnabledAt`; failure clears the in-flight marker so
     /// the next poll retries.
     private func attemptEnableAutoMerge(session: Session, pr: ViewerPR) async {
-        guard await prHasCrowAuthoredCommit(pr: pr) else {
+        guard let backend = codeBackend(for: session) else {
+            autoMergeInFlight.remove(pr.url)
+            return
+        }
+        guard await prHasCrowAuthoredCommit(pr: pr, backend: backend) else {
             NSLog("[Crow] crow:merge ignored on %@ — no Crow-Session trailer matching a known session",
                   pr.url as NSString)
             return
         }
 
-        await ensureMergeLabel(repo: pr.repoNameWithOwner)
+        await ensureMergeLabel(repo: pr.repoNameWithOwner, backend: backend)
 
-        let backend = providerManager.codeBackend(for: .github)!
         guard backend.capabilities.contains(.autoMerge) else {
             // Capability gate: don't even try if the backend can't enable auto-merge.
             autoMergeInFlight.remove(pr.url)
@@ -1849,13 +1871,13 @@ final class IssueTracker {
     /// caller) is left in place so a failed/no-op update isn't retried until
     /// the head commit changes.
     private func attemptUpdateBranch(session: Session, pr: ViewerPR) async {
-        guard await prHasCrowAuthoredCommit(pr: pr) else {
+        guard let backend = codeBackend(for: session) else { return }
+        guard await prHasCrowAuthoredCommit(pr: pr, backend: backend) else {
             NSLog("[Crow] crow:merge update-branch skipped on %@ — no Crow-Session trailer matching a known session",
                   pr.url as NSString)
             return
         }
 
-        let backend = providerManager.codeBackend(for: .github)!
         defer { autoMergeInFlight.remove(pr.url) }
         guard backend.capabilities.contains(.updateBranch) else { return }
         do {
@@ -1870,8 +1892,7 @@ final class IssueTracker {
 
     /// Fetch the PR's commits and return true iff at least one carries a
     /// `Crow-Session: <uuid>` trailer matching a known session.
-    private func prHasCrowAuthoredCommit(pr: ViewerPR) async -> Bool {
-        let backend = providerManager.codeBackend(for: .github)!
+    private func prHasCrowAuthoredCommit(pr: ViewerPR, backend: CodeBackend) async -> Bool {
         let commits: [CommitInfo]
         do {
             commits = try await backend.fetchCrowAuthoredCommits(
@@ -1892,9 +1913,8 @@ final class IssueTracker {
     /// Best-effort: ensure the `crow:merge` label exists in the repo so
     /// repo owners don't need to pre-create it. The backend swallows the
     /// "already exists" failure.
-    private func ensureMergeLabel(repo: String) async {
+    private func ensureMergeLabel(repo: String, backend: CodeBackend) async {
         guard !repo.isEmpty else { return }
-        let backend = providerManager.codeBackend(for: .github)!
         guard backend.capabilities.contains(.autoMergeLabel) else { return }
         do {
             try await backend.ensureMergeLabel(repo: repo)
@@ -1979,7 +1999,8 @@ final class IssueTracker {
             return
         }
 
-        guard await prHasCrowAuthoredCommit(pr: pr) else {
+        guard let backend = codeBackend(for: session) else { return }
+        guard await prHasCrowAuthoredCommit(pr: pr, backend: backend) else {
             NSLog("[Crow] auto-rebase skipped on %@ — no Crow-Session trailer matching a known session",
                   pr.url as NSString)
             return
@@ -2624,8 +2645,7 @@ final class IssueTracker {
     func addMergeLabel(sessionID: UUID) async {
         guard let session = appState.sessions.first(where: { $0.id == sessionID }),
               let prLink = appState.links(for: sessionID).first(where: { $0.linkType == .pr }),
-              let provider = session.provider,
-              let backend = providerManager.codeBackend(for: provider),
+              let backend = codeBackend(for: session),
               backend.capabilities.contains(.autoMergeLabel) else { return }
 
         appState.isAddingMergeLabel[sessionID] = true

--- a/Tests/CrowTests/IssueTrackerAutoMergeTests.swift
+++ b/Tests/CrowTests/IssueTrackerAutoMergeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import CrowCore
+import CrowProvider
 @testable import Crow
 
 @Suite("IssueTracker auto-merge watcher (crow:merge label)")
@@ -242,5 +243,50 @@ struct IssueTrackerAutoMergeTests {
             "later commit\n\nCrow-Session: \(known.uuidString)\n"      // known — wins
         ]
         #expect(IssueTracker.crowAuthored(commitMessages: messages, knownSessionIDs: [known]))
+    }
+}
+
+/// CROW-532: the "Add label crow:merge to PR" affordance must gate on the
+/// session's **code** backend, not its **task** provider — so a Jira-tasked
+/// session whose PR lives on GitHub gets the action, while a GitLab-code
+/// session (no `.autoMergeLabel` capability) does not.
+@Suite("canAddMergeLabel — gates on code backend, not task provider")
+struct CanAddMergeLabelTests {
+    private let providerManager = ProviderManager()
+
+    private func session(provider: Provider?, codeProvider: Provider? = nil) -> Session {
+        Session(id: UUID(), name: "s", provider: provider, codeProvider: codeProvider)
+    }
+
+    @Test func jiraTaskWithGitHubCodeShowsAffordance() {
+        // The bug being fixed: task is Jira but the PR is on GitHub.
+        let s = session(provider: .jira, codeProvider: .github)
+        #expect(IssueTracker.canAddMergeLabel(session: s, providerManager: providerManager))
+    }
+
+    @Test func gitHubTaskStillShowsAffordance() {
+        // No regression for the original GitHub-tasked case.
+        let s = session(provider: .github)
+        #expect(IssueTracker.canAddMergeLabel(session: s, providerManager: providerManager))
+    }
+
+    @Test func jiraTaskWithGitLabCodeHidesAffordance() {
+        // GitLab declares no `.autoMergeLabel` capability — stays hidden
+        // regardless of task provider.
+        let s = session(provider: .jira, codeProvider: .gitlab)
+        #expect(!IssueTracker.canAddMergeLabel(session: s, providerManager: providerManager))
+    }
+
+    @Test func gitLabTaskHidesAffordance() {
+        let s = session(provider: .gitlab)
+        #expect(!IssueTracker.canAddMergeLabel(session: s, providerManager: providerManager))
+    }
+
+    @Test func taskOnlyWithoutCodeProviderHidesAffordance() {
+        // Defensive: a `.jira` task with no resolved `codeProvider` falls to
+        // `.jira` (a task-only provider with no code backend) → hidden. In
+        // practice `SessionService.resolvedCodeProvider` populates this field.
+        let s = session(provider: .jira, codeProvider: nil)
+        #expect(!IssueTracker.canAddMergeLabel(session: s, providerManager: providerManager))
     }
 }


### PR DESCRIPTION
Closes #532

## Problem

For a session whose **task** is a Jira ticket but whose **code/PR lives on GitHub**, the right-click affordance to add **`crow:merge`** to the PR was missing. The PR is a normal GitHub PR and perfectly mergeable — only the *task* tracker differs. Same root-cause family as CROW-523/529/533: a **code/PR affordance gated on the task provider** instead of the **code backend**.

## Root cause

The affordance ("Add label crow:merge to PR" in `SessionListView`) gated correctly on `hasPR && canAddMergeLabel`. The bug was one layer down — the capability resolved against the **task** provider:

- `AppDelegate.canAddMergeLabelResolver` → `codeBackend(for: session.provider)`. For a Jira session that's `.jira` → nil backend → affordance hidden.
- `IssueTracker.addMergeLabel` had the same `session.provider` guard, so even if shown it would no-op.

## Fix

- Re-gate both on the **code** backend via the established `codeProvider ?? provider ?? .github` convention (ADR 0005), extracted into a pure, unit-tested `IssueTracker.canAddMergeLabel(session:providerManager:)`.
- GitLab-code sessions still correctly hide it (no `.autoMergeLabel` capability), regardless of task provider.
- De-hardcoded the auto-merge / auto-rebase watcher (`attemptEnableAutoMerge`, `attemptUpdateBranch`, `attemptRebase`, `prHasCrowAuthoredCommit`, `ensureMergeLabel`) from `codeBackend(for: .github)!` to the session's resolved code backend, dropping the force-unwrap. No behavior change today (GitLab has no auto-merge) but consistent with the family.

## Checked siblings (no bug)

- `SessionDetailView` quick-actions (Rebase / Address Review / Fix Checks / Merge PR) gate on `prStatus` + managed-terminal, not the task provider.
- `canSetProjectStatus` is a genuine task-side capability — left as-is.

## Tests

New `CanAddMergeLabelTests`: affordance shows for Jira-task + GitHub-code and GitHub-task sessions; hides for GitLab-code / GitLab-task / task-only-without-codeProvider. Existing auto-merge + reconcile suites still pass; `make app` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)