### PR TITLE
Reflect Jira status + linked session on the ticket board (read-back; #533)

### DIFF
--- a/Packages/CrowCore/Sources/CrowCore/AppState.swift
+++ b/Packages/CrowCore/Sources/CrowCore/AppState.swift
@@ -559,15 +559,39 @@ public final class AppState {
         return result
     }
 
-    /// Find the active session linked to a given issue (by matching ticket URL).
-    public func activeSession(for issue: AssignedIssue) -> Session? {
-        activeSessions.first { $0.ticketURL == issue.url }
+    /// Work sessions eligible to be shown as "linked" on the ticket board: every
+    /// non-terminal session (`.active`, `.paused`, `.inReview`), excluding the
+    /// terminal `.completed`/`.archived`. Broader than ``activeSessions`` so a
+    /// ticket whose session has moved to In Review still shows as linked (#533).
+    public var linkableSessions: [Session] {
+        sessions.filter { $0.kind == .work && $0.status != .completed && $0.status != .archived }
     }
 
-    /// Find the assigned issue linked to a given session (by matching ticket URL).
+    /// Whether `session` is the Crow session for `issue`. Exact `ticketURL` match
+    /// for all providers, plus a Jira-key fallback (`PROJ-123`) so Jira browse-URL
+    /// variants still link (#533). GitHub/GitLab keep exact-URL matching only.
+    private func ticketMatches(session: Session, issue: AssignedIssue) -> Bool {
+        guard let url = session.ticketURL else { return false }
+        if url == issue.url { return true }
+        guard issue.provider == .jira,
+              let sessionKey = Validation.jiraKey(from: url),
+              let issueKey = Validation.jiraKey(from: issue.url) else { return false }
+        return sessionKey.caseInsensitiveCompare(issueKey) == .orderedSame
+    }
+
+    /// Find the non-terminal session linked to a given issue. Considers Active,
+    /// Paused, and In-Review sessions and matches Jira tickets robustly (#533) —
+    /// the board uses this to show the linked-session indicator vs "Start Working".
+    public func linkedSession(for issue: AssignedIssue) -> Session? {
+        linkableSessions.first { ticketMatches(session: $0, issue: issue) }
+    }
+
+    /// Find the assigned issue linked to a given session. Matches exact ticket
+    /// URL, plus a Jira-key fallback so labels/metadata resolve for In-Review and
+    /// browse-URL-variant Jira sessions (#533).
     public func assignedIssue(for session: Session) -> AssignedIssue? {
-        guard let url = session.ticketURL else { return nil }
-        return assignedIssues.first { $0.url == url }
+        guard session.ticketURL != nil else { return nil }
+        return assignedIssues.first { ticketMatches(session: session, issue: $0) }
     }
 
     /// Find the review request linked to a given session (by matching PR link URL).

--- a/Packages/CrowCore/Sources/CrowCore/JiraSearchClient.swift
+++ b/Packages/CrowCore/Sources/CrowCore/JiraSearchClient.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Fetches the operator's **assigned Jira work items** for the ticket board via
+/// the Jira Cloud REST API, so the board read-back agrees with Jira (#533).
+///
+/// Why REST and not `acli` / the agent-side MCP — same reasoning as
+/// ``JiraTransitionClient`` and ``JiraStatusFetcher``: `acli` requires a separate
+/// install + auth, and the session-side `jira` MCP isn't reachable from the Crow
+/// app process. The app drives the read itself over REST, authenticated with the
+/// same Atlassian email + API token used elsewhere (HTTP Basic via
+/// ``JiraCredentialResolver``). Mirrors ``JiraStatusFetcher`` — same site host,
+/// same credential, injectable transport for tests.
+///
+/// Uses Jira Cloud's enhanced JQL search endpoint
+/// `GET /rest/api/3/search/jql` (the legacy `/rest/api/3/search` was removed on
+/// Cloud). A single page of up to `maxResults` items is fetched, matching the
+/// previous `acli --limit 100` behavior; token pagination (`nextPageToken`) is a
+/// follow-up if boards ever exceed a page.
+public enum JiraSearchClient {
+    public enum FetchError: Error, Equatable {
+        case badSite
+        case http(Int)
+        case transport(String)
+        case decode
+    }
+
+    /// Build the enhanced-search REST URL for a site host + JQL + fields. Accepts
+    /// a bare host (`acme.atlassian.net`) or a full origin; the scheme is always
+    /// forced to **https** so the Basic credential is never sent in cleartext
+    /// (mirrors ``JiraStatusFetcher/statusesURL(site:projectKey:)``).
+    static func searchURL(site: String, jql: String, fields: [String], maxResults: Int) -> URL? {
+        let trimmedSite = site.trimmingCharacters(in: .whitespaces)
+        let trimmedJQL = jql.trimmingCharacters(in: .whitespaces)
+        guard !trimmedSite.isEmpty, !trimmedJQL.isEmpty else { return nil }
+        let bareHost = trimmedSite.range(of: "://").map { String(trimmedSite[$0.upperBound...]) } ?? trimmedSite
+        guard !bareHost.isEmpty else { return nil }
+
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = bareHost
+        components.path = "/rest/api/3/search/jql"
+        components.queryItems = [
+            URLQueryItem(name: "jql", value: trimmedJQL),
+            URLQueryItem(name: "fields", value: fields.joined(separator: ",")),
+            URLQueryItem(name: "maxResults", value: "\(maxResults)"),
+        ]
+        return components.url
+    }
+
+    /// Parse the `search/jql` payload (`{ "issues": [ { key, fields:{…} } ] }`)
+    /// into the raw issue dictionaries. Returns the (possibly empty) `issues`
+    /// array, or `nil` when the payload shape is unrecognized.
+    static func parseIssues(_ data: Data) -> [[String: Any]]? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        guard let issues = json["issues"] as? [[String: Any]] else {
+            // A well-formed response with no matches still carries an `issues` key;
+            // a missing key means an unexpected shape.
+            return nil
+        }
+        return issues
+    }
+
+    /// Fetch the assigned work items matching `jql` on `site`, authenticated with
+    /// `authorization` (a full header value, e.g. `Basic …` from
+    /// ``JiraCredentialResolver``). Returns the raw issue dictionaries (each
+    /// `{ key, fields }`) for the caller to map. Injectable transport for testing.
+    public static func fetchAssigned(
+        site: String,
+        jql: String,
+        authorization: String,
+        fields: [String] = ["key", "summary", "status", "labels"],
+        maxResults: Int = 100,
+        transport: (URLRequest) async throws -> (Data, URLResponse) = { try await URLSession.shared.data(for: $0) }
+    ) async -> Result<[[String: Any]], FetchError> {
+        guard let url = searchURL(site: site, jql: jql, fields: fields, maxResults: maxResults) else {
+            return .failure(.badSite)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await transport(request)
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                return .failure(.http(http.statusCode))
+            }
+            guard let issues = parseIssues(data) else { return .failure(.decode) }
+            return .success(issues)
+        } catch {
+            return .failure(.transport(error.localizedDescription))
+        }
+    }
+}

--- a/Packages/CrowCore/Tests/CrowCoreTests/AppStateLookupTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/AppStateLookupTests.swift
@@ -44,6 +44,90 @@ import Testing
     #expect(appState.assignedIssue(for: session) == nil)
 }
 
+// MARK: - linkedSession(for:) — broadened matching (#533)
+
+@MainActor @Test func linkedSessionMatchesActiveGitHubByExactURL() {
+    let appState = AppState()
+    let issue = AssignedIssue(
+        id: "github:org/repo#42", number: 42, title: "Bug",
+        state: "open", url: "https://github.com/org/repo/issues/42",
+        repo: "org/repo", provider: .github
+    )
+    let session = Session(name: "fix", status: .active, ticketURL: "https://github.com/org/repo/issues/42", provider: .github)
+    appState.sessions = [session]
+    #expect(appState.linkedSession(for: issue)?.id == session.id)
+}
+
+@MainActor @Test func linkedSessionMatchesInReviewAndPausedSessions() {
+    let appState = AppState()
+    let issue = AssignedIssue(
+        id: "github:org/repo#7", number: 7, title: "T",
+        state: "open", url: "https://github.com/org/repo/issues/7",
+        repo: "org/repo", provider: .github
+    )
+    // In Review session — would NOT match under the old `.active`-only scan.
+    let inReview = Session(name: "ir", status: .inReview, ticketURL: "https://github.com/org/repo/issues/7", provider: .github)
+    appState.sessions = [inReview]
+    #expect(appState.linkedSession(for: issue)?.id == inReview.id)
+
+    let paused = Session(name: "p", status: .paused, ticketURL: "https://github.com/org/repo/issues/7", provider: .github)
+    appState.sessions = [paused]
+    #expect(appState.linkedSession(for: issue)?.id == paused.id)
+}
+
+@MainActor @Test func linkedSessionExcludesTerminalSessions() {
+    let appState = AppState()
+    let issue = AssignedIssue(
+        id: "github:org/repo#7", number: 7, title: "T",
+        state: "open", url: "https://github.com/org/repo/issues/7",
+        repo: "org/repo", provider: .github
+    )
+    let completed = Session(name: "c", status: .completed, ticketURL: "https://github.com/org/repo/issues/7", provider: .github)
+    let archived = Session(name: "a", status: .archived, ticketURL: "https://github.com/org/repo/issues/7", provider: .github)
+    appState.sessions = [completed, archived]
+    #expect(appState.linkedSession(for: issue) == nil)
+}
+
+@MainActor @Test func linkedSessionMatchesJiraByKeyAcrossURLVariants() {
+    let appState = AppState()
+    let issue = AssignedIssue(
+        id: "jira:MAXX-10", number: 10, title: "Jira one",
+        state: "open", url: "https://acme.atlassian.net/browse/MAXX-10",
+        repo: "MAXX", provider: .jira, projectStatus: .inProgress
+    )
+    // Session stored a browse URL with extra path/query — exact match fails, key matches.
+    let session = Session(name: "jira", status: .inReview, ticketURL: "https://acme.atlassian.net/browse/MAXX-10?focusedCommentId=99", provider: .jira)
+    appState.sessions = [session]
+    #expect(appState.linkedSession(for: issue)?.id == session.id)
+}
+
+@MainActor @Test func linkedSessionDoesNotKeyMatchNonJiraProviders() {
+    let appState = AppState()
+    // Two different GitHub issues that share no exact URL must not link via key.
+    let issue = AssignedIssue(
+        id: "github:org/repo#1", number: 1, title: "T",
+        state: "open", url: "https://github.com/org/repo/issues/1",
+        repo: "org/repo", provider: .github
+    )
+    let session = Session(name: "other", status: .active, ticketURL: "https://github.com/org/repo/issues/2", provider: .github)
+    appState.sessions = [session]
+    #expect(appState.linkedSession(for: issue) == nil)
+}
+
+@MainActor @Test func assignedIssueMatchesJiraByKey() {
+    let appState = AppState()
+    appState.assignedIssues = [
+        AssignedIssue(
+            id: "jira:MAXX-10", number: 10, title: "Jira one",
+            state: "open", url: "https://acme.atlassian.net/browse/MAXX-10",
+            repo: "MAXX", labels: [LabelInfo(name: "bug")], provider: .jira, projectStatus: .inReview
+        )
+    ]
+    let session = Session(name: "jira", status: .inReview, ticketURL: "MAXX-10", provider: .jira)
+    #expect(appState.assignedIssue(for: session)?.id == "jira:MAXX-10")
+    #expect(appState.labels(forSession: session) == [LabelInfo(name: "bug")])
+}
+
 @MainActor @Test func reviewRequestForSessionMatchesByPRLink() {
     let appState = AppState()
     let session = Session(name: "review-repo-123", kind: .review)

--- a/Packages/CrowCore/Tests/CrowCoreTests/JiraSearchClientTests.swift
+++ b/Packages/CrowCore/Tests/CrowCoreTests/JiraSearchClientTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import CrowCore
+
+@Suite struct JiraSearchClientTests {
+
+    // A realistic `search/jql` payload: one in-progress (renamed status) and one
+    // done issue, mirroring the REST shape `{ "issues": [ { key, fields } ] }`.
+    private static let searchPayload = """
+    {"issues":[
+      {"key":"MAXX-1","fields":{"summary":"Open one","status":{"name":"In Development","statusCategory":{"key":"indeterminate"}},"labels":["bug"]}},
+      {"key":"MAXX-2","fields":{"summary":"Done two","status":{"name":"Done","statusCategory":{"key":"done"}},"labels":[]}}
+    ]}
+    """.data(using: .utf8)!
+
+    // MARK: - URL building
+
+    @Test func buildsSearchURLFromBareHost() {
+        let url = JiraSearchClient.searchURL(
+            site: "acme.atlassian.net",
+            jql: "assignee = currentUser()",
+            fields: ["key", "summary", "status", "labels"],
+            maxResults: 100
+        )
+        let s = url?.absoluteString ?? ""
+        #expect(s.hasPrefix("https://acme.atlassian.net/rest/api/3/search/jql?"))
+        // JQL is percent-encoded in the query.
+        #expect(s.contains("jql=assignee%20=%20currentUser()") || s.contains("jql=assignee%20%3D%20currentUser()"))
+        #expect(s.contains("fields=key,summary,status,labels"))
+        #expect(s.contains("maxResults=100"))
+    }
+
+    @Test func searchURLForcesHTTPSOnCleartextOrigin() {
+        let url = JiraSearchClient.searchURL(site: "http://acme.atlassian.net", jql: "x", fields: ["key"], maxResults: 50)
+        #expect(url?.scheme == "https")
+        #expect(url?.host == "acme.atlassian.net")
+    }
+
+    @Test func searchURLNilForBlankInputs() {
+        #expect(JiraSearchClient.searchURL(site: "", jql: "x", fields: ["key"], maxResults: 1) == nil)
+        #expect(JiraSearchClient.searchURL(site: "acme.atlassian.net", jql: " ", fields: ["key"], maxResults: 1) == nil)
+    }
+
+    // MARK: - Parsing
+
+    @Test func parsesIssuesArray() {
+        let issues = JiraSearchClient.parseIssues(Self.searchPayload)
+        #expect(issues?.count == 2)
+        #expect(issues?.first?["key"] as? String == "MAXX-1")
+    }
+
+    @Test func parseIssuesNilOnUnexpectedShape() {
+        #expect(JiraSearchClient.parseIssues(Data("[]".utf8)) == nil)
+        #expect(JiraSearchClient.parseIssues(Data("not json".utf8)) == nil)
+    }
+
+    @Test func parseIssuesEmptyWhenNoMatches() {
+        let issues = JiraSearchClient.parseIssues(Data(#"{"issues":[]}"#.utf8))
+        #expect(issues?.isEmpty == true)
+    }
+
+    // MARK: - fetchAssigned
+
+    @Test func fetchAssignedSendsAuthAndReturnsIssues() async {
+        let result = await JiraSearchClient.fetchAssigned(
+            site: "acme.atlassian.net",
+            jql: "assignee = currentUser()",
+            authorization: "Basic creds",
+            transport: { request in
+                #expect(request.httpMethod == "GET")
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "Basic creds")
+                #expect(request.url?.path == "/rest/api/3/search/jql")
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (Self.searchPayload, response)
+            }
+        )
+        guard case .success(let issues) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(issues.count == 2)
+    }
+
+    @Test func fetchAssignedFailsOnNon2xx() async {
+        let result = await JiraSearchClient.fetchAssigned(
+            site: "acme.atlassian.net",
+            jql: "x",
+            authorization: "Basic creds",
+            transport: { request in
+                let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+                return (Data(), response)
+            }
+        )
+        #expect(result.failureError == .http(401))
+    }
+
+    @Test func fetchAssignedFailsBadSite() async {
+        let result = await JiraSearchClient.fetchAssigned(site: "", jql: "x", authorization: "Basic creds")
+        #expect(result.failureError == .badSite)
+    }
+}
+
+/// `Result<[[String:Any]], _>` isn't `Equatable` (the success payload holds
+/// dictionaries), so assert on the error alone.
+private extension Result {
+    var failureError: Failure? {
+        if case .failure(let error) = self { return error }
+        return nil
+    }
+}

--- a/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
+++ b/Packages/CrowProvider/Sources/CrowProvider/Backends/JiraTaskBackend.swift
@@ -100,11 +100,42 @@ public struct JiraTaskBackend: TaskBackend {
     }
 
     public func listAssigned(includeClosed: Bool) async throws -> AssignedListing {
-        let jql = config.jql ?? Self.defaultOpenJQL
+        let openJQL = config.jql ?? Self.defaultOpenJQL
+
+        // REST-preferred (#533): when a Jira Cloud credential is configured, read
+        // assigned issues over the REST API — same auth the transition write path
+        // (#529) uses — so the board read-back doesn't depend on a separately
+        // installed/authenticated `acli`. Degrades to empty on failure, matching
+        // GitLab's semantics. Falls back to `acli` when no REST credential is set.
+        if let authorization = config.authorization, let site = config.site, !site.isEmpty {
+            let open: [AssignedIssue]
+            switch await JiraSearchClient.fetchAssigned(site: site, jql: openJQL, authorization: authorization, transport: transport) {
+            case .success(let items):
+                open = Self.parseAssigned(items: items, site: config.site, statusOverride: nil, statusMap: config.statusMap)
+            case .failure(let error):
+                NSLog("[JiraTaskBackend] REST listAssigned failed for %@: %@", site, String(describing: error))
+                return AssignedListing(open: [], closed: [])
+            }
+
+            guard includeClosed else {
+                return AssignedListing(open: open, closed: [])
+            }
+
+            let closed: [AssignedIssue]
+            switch await JiraSearchClient.fetchAssigned(site: site, jql: Self.closedJQL, authorization: authorization, maxResults: 50, transport: transport) {
+            case .success(let items):
+                closed = Self.parseAssigned(items: items, site: config.site, statusOverride: .done, statusMap: config.statusMap)
+            case .failure:
+                return AssignedListing(open: open, closed: [])
+            }
+            return AssignedListing(open: open, closed: closed)
+        }
+
+        // Legacy fallback: `acli` (no REST credential configured).
         let open: [AssignedIssue]
         do {
-            let openOut = try await search(jql: jql, limit: 100)
-            open = Self.parseAssigned(openOut, site: config.site, statusOverride: nil)
+            let openOut = try await search(jql: openJQL, limit: 100)
+            open = Self.parseAssigned(openOut, site: config.site, statusOverride: nil, statusMap: config.statusMap)
         } catch {
             // Match GitLab's degrade-to-empty semantics rather than throwing.
             return AssignedListing(open: [], closed: [])
@@ -117,7 +148,7 @@ public struct JiraTaskBackend: TaskBackend {
         let closed: [AssignedIssue]
         do {
             let closedOut = try await search(jql: Self.closedJQL, limit: 50)
-            closed = Self.parseAssigned(closedOut, site: config.site, statusOverride: .done)
+            closed = Self.parseAssigned(closedOut, site: config.site, statusOverride: .done, statusMap: config.statusMap)
         } catch {
             return AssignedListing(open: open, closed: [])
         }
@@ -322,9 +353,36 @@ public struct JiraTaskBackend: TaskBackend {
         return String(output[range])
     }
 
-    static func parseAssigned(_ output: String, site: String?, statusOverride: TicketStatus?) -> [AssignedIssue] {
+    /// Resolve a Jira workflow **status name** back to a Crow ``TicketStatus`` —
+    /// the inverse of ``jiraStatusName(for:)`` (the #529 write path), honoring the
+    /// per-workspace ``JiraConfig/statusMap`` (#523). For each pipeline status,
+    /// resolve the Jira name it maps to (override or default) and match
+    /// case-insensitively; otherwise fall back to the built-in alias table
+    /// (`TicketStatus(projectBoardName:)`, which handles "Doing"/"Closed"/etc.).
+    /// This is what makes a renamed status (e.g. "In Development" → In Progress)
+    /// land in the right board column instead of collapsing to Backlog (#533).
+    static func ticketStatus(forJiraName name: String, statusMap: [String: String]?) -> TicketStatus {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return .unknown }
+        for status in TicketStatus.pipelineStatuses {
+            let jiraName = statusMap?[status.rawValue]?.nonBlank ?? Self.defaultJiraStatusName(for: status)
+            if jiraName.caseInsensitiveCompare(trimmed) == .orderedSame {
+                return status
+            }
+        }
+        return TicketStatus(projectBoardName: trimmed)
+    }
+
+    /// Decode `acli`'s top-level-array JSON output, then map via the shared
+    /// `parseAssigned(items:…)` core. The REST path passes its unwrapped `issues`
+    /// array directly to that core instead.
+    static func parseAssigned(_ output: String, site: String?, statusOverride: TicketStatus?, statusMap: [String: String]?) -> [AssignedIssue] {
         guard let data = output.data(using: .utf8),
               let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        return parseAssigned(items: items, site: site, statusOverride: statusOverride, statusMap: statusMap)
+    }
+
+    static func parseAssigned(items: [[String: Any]], site: String?, statusOverride: TicketStatus?, statusMap: [String: String]?) -> [AssignedIssue] {
         return items.compactMap { item -> AssignedIssue? in
             guard let key = item["key"] as? String,
                   let parsed = JiraKey.parse(key) else { return nil }
@@ -333,7 +391,7 @@ public struct JiraTaskBackend: TaskBackend {
             let statusDict = fields?["status"] as? [String: Any]
             let statusName = statusDict?["name"] as? String ?? ""
             let categoryKey = (statusDict?["statusCategory"] as? [String: Any])?["key"] as? String ?? ""
-            let status = statusOverride ?? TicketStatus(projectBoardName: statusName)
+            let status = statusOverride ?? Self.ticketStatus(forJiraName: statusName, statusMap: statusMap)
             let state = (statusOverride == .done || categoryKey == "done") ? "closed" : "open"
             // Jira labels are plain strings (no color); surface them so
             // label-driven flows (e.g. auto-create) work for Jira too.

--- a/Packages/CrowProvider/Tests/CrowProviderTests/JiraTaskBackendTests.swift
+++ b/Packages/CrowProvider/Tests/CrowProviderTests/JiraTaskBackendTests.swift
@@ -136,6 +136,82 @@ final class JiraTaskBackendTests: XCTestCase {
         XCTAssertTrue(listing.closed.isEmpty)
     }
 
+    // MARK: - Status read-back mapping (inverse of jiraStatusMap, #533)
+
+    func testTicketStatusInverseHonorsStatusMap() {
+        let map = ["In Progress": "In Development", "In Review": "Code Review", "Done": "Resolved"]
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "In Development", statusMap: map), .inProgress)
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "code review", statusMap: map), .inReview) // case-insensitive
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "Resolved", statusMap: map), .done)
+    }
+
+    func testTicketStatusInverseFallsBackToAliasTable() {
+        // A name neither mapped nor a pipeline default still resolves via the
+        // built-in alias table; a truly unknown name is `.unknown`.
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "Doing", statusMap: nil), .inProgress)
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "Closed", statusMap: nil), .done)
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "Parking Lot", statusMap: nil), .unknown)
+    }
+
+    func testTicketStatusInverseDefaultNamesUnchanged() {
+        // No override: the default Jira names round-trip to their pipeline status.
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "In Progress", statusMap: nil), .inProgress)
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "In Review", statusMap: nil), .inReview)
+        XCTAssertEqual(JiraTaskBackend.ticketStatus(forJiraName: "To Do", statusMap: nil), .ready)
+    }
+
+    /// The acli read path threads `config.statusMap` so a renamed status lands in
+    /// the right column instead of collapsing to Backlog (#533).
+    func testListAssignedAcliAppliesStatusMapInverse() async throws {
+        let fake = FakeShellRunner()
+        fake.responses = [.success(#"[{"key":"MAXX-1","fields":{"summary":"Dev one","status":{"name":"In Development","statusCategory":{"key":"indeterminate"}}}}]"#)]
+        let cfg = JiraConfig(site: "acme.atlassian.net", statusMap: ["In Progress": "In Development"])
+        let listing = try await backend(fake, config: cfg).listAssigned(includeClosed: false)
+        XCTAssertEqual(listing.open.first?.projectStatus, .inProgress)
+    }
+
+    // MARK: - listAssigned over REST (#533)
+
+    /// With an Authorization header + site, the read goes via REST — `acli` is
+    /// never shelled out — and the mapped status name is read back correctly.
+    func testListAssignedUsesRESTWhenCredentialed() async throws {
+        let fake = FakeShellRunner()
+        let sawGET = Box<Bool>(false)
+        let cfg = JiraConfig(
+            site: "acme.atlassian.net",
+            statusMap: ["In Progress": "In Development"],
+            authorization: "Basic creds"
+        )
+        let payload = #"{"issues":[{"key":"MAXX-1","fields":{"summary":"Dev one","status":{"name":"In Development","statusCategory":{"key":"indeterminate"}},"labels":["bug"]}}]}"#.data(using: .utf8)!
+        let b = JiraTaskBackend(shellRunner: fake, config: cfg, transport: { request in
+            sawGET.set(true)
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Basic creds")
+            XCTAssertEqual(request.url?.path, "/rest/api/3/search/jql")
+            return (payload, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        })
+        let listing = try await b.listAssigned(includeClosed: false)
+        XCTAssertTrue(sawGET.get())
+        XCTAssertTrue(fake.calls.isEmpty, "REST path must not shell out to acli")
+        XCTAssertEqual(listing.open.count, 1)
+        XCTAssertEqual(listing.open[0].id, "jira:MAXX-1")
+        XCTAssertEqual(listing.open[0].projectStatus, .inProgress)
+        XCTAssertEqual(listing.open[0].url, "https://acme.atlassian.net/browse/MAXX-1")
+        XCTAssertEqual(listing.open[0].labels.map(\.name), ["bug"])
+    }
+
+    /// A REST failure degrades to an empty listing (like GitLab) without throwing.
+    func testListAssignedRESTDegradesToEmptyOnHTTPError() async throws {
+        let fake = FakeShellRunner()
+        let cfg = JiraConfig(site: "acme.atlassian.net", authorization: "Basic creds")
+        let b = JiraTaskBackend(shellRunner: fake, config: cfg, transport: { request in
+            (Data(), HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!)
+        })
+        let listing = try await b.listAssigned(includeClosed: false)
+        XCTAssertTrue(listing.open.isEmpty)
+        XCTAssertTrue(listing.closed.isEmpty)
+    }
+
     // MARK: - setLabels
 
     func testSetLabelsAddsAndRemoves() async throws {

--- a/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/TicketBoardView.swift
@@ -410,7 +410,7 @@ struct TicketCard: View {
     var onToggleSelection: (() -> Void)?
 
     private var linkedSession: Session? {
-        appState.activeSession(for: issue)
+        appState.linkedSession(for: issue)
     }
 
     private var isSelectable: Bool {

--- a/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
+++ b/Packages/CrowUI/Sources/CrowUI/WorkspaceFormView.swift
@@ -176,9 +176,16 @@ public struct WorkspaceFormView: View {
                     .foregroundStyle(.secondary)
 
                 if jiraAvailability != nil, jiraAvailability != .ready {
-                    Label(jiraAvailability?.fixHint ?? "Jira (acli) is not available.", systemImage: "exclamationmark.triangle")
-                        .font(.caption)
-                        .foregroundStyle(jiraSelected ? .red : .secondary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Label(jiraAvailability?.fixHint ?? "Jira (acli) is not available.", systemImage: "exclamationmark.triangle")
+                        // The board's status read-back uses the Jira REST credential
+                        // (Settings → Automation), not acli (#533); acli gates only
+                        // task creation/editing here.
+                        Text("acli gates task creation/editing. The ticket board reads Jira status over REST using the Settings → Automation credential.")
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(jiraSelected ? .red : .secondary)
                 }
 
                 if jiraSelected {

--- a/Sources/Crow/App/IssueTracker.swift
+++ b/Sources/Crow/App/IssueTracker.swift
@@ -384,11 +384,14 @@ final class IssueTracker {
                 gitLabHosts.append(host)
             }
         }
-        // Collect distinct Jira queries (acli is authed to a single site, so the
-        // site/JQL/project triple is what actually varies).
+        // Collect distinct Jira queries (the site/JQL/project triple is what
+        // actually varies). Resolve the shared Jira REST credential once (it may
+        // shell `op read`) and thread it into every config so the board read-back
+        // can list assigned issues over REST instead of acli (#533).
+        let jiraAuthorization = config.jiraCredential.flatMap { JiraCredentialResolver.resolve($0) }
         var jiraConfigs: [JiraConfig] = []
         for ws in config.workspaces where ws.derivedTaskProvider == "jira" {
-            let cfg = JiraConfig(site: ws.jiraSite, projectKey: ws.jiraProjectKey, jql: ws.jiraJQL, statusMap: ws.jiraStatusMap)
+            let cfg = JiraConfig(site: ws.jiraSite, projectKey: ws.jiraProjectKey, jql: ws.jiraJQL, statusMap: ws.jiraStatusMap, authorization: jiraAuthorization)
             if !jiraConfigs.contains(cfg) { jiraConfigs.append(cfg) }
         }
         // Collect distinct Corveil configs. The corveil CLI is authed to one
@@ -574,7 +577,7 @@ final class IssueTracker {
             guard labeled else { continue }
             guard !autoCreateInFlight.contains(issue.url) else { continue }
 
-            if appState.activeSession(for: issue) != nil {
+            if appState.linkedSession(for: issue) != nil {
                 // Stale label — work already picked up elsewhere. Best-effort cleanup.
                 Task { [weak self] in await self?.removeAutoCreateLabel(from: issue) }
                 continue


### PR DESCRIPTION
Closes #533

## What this fixes
In-flight Jira tickets sat in **Backlog** even when Jira said *In Development / In Review*, and the board showed no linked session. Jira ingestion already existed (CROW-528/529) — the gaps were narrower than the ticket's stale root cause suggested:

1. **Status read-back ignored `jiraStatusMap`.** `JiraTaskBackend.parseAssigned` mapped a Jira status name → `TicketStatus` via `TicketStatus(projectBoardName:)` only, so a renamed status (`"In Development"`) → `.unknown` → collapsed to Backlog. Added `ticketStatus(forJiraName:statusMap:)` — the **inverse** of the #529 write path (using #523's `jiraStatusMap`) — and threaded the map through `parseAssigned`.
2. **Read transport was `acli`**, inconsistent with the REST write path (#529) and status-name list (#523). Added **`JiraSearchClient`** (Jira Cloud `GET /rest/api/3/search/jql`, HTTP Basic, injectable transport, mirrors `JiraStatusFetcher`/`JiraTransitionClient`) and made `listAssigned` **REST-preferred with acli fallback**. Threaded the resolved `jiraCredential` into the refresh-loop `JiraConfig` so the board read authenticates.
   - Caught + fixed a real bug along the way: the REST `listAssigned` path must forward the backend's injectable `transport` (like `setTaskStatus` does) — without it the read made a hardcoded `URLSession.shared` call.
3. **Linked-session detection was `.active`-only + exact-URL.** `activeSession(for:)` → `linkedSession(for:)` now scans **non-terminal work sessions** (`.active`, `.paused`, `.inReview`) and matches Jira tickets on the **parsed Jira key**, so browse-URL variants and In-Review sessions link. `assignedIssue(for:)` aligned. **GitHub/GitLab keep exact-URL matching unchanged.**

## Acceptance criteria
- ✅ A Jira ticket that's *In Development* in Jira appears under **In Progress** (and *In Review* under **In Review**) via the status-map inverse, not stuck in Backlog.
- ✅ A Jira ticket with an established Crow session shows as linked for both **Active** and **In-Review** sessions.
- ✅ GitHub/GitLab board behavior unchanged.

## Tests
- `JiraSearchClientTests` (CrowCore): URL build (https-forcing, encoding), `parseIssues`, `fetchAssigned` success / non-2xx / bad-site.
- `JiraTaskBackendTests` (CrowProvider): `ticketStatus` inverse (mapped, alias fallback, defaults unchanged); acli + REST `listAssigned` apply the map; REST degrades to empty on HTTP error; REST path never shells acli.
- `AppStateLookupTests` (CrowCore): `linkedSession`/`assignedIssue` match `.inReview`/`.paused`, Jira-key across URL variants, terminal sessions excluded, GitHub exact-URL unchanged + no cross-issue key match.

`swift test` green for CrowCore (321) and CrowProvider (109 + 52); `make app` builds clean.

## Coordination (Jira-parity family)
Inverse of **CROW-523** `jiraStatusMap`; read-back complement to **CROW-529** (write side). No new `Provider` enum case (`.jira` already exists). Overlaps **CROW-532** on provider resolution + session/issue matching — branch is current with `main` (CROW-529 tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)